### PR TITLE
ENG-1852: Hotfix, added fail-fast option

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,7 @@ jobs:
   setup-and-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         test-suite: [
           'tests/unit',


### PR DESCRIPTION
This fix prevents all tests to fail when any of them fails.