### PR TITLE
BUG-233 Prompt variables are now populated and validated automatically

### DIFF
--- a/aixplain/factories/pipeline_factory/utils.py
+++ b/aixplain/factories/pipeline_factory/utils.py
@@ -88,7 +88,7 @@ def build_from_response(response: Dict, load_architecture: bool = False) -> Pipe
                             data_type=custom_input.get("dataType"),
                             code=custom_input["code"],
                             value=custom_input.get("value"),
-                            is_required=custom_input.get("isRequired", False),
+                            is_required=custom_input.get("isRequired", True),
                         )
                 node.number = node_json["number"]
                 node.label = node_json["label"]

--- a/aixplain/modules/pipeline/designer/base.py
+++ b/aixplain/modules/pipeline/designer/base.py
@@ -1,3 +1,4 @@
+import re
 from typing import (
     List,
     Union,
@@ -11,7 +12,7 @@ from typing import (
 
 from aixplain.enums import DataType
 from .enums import NodeType, ParamType
-
+from .utils import find_prompt_params
 
 if TYPE_CHECKING:
     from .pipeline import DesignerPipeline
@@ -280,14 +281,31 @@ class ParamProxy(Serializable):
                 return param
         raise KeyError(f"Parameter with code '{code}' not found.")
 
+    def special_prompt_handling(self, code: str, value: str) -> None:
+        """
+        This method will handle the special prompt handling for asset nodes
+        having `text-generation` function type.
+        """
+        from .nodes import AssetNode
+
+        if isinstance(self.node, AssetNode) and self.node.asset.function == "text-generation":
+            if code == "prompt":
+                matches = find_prompt_params(value)
+                for match in matches:
+                    self.node.inputs.create_param(match, DataType.TEXT, is_required=True)
+
+    def set_param_value(self, code: str, value: str) -> None:
+        self.special_prompt_handling(code, value)
+        self[code].value = value
+
     def __setitem__(self, code: str, value: str) -> None:
         # set param value on set item to avoid setting it manually
-        self[code].value = value
+        self.set_param_value(code, value)
 
     def __setattr__(self, name: str, value: any) -> None:
         # set param value on attribute assignment to avoid setting it manually
         if isinstance(value, str) and hasattr(self, name):
-            self[name].value = value
+            self.set_param_value(name, value)
         else:
             super().__setattr__(name, value)
 

--- a/aixplain/modules/pipeline/designer/utils.py
+++ b/aixplain/modules/pipeline/designer/utils.py
@@ -1,0 +1,13 @@
+import re
+from typing import List
+
+
+def find_prompt_params(prompt: str) -> List[str]:
+    """
+    This method will find the prompt parameters in the prompt string.
+
+    :param prompt: the prompt string
+    :return: list of prompt parameters
+    """
+    param_regex = re.compile(r"\{\{([^\}]+)\}\}")
+    return param_regex.findall(prompt)


### PR DESCRIPTION
This PR will handle the population of below the prompt variables automatically. And their validation as well.
```
from aixplain.enums import DataType
from aixplain.factories import PipelineFactory
from aixplain.modules import Pipeline

# Initializing Pipeline
pipeline = PipelineFactory.init("Simple RAG")

# Creating Input Node
question_input = pipeline.input()
question_input.label = "QuestionInput"

# Creating Custom RAG Node
search_node = pipeline.search(asset_id="66fb68b6c2d6534d5a3fe1a8")

# Creating LLM Node
OPENAI_GPT4O_MINI_ASSET = "669a63646eb56306647e1091"
llm_node = pipeline.text_generation(asset_id=OPENAI_GPT4O_MINI_ASSET)

# CAUTION:
# No need to explicitly create the variables now
# llm_node.inputs.create_param(code="question_data", data_type=DataType.TEXT)
# llm_node.inputs.create_param(code="context_data", data_type=DataType.TEXT)

llm_node.inputs.prompt = """Based on the context, answer the question.

Context:
{{context_data}}

Question:
{{question_data}}

Answer:"""

# Question Input -> Search
question_input.outputs.input.link(search_node.inputs.text)
# Question Input -> LLM
question_input.outputs.input.link(llm_node.inputs.question_data)
# Search -> LLM
search_node.outputs.data.link(llm_node.inputs.context_data)
# LLM -> Output
llm_node.use_output("data")

pipeline.save(save_as_asset=True)
```