### PR TITLE
Bug 431

### DIFF
--- a/aixplain/modules/pipeline/designer/base.py
+++ b/aixplain/modules/pipeline/designer/base.py
@@ -247,12 +247,13 @@ class ParamProxy(Serializable):
 
     def add_param(self, param: Param) -> None:
         # check if param already registered
-        if hasattr(self, param.code) or param in self:
+        if param in self:
             raise ValueError(f"Parameter with code '{param.code}' already exists.")
         self._params.append(param)
         # also set attribute on the node dynamically if there's no
         # any attribute with the same name
-        setattr(self, param.code, param)
+        if not hasattr(self, param.code):
+            setattr(self, param.code, param)
 
     def _create_param(self, code: str, data_type: DataType = None, value: any = None) -> Param:
         raise NotImplementedError()
@@ -287,7 +288,8 @@ class ParamProxy(Serializable):
             if code == "prompt":
                 matches = find_prompt_params(value)
                 for match in matches:
-                    self.node.inputs.create_param(match, DataType.TEXT, is_required=True)
+                    if match not in self:
+                        self.node.inputs.create_param(match, DataType.TEXT, is_required=True)
 
     def set_param_value(self, code: str, value: str) -> None:
         self.special_prompt_handling(code, value)

--- a/aixplain/modules/pipeline/designer/base.py
+++ b/aixplain/modules/pipeline/designer/base.py
@@ -247,13 +247,12 @@ class ParamProxy(Serializable):
 
     def add_param(self, param: Param) -> None:
         # check if param already registered
-        if param in self:
+        if hasattr(self, param.code) or param in self:
             raise ValueError(f"Parameter with code '{param.code}' already exists.")
         self._params.append(param)
         # also set attribute on the node dynamically if there's no
         # any attribute with the same name
-        if not hasattr(self, param.code):
-            setattr(self, param.code, param)
+        setattr(self, param.code, param)
 
     def _create_param(self, code: str, data_type: DataType = None, value: any = None) -> Param:
         raise NotImplementedError()
@@ -300,7 +299,7 @@ class ParamProxy(Serializable):
 
     def __setattr__(self, name: str, value: any) -> None:
         # set param value on attribute assignment to avoid setting it manually
-        if hasattr(self, name) and not isinstance(value, Param):
+        if hasattr(self, "_params") and name in self._params:
             self.set_param_value(name, value)
         else:
             super().__setattr__(name, value)

--- a/aixplain/modules/pipeline/designer/base.py
+++ b/aixplain/modules/pipeline/designer/base.py
@@ -271,38 +271,54 @@ class ParamProxy(Serializable):
         param.node = self.node
         return param
 
-    def __getitem__(self, code: str) -> Param:
+    def __getattr__(self, code: str) -> Param:
+        if code == "_params":
+            raise AttributeError("Attribute '_params' is not accessible")
         for param in self._params:
             if param.code == code:
                 return param
-        raise KeyError(f"Parameter with code '{code}' not found.")
+        raise AttributeError(f"Attribute with code '{code}' not found.")
+
+    def __getitem__(self, code: str) -> Param:
+        try:
+            return getattr(self, code)
+        except AttributeError:
+            raise KeyError(f"Parameter with code '{code}' not found.")
 
     def special_prompt_handling(self, code: str, value: str) -> None:
         """
         This method will handle the special prompt handling for asset nodes
         having `text-generation` function type.
         """
+        prompt_param = getattr(self, "prompt", None)
+        if prompt_param:
+            raise ValueError("Prompt param already exists")
+
         from .nodes import AssetNode
 
-        if isinstance(self.node, AssetNode) and self.node.asset.function == "text-generation":
-            if code == "prompt":
-                matches = find_prompt_params(value)
-                for match in matches:
-                    if match not in self:
-                        self.node.inputs.create_param(match, DataType.TEXT, is_required=True)
+        if not isinstance(self.node, AssetNode):
+            return
 
