### PR TITLE
Remove unused decorator import and add Colab links in user docs

### DIFF
--- a/aixplain/decorators/__init__.py
+++ b/aixplain/decorators/__init__.py
@@ -1,0 +1,1 @@
+from .api_key_checker import check_api_key

--- a/aixplain/factories/finetune_factory.py
+++ b/aixplain/factories/finetune_factory.py
@@ -31,7 +31,6 @@ from aixplain.modules.finetune_cost import FinetuneCost
 from aixplain.utils import config
 from aixplain.utils.file_utils import _request_with_retry
 from urllib.parse import urljoin
-from aixplain.decorators.api_key_checker import check_api_key
 
 
 class FinetuneFactory:

--- a/docs/user/user_doc.md
+++ b/docs/user/user_doc.md
@@ -95,6 +95,7 @@ poll_response = pipeline.poll(poll_url)
 ```
 
 ## Corpus
+
 aiXplain has an extensive collection of general-purpose corpora to be explored, processed and used to create task-specific datasets.
 
 The aiXplain SDK allows searching for existing corpora that match a specific criteria. `CorpusFactory` can search for corpora that contain data from a particular language pair or data type.
@@ -108,7 +109,9 @@ Note: This does not download the resulted corpora to your local machine.
 
 ### Corpus Onboarding
 
-Using the aiXplain SDK, you can also onboard your corpus into the aiXplain platform. A step-by-step example on how to do it can be accessed [here](/docs/samples/corpus_onboarding/corpus_onboarding.ipynb).
+Using the aiXplain SDK, you can also onboard your corpus into the aiXplain platform. A step-by-step example on how to do it can be accessed here:
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1-FYTtyVaDxyVv7kGCaMEd5E3uiHYHRTt?usp=sharing) 
 
 ## Datasets
 Different from corpus, a dataset is a representative sample of a specific phenomenon to a specific AI task. aiXplain also counts with an extensive collection of datasets for training, infer and benchmark various tasks like Translation, Speech Recognition, Diacritization, Sentiment Analysis, and much more.
@@ -127,12 +130,22 @@ Note: This does not download datasets to your local machine.
 
 ### Dataset Onboarding
 
-Using the aiXplain SDK, you can also onboard your dataset into the aiXplain platform. A step-by-step example on how to do it can be accessed [here](/docs/samples/dataset_onboarding/dataset_onboarding.ipynb).
+Using the aiXplain SDK, you can also onboard your dataset into the aiXplain platform. A step-by-step example on how to do it can be accessed here:
+- Machine translation dataset:
+  - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1rVxxZpHzyP4FWn_Rd_j_g8tHU76S3rVT?usp=sharing) 
+
+
+- Speech recognition dataset:
+  - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1f1NXHGxhIy0AAXnUZJB8QY3JLl-uC37e?usp=sharing) 
+
 
 ## FineTune
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1rVxxZpHzyP4FWn_Rd_j_g8tHU76S3rVT?usp=sharing)
 
 [FineTune](https://aixplain.com/platform/finetune) allows you to customize models by tuning them using your data and enhancing their performance. Set up and start fine-tuning with a few lines of code. Once fine-tuning is complete, the model will be deployed into your assets, ready for you to use.
+
+You can also run this FineTune guide in Google Colab:
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1rVxxZpHzyP4FWn_Rd_j_g8tHU76S3rVT?usp=sharing)
 
 ### Creating a FineTune
 


### PR DESCRIPTION
## Summary
Remove decorator from FinetuneFactory, create __init__.py file inside the decorator folder, and update user_doc, including Colab links to dataset and corpus onboarding.
## Bug fixed
While running pip install from github repo inside Colab:
```bash
!pip install git+https://github.com/aixplain/aiXplain.git
```
and then importing the dependencies, I'm getting the following error:

<img width="739" alt="image" src="https://github.com/aixplain/aiXplain/assets/86805709/83558d95-d9b9-49f4-b079-fa4bf97ad967">

By removing the decorator from FinetuneFactory and creating __init__.py file, we should fix this problem. Then, we can update the Colab to install the package using the above command.

## Monday
Task: M-4813362133