### PR TITLE
Remove PIPELINES_RUN_URL environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+BACKEND_URL=https://platform-api.aixplain.com
+MODELS_RUN_URL=https://models.aixplain.com/api/v1/execute
 PIPELINE_API_KEY=<API_KEY>
 MODEL_API_KEY=<API_KEY>
 LOG_LEVEL=DEBUG

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-PIPELINES_RUN_URL=https://platform-api.aixplain.com/assets/pipeline/execution/run
-MODELS_RUN_URL=https://models.aixplain.com/api/v1/execute
 PIPELINE_API_KEY=<API_KEY>
 MODEL_API_KEY=<API_KEY>
 LOG_LEVEL=DEBUG

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -37,16 +37,6 @@ load_dotenv()
 # Validate API keys
 from aixplain.utils import config
 
-if config.AIXPLAIN_ENV == "dev":
-    config.BACKEND_URL = "https://dev-platform-api.aixplain.com"
-    config.MODELS_RUN_URL = "https://dev-models.aixplain.com/api/v1/execute"
-elif config.AIXPLAIN_ENV == "test":
-    config.BACKEND_URL = "https://test-platform-api.aixplain.com"
-    config.MODELS_RUN_URL = "https://test-models.aixplain.com/api/v1/execute"
-else:
-    config.BACKEND_URL = "https://platform-api.aixplain.com"
-    config.MODELS_RUN_URL = "https://models.aixplain.com/api/v1/execute"
-
 if config.TEAM_API_KEY == "" and config.AIXPLAIN_API_KEY == "":
     raise Exception(
         "'TEAM_API_KEY' has not been set properly and is empty. For help, please refer to the documentation (https://github.com/aixplain/aixplain#api-key-setup)"

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -24,7 +24,8 @@ limitations under the License.
 import os
 import logging
 from logging import NullHandler
-LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=LOG_LEVEL)
 logging.getLogger(__name__).addHandler(NullHandler())
 
@@ -35,6 +36,16 @@ load_dotenv()
 
 # Validate API keys
 from aixplain.utils import config