-    def set_param_value(self, code: str, value: str) -> None:
-        self.special_prompt_handling(code, value)
-        self[code].value = value
+        if not hasattr(self.node, "asset") or self.node.asset.function != "text-generation":
+            return
+
+        matches = find_prompt_params(value)
+        for match in matches:
+            if match in self:
+                raise ValueError(f"Prompt param with code '{match}' already exists")
+
+            self.node.inputs.create_param(match, DataType.TEXT, is_required=True)
 
     def __setitem__(self, code: str, value: str) -> None:
-        # set param value on set item to avoid setting it manually
-        self.set_param_value(code, value)
+        setattr(self, code, value)
 
     def __setattr__(self, name: str, value: any) -> None:
-        # set param value on attribute assignment to avoid setting it manually
-        if hasattr(self, "_params") and name in self._params:
-            self.set_param_value(name, value)
+        if name == "prompt":
+            self.special_prompt_handling(name, value)
+
+        param = getattr(self, name, None)
+        if param and isinstance(param, Param):
+            param.value = value
         else:
             super().__setattr__(name, value)
 

--- a/aixplain/modules/pipeline/designer/base.py
+++ b/aixplain/modules/pipeline/designer/base.py
@@ -300,7 +300,7 @@ class ParamProxy(Serializable):
 
     def __setattr__(self, name: str, value: any) -> None:
         # set param value on attribute assignment to avoid setting it manually
-        if isinstance(value, str) and hasattr(self, name):
+        if hasattr(self, name) and not isinstance(value, Param):
             self.set_param_value(name, value)
         else:
             super().__setattr__(name, value)

--- a/tests/unit/designer_unit_test.py
+++ b/tests/unit/designer_unit_test.py
@@ -597,6 +597,14 @@ def test_param_proxy_set_param_value():
         mock_special_prompt_handling.assert_called_once_with("prompt", "hello {{foo}}")
         assert prompt_param.value == "hello {{foo}}"
 
+        # Use a non string value
+        param_proxy.set_param_value("prompt", 123)
+        assert prompt_param.value == 123
+
+        # Now change it to another non string value
+        param_proxy.set_param_value("prompt", 456)
+        assert prompt_param.value == 456
+
 
 def test_param_proxy_special_prompt_handling():
     from aixplain.modules.pipeline.designer.nodes import AssetNode

--- a/tests/unit/designer_unit_test.py
+++ b/tests/unit/designer_unit_test.py
@@ -593,16 +593,16 @@ def test_param_proxy_set_param_value():
     param_proxy = ParamProxy(Mock())
     param_proxy._params = [prompt_param]
     with patch.object(param_proxy, "special_prompt_handling") as mock_special_prompt_handling:
-        param_proxy.set_param_value("prompt", "hello {{foo}}")
+        param_proxy.prompt = "hello {{foo}}"
         mock_special_prompt_handling.assert_called_once_with("prompt", "hello {{foo}}")
         assert prompt_param.value == "hello {{foo}}"
 
         # Use a non string value
-        param_proxy.set_param_value("prompt", 123)
+        param_proxy.prompt = 123
         assert prompt_param.value == 123
 
         # Now change it to another non string value
-        param_proxy.set_param_value("prompt", 456)
+        param_proxy.prompt = 456
         assert prompt_param.value == 456
 
 


### PR DESCRIPTION
This PR fixes the bug on setting params properly through `ParamProxy` class.

```
% PYTHONPATH=. pytest tests/unit/designer_unit_test.py
============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.9.20, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/kadirpekel/aixplain/aiXplain
configfile: pytest.ini
plugins: mock-3.14.0, requests-mock-1.12.1
collected 33 items

tests/unit/designer_unit_test.py .................................                                                                                                                                         [100%]

=============================================================================================== 33 passed in 1.32s ===============================================================================================
```

```
% PYTHONPATH=. pytest tests/functional/pipelines/designer_test.py
============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.9.20, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/kadirpekel/aixplain/aiXplain
configfile: pytest.ini
plugins: mock-3.14.0, requests-mock-1.12.1
collected 8 items

tests/functional/pipelines/designer_test.py ........                                                                                                                                                       [100%]

========================================================================================= 8 passed in 288.51s (0:04:48) ==========================================================================================
```

