### PR TITLE
BUG-447: Renamed decision node output param along with dataSourceId c…

### DIFF
--- a/aixplain/modules/pipeline/designer/base.py
+++ b/aixplain/modules/pipeline/designer/base.py
@@ -1,4 +1,3 @@
-import re
 from typing import (
     List,
     Union,
@@ -131,6 +130,7 @@ class Link(Serializable):
     to_node: "Node"
     from_param: str
     to_param: str
+    data_source_id: Optional[str] = None
 
     pipeline: Optional["DesignerPipeline"] = None
 
@@ -140,6 +140,7 @@ class Link(Serializable):
         to_node: "Node",
         from_param: Union[Param, str],
         to_param: Union[Param, str],
+        data_source_id: Optional[str] = None,
         pipeline: "DesignerPipeline" = None,
     ):
 
@@ -171,6 +172,7 @@ class Link(Serializable):
         self.to_node = to_node
         self.from_param = from_param
         self.to_param = to_param
+        self.data_source_id = data_source_id
 
         if pipeline:
             self.attach_to(pipeline)
@@ -224,15 +226,17 @@ class Link(Serializable):
     def serialize(self) -> dict:
         assert self.from_node.number is not None, "From node number not set"
         assert self.to_node.number is not None, "To node number not set"
+        param_mapping = {
+            "from": self.from_param,
+            "to": self.to_param,
+        }
+        if self.data_source_id:
+            param_mapping["dataSourceId"] = self.data_source_id
+
         return {
             "from": self.from_node.number,
             "to": self.to_node.number,
-            "paramMapping": [
-                {
-                    "from": self.from_param,
-                    "to": self.to_param,
-                }
-            ],
+            "paramMapping": [param_mapping],
         }
 
 

--- a/aixplain/modules/pipeline/designer/pipeline.py
+++ b/aixplain/modules/pipeline/designer/pipeline.py
@@ -213,29 +213,7 @@ class DesignerPipeline(Serializable):
         nodes based on the data types of the connected nodes.
         """
         for link in self.links:
-            from_node = self.get_node(link.from_node)
-            to_node = self.get_node(link.to_node)
-            if not from_node or not to_node:
-                continue  # will be handled by the validation
-            for param in link.param_mapping:
-                from_param = from_node.outputs[param.from_param]
-                to_param = to_node.inputs[param.to_param]
-                if not from_param or not to_param:
-                    continue  # will be handled by the validation
-                # if one of the data types is missing, infer the other one
-                dataType = from_param.data_type or to_param.data_type
-                from_param.data_type = dataType
-                to_param.data_type = dataType
-
-            def infer_data_type(node):
-                from .nodes import Input, Output
-
-                if isinstance(node, Input) or isinstance(node, Output):
-                    if dataType and dataType not in node.data_types:
-                        node.data_types.append(dataType)
-
-            infer_data_type(self)
-            infer_data_type(to_node)
+            link.auto_infer()
 
     def asset(self, asset_id: str, *args, asset_class: Type[T] = AssetNode, **kwargs) -> T:
         """

--- a/tests/functional/pipelines/designer_test.py
+++ b/tests/functional/pipelines/designer_test.py
@@ -184,11 +184,10 @@ def test_decision_pipeline(pipeline):
     input.outputs.input.link(sentiment_analysis.inputs.text)
     sentiment_analysis.outputs.data.link(decision_node.inputs.comparison)
     input.outputs.input.link(decision_node.inputs.passthrough)
-    decision_node.outputs.input.link(positive_output.inputs.output)
-    decision_node.outputs.input.link(negative_output.inputs.output)
+    decision_node.outputs.data.link(positive_output.inputs.output)
+    decision_node.outputs.data.link(negative_output.inputs.output)
 
     pipeline.save()
-
     output = pipeline.run(
         "I feel so bad today!",
         version="3.0",


### PR DESCRIPTION
Functional and unit tests are passing
```
tests/functional/pipelines/designer_test.py ........                                                                                                                                                       
tests/unit/designer_unit_test.py ..................................  
```