### PR TITLE
Update unit tests for team-agents and agents

### DIFF
--- a/tests/unit/agent/agent_test.py
+++ b/tests/unit/agent/agent_test.py
@@ -18,21 +18,21 @@ from aixplain.modules.agent.agent_response_data import AgentResponseData
 
 
 def test_fail_no_data_query():
-    agent = Agent("123", "Test Agent(-)", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent(-)", "Sample Description", instructions="Test Agent Instructions")
     with pytest.raises(Exception) as exc_info:
         agent.run_async()
     assert str(exc_info.value) == "Either 'data' or 'query' must be provided."
 
 
 def test_fail_query_must_be_provided():
-    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Instructions")
     with pytest.raises(Exception) as exc_info:
         agent.run_async(data={})
     assert str(exc_info.value) == "When providing a dictionary, 'query' must be provided."
 
 
 def test_fail_query_as_text_when_content_not_empty():
-    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Instructions")
     with pytest.raises(Exception) as exc_info:
         agent.run_async(
             data={"query": "https://aixplain-platform-assets.s3.amazonaws.com/samples/en/CPAC1x2.wav"},
@@ -45,7 +45,7 @@ def test_fail_query_as_text_when_content_not_empty():
 
 
 def test_fail_content_exceed_maximum():
-    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Instructions")
     with pytest.raises(Exception) as exc_info:
         agent.run_async(
             data={"query": "Transcribe the audios:"},
@@ -60,14 +60,14 @@ def test_fail_content_exceed_maximum():
 
 
 def test_fail_key_not_found():
-    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent", "Sample Description", instructions="Test Agent Instructions")
     with pytest.raises(Exception) as exc_info:
         agent.run_async(data={"query": "Translate the text: {{input1}}"}, content={"input2": "Hello, how are you?"})
     assert str(exc_info.value) == "Key 'input2' not found in query."
 
 
 def test_success_query_content():
-    agent = Agent("123", "Test Agent(-)", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent(-)", "Sample Description", instructions="Test Agent Instructions")
     with requests_mock.Mocker() as mock:
         url = agent.url
         headers = {"x-api-key": config.TEAM_API_KEY, "Content-Type": "application/json"}
@@ -90,7 +90,7 @@ def test_invalid_pipelinetool(mocker):
         AgentFactory.create(
             name="Test",
             description="Test Description",
-            instructions="Test Role",
+            instructions="Test Instructions",
             tools=[PipelineTool(pipeline="309851793", description="Test")],
             llm_id="6646261c6eb563165658bbb1",
         )
@@ -186,7 +186,7 @@ def test_create_agent(mock_model_factory_get):
             agent = AgentFactory.create(
                 name="Test Agent(-)",
                 description="Test Agent Description",
-                instructions="Test Agent Role",
+                instructions="Test Agent Instructions",
                 llm_id="6646261c6eb563165658bbb1",
                 tools=[
                     AgentFactory.create_model_tool(
@@ -220,7 +220,7 @@ def test_to_dict():
         id="",
         name="Test Agent(-)",
         description="Test Agent Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         llm_id="6646261c6eb563165658bbb1",
         tools=[AgentFactory.create_model_tool(function="text-generation")],
         api_key="test_api_key",
@@ -231,7 +231,7 @@ def test_to_dict():
     assert agent_json["id"] == ""
     assert agent_json["name"] == "Test Agent(-)"
     assert agent_json["description"] == "Test Agent Description"
-    assert agent_json["instructions"] == "Test Agent Role"
+    assert agent_json["instructions"] == "Test Agent Instructions"
     assert agent_json["llmId"] == "6646261c6eb563165658bbb1"
     assert agent_json["assets"][0]["function"] == "text-generation"
     assert agent_json["assets"][0]["type"] == "model"
@@ -252,7 +252,7 @@ def test_update_success(mock_model_factory_get):
         id="123",
         name="Test Agent(-)",
         description="Test Agent Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         llm_id="6646261c6eb563165658bbb1",
         tools=[AgentFactory.create_model_tool(function="text-generation")],
     )
@@ -264,7 +264,7 @@ def test_update_success(mock_model_factory_get):
             "id": "123",
             "name": "Test Agent(-)",
             "description": "Test Agent Description",
-            "instructions": "Test Agent Role",
+            "instructions": "Test Agent Instructions",
             "teamId": "123",
             "version": "1.0",
             "status": "onboarded",
@@ -324,7 +324,7 @@ def test_save_success(mock_model_factory_get):
         id="123",
         name="Test Agent(-)",
         description="Test Agent Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         llm_id="6646261c6eb563165658bbb1",
         tools=[AgentFactory.create_model_tool(function="text-generation")],
     )
@@ -336,7 +336,7 @@ def test_save_success(mock_model_factory_get):
             "id": "123",
             "name": "Test Agent(-)",
             "description": "Test Agent Description",
-            "instructions": "Test Agent Role",
+            "instructions": "Test Agent Instructions",
             "teamId": "123",
             "version": "1.0",
             "status": "onboarded",
@@ -388,7 +388,7 @@ def test_save_success(mock_model_factory_get):
 
 
 def test_run_success():
-    agent = Agent("123", "Test Agent(-)", "Sample Description", instructions="Test Agent Role")
+    agent = Agent("123", "Test Agent(-)", "Sample Description", instructions="Test Agent Instructions")
     url = urljoin(config.BACKEND_URL, f"sdk/agents/{agent.id}/run")
     agent.url = url
     with requests_mock.Mocker() as mock:
@@ -440,7 +440,7 @@ def test_agent_api_key_propagation():
         id="123",
         name="Test Agent",
         description="Test Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         tools=[tool],
         api_key=custom_api_key,
     )
@@ -454,7 +454,7 @@ def test_agent_api_key_propagation():
 def test_agent_default_api_key():
     """Test that the default api_key is used when none is provided"""
     tool = AgentFactory.create_model_tool(function="text-generation")
-    agent = Agent(id="123", name="Test Agent", description="Test Description", instructions="Test Agent Role", tools=[tool])
+    agent = Agent(id="123", name="Test Agent", description="Test Description", instructions="Test Agent Instructions", tools=[tool])
 
     # Check that the agent has the default api_key
     assert agent.api_key == config.TEAM_API_KEY
@@ -543,7 +543,7 @@ def test_agent_factory_create_without_instructions():
             sent_request = mock.request_history[0]
             sent_payload = sent_request.json()
 
-            # The role should be set to description when instructions is None
+            # The Instructions should be set to description when instructions is None
             assert sent_payload["instructions"] == "Test Agent Description"
             assert sent_payload["description"] == "Test Agent Description"
 
@@ -556,7 +556,7 @@ def test_agent_to_dict_payload_without_instructions():
     # Get the payload
     payload = agent.to_dict()
 
-    # Check that role falls back to description when instructions is None
+    # Check that Instructions falls back to description when instructions is None
     assert payload["instructions"] == "Test Description"  # Should fallback to description
     assert payload["description"] == "Test Description"
     assert agent.instructions is None
@@ -570,7 +570,7 @@ def test_agent_to_dict_payload_with_instructions():
     # Get the payload
     payload = agent.to_dict()
 
-    # Check that role uses instructions when provided
+    # Check that Instructions uses instructions when provided
     assert payload["instructions"] == "Custom Instructions"
     assert payload["description"] == "Test Description"
     assert agent.instructions == "Custom Instructions"
@@ -644,7 +644,7 @@ def test_agent_factory_create_with_explicit_none_instructions():
             sent_request = mock.request_history[0]
             sent_payload = sent_request.json()
 
-            # The role should be set to description when instructions is None
+            # The Instructions should be set to description when instructions is None
             assert sent_payload["instructions"] == "Test Agent Description"
             assert sent_payload["description"] == "Test Agent Description"
 
@@ -664,7 +664,7 @@ def test_agent_multiple_tools_api_key():
         id="123",
         name="Test Agent",
         description="Test Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         tools=tools,
         api_key=custom_api_key,
     )
@@ -678,7 +678,7 @@ def test_agent_api_key_in_requests():
     """Test that the api_key is properly used in API requests"""
     custom_api_key = "custom_test_key"
     agent = Agent(
-        id="123", name="Test Agent", description="Test Description", instructions="Test Agent Role", api_key=custom_api_key
+        id="123", name="Test Agent", description="Test Description", instructions="Test Agent Instructions", api_key=custom_api_key
     )
 
     with requests_mock.Mocker() as mock:

--- a/tests/unit/agent/agent_test.py
+++ b/tests/unit/agent/agent_test.py
@@ -231,7 +231,7 @@ def test_to_dict():
     assert agent_json["id"] == ""
     assert agent_json["name"] == "Test Agent(-)"
     assert agent_json["description"] == "Test Agent Description"
-    assert agent_json["instructions"] == "Test Agent Instructions"
+    assert agent_json["instructions"] == "Test Agent Role"
     assert agent_json["llmId"] == "6646261c6eb563165658bbb1"
     assert agent_json["assets"][0]["function"] == "text-generation"
     assert agent_json["assets"][0]["type"] == "model"
@@ -264,7 +264,7 @@ def test_update_success(mock_model_factory_get):
             "id": "123",
             "name": "Test Agent(-)",
             "description": "Test Agent Description",
-            "instructions": "Test Agent Instructions",
+            "instructions": "Test Agent Role",
             "teamId": "123",
             "version": "1.0",
             "status": "onboarded",
@@ -336,7 +336,7 @@ def test_save_success(mock_model_factory_get):
             "id": "123",
             "name": "Test Agent(-)",
             "description": "Test Agent Description",
-            "instructions": "Test Agent Instructions",
+            "instructions": "Test Agent Role",
             "teamId": "123",
             "version": "1.0",
             "status": "onboarded",
@@ -1272,7 +1272,7 @@ def test_agent_serialization_completeness():
     required_fields = {
         "llmId",
         "version",
-        "role",
+        "instructions",
         "api_key",
         "supplier",
         "outputFormat",
@@ -1293,7 +1293,7 @@ def test_agent_serialization_completeness():
     assert agent_dict["id"] == "test-agent-123"
     assert agent_dict["name"] == "Test Agent"
     assert agent_dict["description"] == "A test agent for validation"
-    assert agent_dict["role"] == "You are a helpful test agent"
+    assert agent_dict["instructions"] == "You are a helpful test agent"
     assert agent_dict["llmId"] == "6646261c6eb563165658bbb1"
     assert agent_dict["api_key"] == "test-api-key"
     assert agent_dict["supplier"] == "aixplain"
@@ -1339,21 +1339,21 @@ def test_agent_serialization_with_llm():
     assert llm_tool["parameters"] == [{"name": "temperature", "value": 0.7}]
 
 
-def test_agent_serialization_role_fallback():
-    """Test Agent to_dict role field fallback behavior."""
+def test_agent_serialization_instructions_fallback():
+    """Test Agent to_dict instructions field fallback behavior."""
     # Test with instructions provided
     agent_with_instructions = Agent(
         id="test1", name="Test Agent 1", description="Test description", instructions="Custom instructions"
     )
 
     dict1 = agent_with_instructions.to_dict()
-    assert dict1["role"] == "Custom instructions"
+    assert dict1["instructions"] == "Custom instructions"
 
     # Test without instructions (should fall back to description)
     agent_without_instructions = Agent(id="test2", name="Test Agent 2", description="Test description")
 
     dict2 = agent_without_instructions.to_dict()
-    assert dict2["role"] == "Test description"
+    assert dict2["instructions"] == "Test description"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/team_agent/team_agent_test.py
+++ b/tests/unit/team_agent/team_agent_test.py
@@ -85,7 +85,7 @@ def test_to_dict():
                 id="",
                 name="Test Agent(-)",
                 description="Test Agent Description",
-                instructions="Test Agent Role",
+                instructions="Test Agent Instructions",
                 llm_id="6646261c6eb563165658bbb1",
                 tools=[ModelTool(function="text-generation")],
             )
@@ -181,7 +181,7 @@ def test_create_team_agent(mock_model_factory_get):
         agent = AgentFactory.create(
             name="Test Agent(-)",
             description="Test Agent Description",
-            instructions="Test Agent Role",
+            instructions="Test Agent Instructions",
             llm_id="6646261c6eb563165658bbb1",
             tools=[ModelTool(model="6646261c6eb563165658bbb1")],
         )
@@ -259,7 +259,7 @@ def test_fail_inspector_without_mentalist():
                     id="123",
                     name="Test Agent(-)",
                     description="Test Agent Description",
-                    instructions="Test Agent Role",
+                    instructions="Test Agent Instructions",
                     llm_id="6646261c6eb563165658bbb1",
                     tools=[ModelTool(function="text-generation")],
                 )
@@ -287,7 +287,7 @@ def test_fail_invalid_inspector_target():
                     id="123",
                     name="Test Agent(-)",
                     description="Test Agent Description",
-                    instructions="Test Agent Role",
+                    instructions="Test Agent Instructions",
                     llm_id="6646261c6eb563165658bbb1",
                     tools=[ModelTool(function="text-generation")],
                 )
@@ -315,7 +315,7 @@ def test_build_team_agent(mocker):
         id="agent1",
         name="Test Agent 1",
         description="Test Agent Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         llm_id="6646261c6eb563165658bbb1",
         tools=[ModelTool(model="6646261c6eb563165658bbb1")],
         tasks=[
@@ -332,7 +332,7 @@ def test_build_team_agent(mocker):
         id="agent2",
         name="Test Agent 2",
         description="Test Agent Description",
-        instructions="Test Agent Role",
+        instructions="Test Agent Instructions",
         llm_id="6646261c6eb563165658bbb1",
         tools=[ModelTool(model="6646261c6eb563165658bbb1")],
         tasks=[
@@ -587,7 +587,7 @@ def test_update_success(mock_model_factory_get):
                 id="agent123",
                 name="Test Agent(-)",
                 description="Test Agent Description",
-                instructions="Test Agent Role",
+                instructions="Test Agent Instructions",
                 llm_id="6646261c6eb563165658bbb1",
                 tools=[ModelTool(model="6646261c6eb563165658bbb1")],
             )
@@ -662,7 +662,7 @@ def test_save_success(mock_model_factory_get):
                 id="agent123",
                 name="Test Agent(-)",
                 description="Test Agent Description",
-                instructions="Test Agent Role",
+                instructions="Test Agent Instructions",
                 llm_id="6646261c6eb563165658bbb1",
                 tools=[ModelTool(model="6646261c6eb563165658bbb1")],
             )

--- a/tests/unit/team_agent/team_agent_test.py
+++ b/tests/unit/team_agent/team_agent_test.py
@@ -442,7 +442,7 @@ def test_team_agent_serialization_completeness():
         "supplier",
         "version",
         "status",
-        "role",
+        "instructions",
         "outputFormat",
         "expectedOutput",
     }
