### PR TITLE
Add attributes to model card additional info

### DIFF
--- a/aixplain/factories/model_factory/utils.py
+++ b/aixplain/factories/model_factory/utils.py
@@ -36,6 +36,11 @@ def create_model_from_response(response: Dict) -> Model:
                 if len(values) > 0:
                     parameters[param["name"]] = values
 
+    attributes = response.get("attributes", None)
+    if attributes:
+        embedding_model = next((item['code'] for item in attributes if item['name'] == 'embeddingmodel'), None)
+        embedding_size = next((item['value'] for item in attributes if item['name'] == 'embeddingSize'), None)
+
     function_id = response["function"]["id"]
     function = Function(function_id)
     function_input_params, function_output_params = function.get_input_output_params()
@@ -100,7 +105,8 @@ def create_model_from_response(response: Dict) -> Model:
         temperature=temperature,
         supports_streaming=response.get("supportsStreaming", False),
         status=status,
-        attributes=response.get("attributes", []),
+        embedding_model=embedding_model,
+        embedding_size=embedding_size
     )
 
 

--- a/aixplain/factories/model_factory/utils.py
+++ b/aixplain/factories/model_factory/utils.py
@@ -100,6 +100,7 @@ def create_model_from_response(response: Dict) -> Model:
         temperature=temperature,
         supports_streaming=response.get("supportsStreaming", False),
         status=status,
+        attributes=response.get("attributes", []),
     )
 
 

--- a/aixplain/factories/model_factory/utils.py
+++ b/aixplain/factories/model_factory/utils.py
@@ -37,11 +37,14 @@ def create_model_from_response(response: Dict) -> Model:
                     parameters[param["name"]] = values
 
     attributes = response.get("attributes", None)
-    embedding_model = None
-    embedding_size = None
+    additional_kwargs = {}
     if attributes:
-        embedding_model = next((item['code'] for item in attributes if item['name'] == 'embeddingmodel'), None)
-        embedding_size = next((item['value'] for item in attributes if item['name'] == 'embeddingSize'), None)
+        embedding_model = next((item["code"] for item in attributes if item["name"] == "embeddingmodel"), None)
+        if embedding_model:
+            additional_kwargs["embedding_model"] = embedding_model
+        embedding_size = next((item["value"] for item in attributes if item["name"] == "embeddingSize"), None)
+        if embedding_size:
+            additional_kwargs["embedding_size"] = embedding_size
 
     function_id = response["function"]["id"]
     function = Function(function_id)
@@ -107,8 +110,7 @@ def create_model_from_response(response: Dict) -> Model:
         temperature=temperature,
         supports_streaming=response.get("supportsStreaming", False),
         status=status,
-        embedding_model=embedding_model,
-        embedding_size=embedding_size
+        **additional_kwargs,
     )
 
 

--- a/aixplain/factories/model_factory/utils.py
+++ b/aixplain/factories/model_factory/utils.py
@@ -37,6 +37,8 @@ def create_model_from_response(response: Dict) -> Model:
                     parameters[param["name"]] = values
 
     attributes = response.get("attributes", None)
+    embedding_model = None
+    embedding_size = None
     if attributes:
         embedding_model = next((item['code'] for item in attributes if item['name'] == 'embeddingmodel'), None)
         embedding_size = next((item['value'] for item in attributes if item['name'] == 'embeddingSize'), None)

--- a/aixplain/modules/model/__init__.py
+++ b/aixplain/modules/model/__init__.py
@@ -123,9 +123,7 @@ class Model(Asset):
         Returns:
             Dict: Model Information
         """
-        clean_additional_info = {
-            k: v for k, v in self.additional_info.items() if v is not None
-        }
+        clean_additional_info = {k: v for k, v in self.additional_info.items() if v not in [None, "", [], {}]}
         return {
             "id": self.id,
             "name": self.name,

--- a/aixplain/modules/model/index_model.py
+++ b/aixplain/modules/model/index_model.py
@@ -50,7 +50,6 @@ class IndexModel(Model):
         is_subscribed: bool = False,
         cost: Optional[Dict] = None,
         embedding_model: Optional[EmbeddingModel] = None,
-        embedding_size: Optional[int] = None,
         **additional_info,
     ) -> None:
         """Index Init

--- a/aixplain/modules/model/index_model.py
+++ b/aixplain/modules/model/index_model.py
@@ -50,6 +50,7 @@ class IndexModel(Model):
         is_subscribed: bool = False,
         cost: Optional[Dict] = None,
         embedding_model: Optional[EmbeddingModel] = None,
