### PR TITLE
ENG-1289: Enabled reconstructor and segmentor designer nodes when pipeline fetched

### DIFF
--- a/aixplain/factories/pipeline_factory/utils.py
+++ b/aixplain/factories/pipeline_factory/utils.py
@@ -14,6 +14,8 @@ from aixplain.modules.pipeline.designer import (
     Route,
     Script,
     Link,
+    BareSegmentor,
+    BareReconstructor,
 )
 from typing import Dict
 
@@ -45,28 +47,45 @@ def build_from_response(response: Dict, load_architecture: bool = False) -> Pipe
                 elif node_json["type"].lower() == "asset":
                     if node_json["functionType"] == "metric":
                         node = BareMetric(asset_id=node_json["assetId"])
+                    elif node_json["functionType"] == "reconstructor":
+                        node = BareReconstructor(asset_id=node_json["assetId"])
+                    elif node_json["functionType"] == "segmentor":
+                        node = BareSegmentor(asset_id=node_json["assetId"])
                     else:
                         node = BareAsset(asset_id=node_json["assetId"])
-                elif node_json["type"].lower() == "segmentor":
-                    raise NotImplementedError()
-                elif node_json["type"].lower() == "reconstructor":
-                    raise NotImplementedError()
                 elif node_json["type"].lower() == "decision":
-                    node = Decision(routes=[Route(**route) for route in node_json["routes"]])
+                    node = Decision(
+                        routes=[Route(**route) for route in node_json["routes"]]
+                    )
                 elif node_json["type"].lower() == "router":
-                    node = Router(routes=[Route(**route) for route in node_json["routes"]])
+                    node = Router(
+                        routes=[Route(**route) for route in node_json["routes"]]
+                    )
                 elif node_json["type"].lower() == "script":
-                    node = Script(fileId=node_json["fileId"], fileMetadata=node_json["fileMetadata"])
+                    node = Script(
+                        fileId=node_json["fileId"],
+                        fileMetadata=node_json["fileMetadata"],
+                    )
                 elif node_json["type"].lower() == "output":
                     node = Output()
 
                 if "inputValues" in node_json:
                     [
                         node.inputs.create_param(
-                            data_type=DataType(input_param["dataType"]) if "dataType" in input_param else None,
+                            data_type=(
+                                DataType(input_param["dataType"])
+                                if "dataType" in input_param
+                                else None
+                            ),
                             code=input_param["code"],
-                            value=input_param["value"] if "value" in input_param else None,
-                            is_required=input_param["isRequired"] if "isRequired" in input_param else False,
+                            value=(
+                                input_param["value"] if "value" in input_param else None
+                            ),
+                            is_required=(
+                                input_param["isRequired"]
+                                if "isRequired" in input_param
+                                else False
+                            ),
                         )
                         for input_param in node_json["inputValues"]
                         if input_param["code"] not in node.inputs
@@ -74,10 +93,22 @@ def build_from_response(response: Dict, load_architecture: bool = False) -> Pipe
                 if "outputValues" in node_json:
                     [
                         node.outputs.create_param(
-                            data_type=DataType(output_param["dataType"]) if "dataType" in output_param else None,
+                            data_type=(
+                                DataType(output_param["dataType"])
+                                if "dataType" in output_param
+                                else None
+                            ),
                             code=output_param["code"],
-                            value=output_param["value"] if "value" in output_param else None,
-                            is_required=output_param["isRequired"] if "isRequired" in output_param else False,
+                            value=(
+                                output_param["value"]
+                                if "value" in output_param
+                                else None
+                            ),
+                            is_required=(
+                                output_param["isRequired"]
+                                if "isRequired" in output_param
+                                else False
+                            ),
                         )
                         for output_param in node_json["outputValues"]
                         if output_param["code"] not in node.outputs

--- a/aixplain/modules/pipeline/designer/__init__.py
+++ b/aixplain/modules/pipeline/designer/__init__.py
@@ -11,6 +11,8 @@ from .nodes import (
     BaseMetric,
     BareAsset,
     BareMetric,
+    BareSegmentor,
+    BareReconstructor,
 )
 from .pipeline import DesignerPipeline
 from .base import (

--- a/aixplain/modules/pipeline/designer/nodes.py
+++ b/aixplain/modules/pipeline/designer/nodes.py
@@ -474,19 +474,11 @@ class BaseReconstructor(AssetNode[TI, TO]):
 
 
 class ReconstructorInputs(Inputs):
-    data: InputParam = None
-
-    def __init__(self, node: Node):
-        super().__init__(node)
-        self.data = self.create_param("data")
+    pass
 
 
 class ReconstructorOutputs(Outputs):
-    data: OutputParam = None
-
-    def __init__(self, node: Node):
-        super().__init__(node)
-        self.data = self.create_param("data")
+    pass
 
 
 class BareReconstructor(BaseReconstructor[ReconstructorInputs, ReconstructorOutputs]):


### PR DESCRIPTION
Added `BareReconstructor` and `BareSegmentor` implementations in place to make them included in pipeline population. Below the code snippet populated and run successfully.
```
from aixplain.factories import PipelineFactory

pipeline = PipelineFactory.get("65f33fec4b3136f9eeae5511")
pipeline.run("https://homepage.ntu.edu.tw/~karchung/miniconversations/mc1.mp3")
```