@@ -453,7 +453,7 @@ def test_team_agent_serialization_completeness():
     assert team_dict["id"] == "test-team-123"
     assert team_dict["name"] == "Test Team"
     assert team_dict["description"] == "A test team agent"
-    assert team_dict["role"] == "You are a helpful team agent"
+    assert team_dict["instructions"] == "You are a helpful team agent"
     assert team_dict["llmId"] == "6646261c6eb563165658bbb1"
     assert team_dict["supplier"] == "aixplain"
     assert team_dict["version"] == "1.0.0"
@@ -566,3 +566,158 @@ def test_team_agent_serialization_supervisor_fallback():
 
     dict2 = team_agent2.to_dict()
     assert dict2["supervisorId"] == "supervisor-llm-id"
+
+
+@patch("aixplain.factories.model_factory.ModelFactory.get")
+def test_update_success(mock_model_factory_get):
+    from aixplain.modules import Model
+    from aixplain.enums import Function
+
+    # Mock the model factory response
+    mock_model = Model(
+        id="6646261c6eb563165658bbb1", name="Test LLM", description="Test LLM Description", function=Function.TEXT_GENERATION
+    )
+    mock_model_factory_get.return_value = mock_model
+
+    team_agent = TeamAgent(
+        id="123",
+        name="Test Team Agent(-)",
+        agents=[
+            Agent(
+                id="agent123",
+                name="Test Agent(-)",
+                description="Test Agent Description",
+                instructions="Test Agent Role",
+                llm_id="6646261c6eb563165658bbb1",
+                tools=[ModelTool(model="6646261c6eb563165658bbb1")],
+            )
+        ],
+        description="Test Team Agent Description",
+        llm_id="6646261c6eb563165658bbb1",
+    )
+
+    with requests_mock.Mocker() as mock:
+        url = urljoin(config.BACKEND_URL, f"sdk/agent-communities/{team_agent.id}")
+        headers = {"x-api-key": config.TEAM_API_KEY, "Content-Type": "application/json"}
+        ref_response = {
+            "id": "123",
+            "name": "Test Team Agent(-)",
+            "status": "onboarded",
+            "teamId": 645,
+            "description": "Test Team Agent Description",
+            "llmId": "6646261c6eb563165658bbb1",
+            "assets": [],
+            "agents": [{"assetId": "agent123", "type": "AGENT", "number": 0, "label": "AGENT"}],
+            "links": [],
+            "plannerId": None,
+            "supervisorId": "6646261c6eb563165658bbb1",
+            "createdAt": "2024-10-28T19:30:25.344Z",
+            "updatedAt": "2024-10-28T19:30:25.344Z",
+        }
+        mock.put(url, headers=headers, json=ref_response)
+
+        url = urljoin(config.BACKEND_URL, "sdk/models/6646261c6eb563165658bbb1")
+        model_ref_response = {
+            "id": "6646261c6eb563165658bbb1",
+            "name": "Test LLM",
+            "description": "Test LLM Description",
+            "function": {"id": "text-generation"},
+            "supplier": "openai",
+            "version": {"id": "1.0"},
+            "status": "onboarded",
+            "pricing": {"currency": "USD", "value": 0.0},
+        }
+        mock.get(url, headers=headers, json=model_ref_response)
+
+        # Capture warnings
+        with pytest.warns(
+            DeprecationWarning,
+            match="update\(\) is deprecated and will be removed in a future version. Please use save\(\) instead.",  # noqa: W605
+        ):
+            team_agent.update()
+
+    assert team_agent.id == ref_response["id"]
+    assert team_agent.name == ref_response["name"]
+    assert team_agent.description == ref_response["description"]
+    assert team_agent.llm_id == ref_response["llmId"]
+    assert team_agent.agents[0].id == ref_response["agents"][0]["assetId"]
+
+
+@patch("aixplain.factories.model_factory.ModelFactory.get")
+def test_save_success(mock_model_factory_get):
+    from aixplain.modules import Model
+    from aixplain.enums import Function
+
+    # Mock the model factory response
+    mock_model = Model(
+        id="6646261c6eb563165658bbb1", name="Test LLM", description="Test LLM Description", function=Function.TEXT_GENERATION
+    )
+    mock_model_factory_get.return_value = mock_model
+
+    team_agent = TeamAgent(
+        id="123",
+        name="Test Team Agent(-)",
+        agents=[
+            Agent(
+                id="agent123",
+                name="Test Agent(-)",
+                description="Test Agent Description",
+                instructions="Test Agent Role",
+                llm_id="6646261c6eb563165658bbb1",
+                tools=[ModelTool(model="6646261c6eb563165658bbb1")],
+            )
+        ],
+        description="Test Team Agent Description",
+        llm_id="6646261c6eb563165658bbb1",
+    )
+
+    with requests_mock.Mocker() as mock:
+        url = urljoin(config.BACKEND_URL, f"sdk/agent-communities/{team_agent.id}")
+        headers = {"x-api-key": config.TEAM_API_KEY, "Content-Type": "application/json"}
+        ref_response = {
+            "id": "123",
+            "name": "Test Team Agent(-)",
+            "status": "onboarded",
+            "teamId": 645,
+            "description": "Test Team Agent Description",
+            "llmId": "6646261c6eb563165658bbb1",
+            "assets": [],
+            "agents": [{"assetId": "agent123", "type": "AGENT", "number": 0, "label": "AGENT"}],
+            "links": [],
+            "plannerId": None,
+            "supervisorId": "6646261c6eb563165658bbb1",
+            "createdAt": "2024-10-28T19:30:25.344Z",
+            "updatedAt": "2024-10-28T19:30:25.344Z",
+        }
+        mock.put(url, headers=headers, json=ref_response)
+
+        url = urljoin(config.BACKEND_URL, "sdk/models/6646261c6eb563165658bbb1")
+        model_ref_response = {
+            "id": "6646261c6eb563165658bbb1",
+            "name": "Test LLM",
+            "description": "Test LLM Description",
+            "function": {"id": "text-generation"},
+            "supplier": "openai",
+            "version": {"id": "1.0"},
+            "status": "onboarded",
+            "pricing": {"currency": "USD", "value": 0.0},
+        }
+        mock.get(url, headers=headers, json=model_ref_response)
+
+        import warnings
+
+        # Capture warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")  # Trigger all warnings
+
+            # Call the save method
+            team_agent.save()
+
+            # Assert no warnings were triggered
+            assert len(w) == 0, f"Warnings were raised: {[str(warning.message) for warning in w]}"
+
+    assert team_agent.id == ref_response["id"]
+    assert team_agent.name == ref_response["name"]
+    assert team_agent.description == ref_response["description"]
+    assert team_agent.llm_id == ref_response["llmId"]
+    assert team_agent.agents[0].id == ref_response["agents"][0]["assetId"]


### PR DESCRIPTION
Fixed `agent` and `team_agents` unit tests. Added update and save tests for `team_agents`.

Found a bug in both test files. "role" had to be renamed to "instructions" in all instances of both test files.