+        embedding_size: Optional[int] = None,
         **additional_info,
     ) -> None:
         """Index Init
@@ -83,11 +84,12 @@ class IndexModel(Model):
         self.url = config.MODELS_RUN_URL
         self.backend_url = config.BACKEND_URL
         self.embedding_model = embedding_model
+        self.embedding_size = embedding_size
 
-    
     def to_dict(self) -> Dict:
         data = super().to_dict()
         data["embedding_model"] = self.embedding_model
+        data["embedding_size"] = self.embedding_size
         data["collection_type"] = self.version.split("-", 1)[0]
         return data
 

--- a/aixplain/modules/model/index_model.py
+++ b/aixplain/modules/model/index_model.py
@@ -84,6 +84,13 @@ class IndexModel(Model):
         self.backend_url = config.BACKEND_URL
         self.embedding_model = embedding_model
 
+    
+    def to_dict(self) -> Dict:
+        data = super().to_dict()
+        data["embedding_model"] = self.embedding_model
+        data["collection_type"] = self.version.split("-", 1)[0]
+        return data
+
     def search(self, query: str, top_k: int = 10, filters: List[IndexFilter] = []) -> ModelResponse:
         """Search for documents in the index
 

--- a/aixplain/modules/model/index_model.py
+++ b/aixplain/modules/model/index_model.py
@@ -84,7 +84,17 @@ class IndexModel(Model):
         self.url = config.MODELS_RUN_URL
         self.backend_url = config.BACKEND_URL
         self.embedding_model = embedding_model
-        self.embedding_size = embedding_size
+        if embedding_model:
+            try:
+                from aixplain.factories import ModelFactory
+
+                model = ModelFactory.get(embedding_model)
+                self.embedding_size = model.additional_info["embedding_size"]
+            except Exception as e:
+                import warnings
+
+                warnings.warn(f"Failed to get embedding size for embedding model {embedding_model}: {e}")
+                self.embedding_size = None
 
     def to_dict(self) -> Dict:
         data = super().to_dict()

--- a/tests/functional/model/run_model_test.py
+++ b/tests/functional/model/run_model_test.py
@@ -14,6 +14,7 @@ from aixplain.utils.cache_utils import CACHE_FOLDER
 from aixplain.modules.model import Model
 from aixplain.factories.index_factory.utils import AirParams, VectaraParams, GraphRAGParams, ZeroEntropyParams
 
+
 def pytest_generate_tests(metafunc):
     if "llm_model" in metafunc.fixturenames:
         four_weeks_ago = datetime.now(timezone.utc) - timedelta(weeks=4)
@@ -78,6 +79,21 @@ def test_run_async():
 
     assert response["status"] == "SUCCESS"
     assert "teste" in response["data"].lower()
+
+
+@pytest.mark.parametrize(
+    "embedding_model,supplier_params",
+    [pytest.param(EmbeddingModel.OPENAI_ADA002, AirParams, id="AIR - OpenAI Ada 002")],
+)
+def test_index_model_with_embedding(embedding_model, supplier_params):
+    from uuid import uuid4
+    from aixplain.factories import IndexFactory
+
+    params = supplier_params(name=str(uuid4()), description=str(uuid4()), embedding_model=embedding_model)
+    index_model = IndexFactory.create(params=params)
+    assert index_model.embedding_model == embedding_model
+    assert index_model.embedding_size == 1536, f"Embedding size mismatch for {embedding_model}"
+    index_model.delete()
 
 
 def run_index_model(index_model):
@@ -206,7 +222,7 @@ def test_aixplain_model_cache_creation():
         os.remove(cache_file)
 
     # Instantiate the Model (replace this with a real model ID from your env)
-    model_id = "6239efa4822d7a13b8e20454"    # Translate from Punjabi to Portuguese (Brazil)
+    model_id = "6239efa4822d7a13b8e20454"  # Translate from Punjabi to Portuguese (Brazil)
     _ = Model(id=model_id)
 
     # Assert the cache file was created
@@ -217,7 +233,8 @@ def test_aixplain_model_cache_creation():
 
     assert "data" in cache_data, "Cache file structure invalid - missing 'data' key."
     assert any(m.get("id") == model_id for m in cache_data["data"]["items"]), "Instantiated model not found in cache."
-=======
+
+
 def test_index_model_air_with_image():
     from aixplain.factories import IndexFactory
     from aixplain.modules.model.record import Record


### PR DESCRIPTION
Add attributes to model card additional_info key:
Example Usage:
- Getting embedding size of embedding models from the model card
- Getting embedding model of IndexModel