+
+if config.AIXPLAIN_ENV == "dev":
+    config.BACKEND_URL = "https://dev-platform-api.aixplain.com"
+    config.MODELS_RUN_URL = "https://dev-models.aixplain.com/api/v1/execute"
+elif config.AIXPLAIN_ENV == "test":
+    config.BACKEND_URL = "https://test-platform-api.aixplain.com"
+    config.MODELS_RUN_URL = "https://test-models.aixplain.com/api/v1/execute"
+else:
+    config.BACKEND_URL = "https://platform-api.aixplain.com"
+    config.MODELS_RUN_URL = "https://models.aixplain.com/api/v1/execute"
 
 if config.TEAM_API_KEY == "" and config.AIXPLAIN_API_KEY == "":
     raise Exception(

--- a/aixplain/factories/pipeline_factory.py
+++ b/aixplain/factories/pipeline_factory.py
@@ -24,7 +24,6 @@ import logging
 import os
 from typing import Dict, List, Optional, Text
 from aixplain.modules.pipeline import Pipeline
-from aixplain.utils.config import PIPELINES_RUN_URL
 from aixplain.utils import config
 from aixplain.utils.file_utils import _request_with_retry
 from urllib.parse import urljoin

--- a/aixplain/modules/pipeline.py
+++ b/aixplain/modules/pipeline.py
@@ -38,7 +38,7 @@ class Pipeline(Asset):
         id (Text): ID of the Pipeline
         name (Text): Name of the Pipeline
         api_key (Text): Team API Key to run the Pipeline.
-        url (Text, optional): running URL of platform. Defaults to config.PIPELINES_RUN_URL.
+        url (Text, optional): running URL of platform. Defaults to config.BACKEND_URL.
         supplier (Text, optional): Pipeline supplier. Defaults to "aiXplain".
         version (Text, optional): version of the pipeline. Defaults to "1.0".
         **additional_info: Any additional Pipeline info to be saved
@@ -49,7 +49,7 @@ class Pipeline(Asset):
         id: Text,
         name: Text,
         api_key: Text,
-        url: Text = config.PIPELINES_RUN_URL,
+        url: Text = config.BACKEND_URL,
         supplier: Text = "aiXplain",
         version: Text = "1.0",
         **additional_info,
@@ -60,14 +60,14 @@ class Pipeline(Asset):
             id (Text): ID of the Pipeline
             name (Text): Name of the Pipeline
             api_key (Text): Team API Key to run the Pipeline.
-            url (Text, optional): running URL of platform. Defaults to config.PIPELINES_RUN_URL.
+            url (Text, optional): running URL of platform. Defaults to config.BACKEND_URL.
             supplier (Text, optional): Pipeline supplier. Defaults to "aiXplain".
             version (Text, optional): version of the pipeline. Defaults to "1.0".
             **additional_info: Any additional Pipeline info to be saved
         """
         super().__init__(id, name, "", supplier, version)
         self.api_key = api_key
-        self.url = url
+        self.url = f"{url}/assets/pipeline/execution/run"
         self.additional_info = additional_info
 
     def __polling(

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -18,7 +18,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com/")
+BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com")
 MODELS_RUN_URL = os.getenv("MODELS_RUN_URL", "https://models.aixplain.com/api/v1/execute")
 # GET THE API KEY FROM CMD
 TEAM_API_KEY = os.getenv("TEAM_API_KEY", "")

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -18,9 +18,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-AIXPLAIN_ENV = os.getenv("AIXPLAIN_ENV", "platform")
-BACKEND_URL = ""
-MODELS_RUN_URL = ""
+BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com/")
+MODELS_RUN_URL = os.getenv("MODELS_RUN_URL", "https://models.aixplain.com/api/v1/execute")
 # GET THE API KEY FROM CMD
 TEAM_API_KEY = os.getenv("TEAM_API_KEY", "")
 AIXPLAIN_API_KEY = os.getenv("AIXPLAIN_API_KEY", "")

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -18,9 +18,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com/")
-PIPELINES_RUN_URL = os.getenv("PIPELINES_RUN_URL", "https://platform-api.aixplain.com/assets/pipeline/execution/run")
-MODELS_RUN_URL = os.getenv("MODELS_RUN_URL", "https://models.aixplain.com/api/v1/execute")
+AIXPLAIN_ENV = os.getenv("AIXPLAIN_ENV", "platform")
+BACKEND_URL = ""
+MODELS_RUN_URL = ""
 # GET THE API KEY FROM CMD
 TEAM_API_KEY = os.getenv("TEAM_API_KEY", "")
 AIXPLAIN_API_KEY = os.getenv("AIXPLAIN_API_KEY", "")

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -18,13 +18,14 @@ limitations under the License.
 
 
 import time
-from aixplain.utils.config import PIPELINES_RUN_URL, PIPELINE_API_KEY
+from aixplain.utils.config import BACKEND_URL, PIPELINE_API_KEY
 from aixplain.factories.pipeline_factory import PipelineFactory
 import pytest
 
+
 @pytest.mark.skip()
 def test_mt1():
-    url = PIPELINES_RUN_URL
+    url = BACKEND_URL
     api_key = PIPELINE_API_KEY
 
     pipeline = PipelineFactory.create_from_api_key(api_key=api_key, url=url)
@@ -33,9 +34,10 @@ def test_mt1():
     response = pipeline.run(data)
     assert response["status"] == "SUCCESS"
 
+
 @pytest.mark.skip()
 def test_mt2():
-    url = PIPELINES_RUN_URL
+    url = BACKEND_URL
     api_key = PIPELINE_API_KEY
 
     pipeline = PipelineFactory.create_from_api_key(api_key=api_key, url=url)
@@ -44,9 +46,10 @@ def test_mt2():
     response = pipeline.run(data)
     assert response["status"] == "SUCCESS"
 
+
 @pytest.mark.skip()
 def test_mt1_async():
-    url = PIPELINES_RUN_URL
+    url = BACKEND_URL
     api_key = PIPELINE_API_KEY
 
     pipeline = PipelineFactory.create_from_api_key(api_key=api_key, url=url)
@@ -61,9 +64,10 @@ def test_mt1_async():
         time.sleep(3)
     assert response["status"] == "SUCCESS"
 
+
 @pytest.mark.skip()
 def test_mt2_async():
-    url = PIPELINES_RUN_URL
+    url = BACKEND_URL
     api_key = PIPELINE_API_KEY
 
     pipeline = PipelineFactory.create_from_api_key(api_key=api_key, url=url)


### PR DESCRIPTION
Instead of having to define `BACKEND_URL`, `MODELS_RUN_URL` and `PIPELINES_RUN_URL`, now we only need to define `AIXPLAIN_ENV` to set the desired environment (dev, test or platform).
Task: M-4576168247