### PR TITLE
create model/pipeline tools from AgentFactory

### DIFF
--- a/aixplain/factories/agent_factory/__init__.py
+++ b/aixplain/factories/agent_factory/__init__.py
@@ -24,10 +24,12 @@ Description:
 import json
 import logging
 
+from aixplain.enums.function import Function
 from aixplain.enums.supplier import Supplier
 from aixplain.modules.agent import Agent, Tool
 from aixplain.modules.agent.tool.model_tool import ModelTool
 from aixplain.modules.agent.tool.pipeline_tool import PipelineTool
+from aixplain.modules.pipeline import Pipeline
 from aixplain.utils import config
 from typing import Dict, List, Optional, Text, Union
 
@@ -112,6 +114,27 @@ class AgentFactory:
         except Exception as e:
             raise Exception(e)
         return agent
+
+    @classmethod
+    def create_model_tool(cls, function: Union[Function, Text], supplier: Optional[Union[Supplier, Text]] = None) -> ModelTool:
+        """Create a new model tool."""
+        if isinstance(function, str):
+            function = Function(function)
+
+        if supplier is not None:
+            if isinstance(supplier, str):
+                for supplier_ in Supplier:
+                    if supplier.lower() in [supplier.value["code"].lower(), supplier.value["name"].lower()]:
+                        supplier = supplier_
+                        break
+                if isinstance(supplier, str):
+                    supplier = None
+        return ModelTool(function=function, supplier=supplier)
+
+    @classmethod
+    def create_pipeline_tool(cls, description: Text, pipeline: Union[Pipeline, Text]) -> PipelineTool:
+        """Create a new pipeline tool."""
+        return PipelineTool(description=description, pipeline=pipeline)
 
     @classmethod
     def list(cls) -> Dict:

--- a/tests/functional/agent/agent_functional_test.py
+++ b/tests/functional/agent/agent_functional_test.py
@@ -20,7 +20,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 from aixplain.factories import AgentFactory
-from aixplain.modules.agent import ModelTool, PipelineTool
 from aixplain.enums.supplier import Supplier
 
 import pytest
@@ -48,10 +47,10 @@ def test_end2end(run_input_map):
                 ]:
                     tool["supplier"] = supplier
                     break
-            tools.append(ModelTool(function=tool["function"], supplier=tool["supplier"]))
+            tools.append(AgentFactory.create_model_tool(function=tool["function"], supplier=tool["supplier"]))
     if "pipeline_tools" in run_input_map:
         for tool in run_input_map["pipeline_tools"]:
-            tools.append(PipelineTool(description=tool["description"], pipeline=tool["pipeline_id"]))
+            tools.append(AgentFactory.create_pipeline_tool(pipeline=tool["pipeline_id"], description=tool["description"]))
     print(f"Creating agent with tools: {tools}")
     agent = AgentFactory.create(name=run_input_map["agent_name"], llm_id=run_input_map["llm_id"], tools=tools)
     print(f"Agent created: {agent.__dict__}")


### PR DESCRIPTION
Decreasing the number of imports to generate an agent:

```python
from aixplain.factories import AgentFactory
from aixplain.enums import Function, Supplier

translation_pipeline_tool = AgentFactory.create_pipeline_tool(
    description="English TTs Pipeline",
    pipeline="66829cbad7b8325606297f81"
)

speech_synthesis_tool = AgentFactory.create_model_tool(
    function=Function.SPEECH_SYNTHESIS,
    supplier=Supplier.GOOGLE
)

ner_tool = AgentFactory.create_model_tool(
    function=Function.NAMED_ENTITY_RECOGNITION,
    supplier=Supplier.MICROSOFT
)

agent = AgentFactory.create(
    name="Test Agent Colab 2024_07_26",
    tools=[
        speech_synthesis_tool,
        ner_tool,
        translation_pipeline_tool
    ],
    description="Test Agent Description",
    # required llm_id
    llm_id="6646261c6eb563165658bbb1" # GPT 4o
)
```