### PR TITLE
feat: add serviceVersion support to v2 Agent run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ scripts/
 .claude/
 .cursor/
 .cursorrules
+docs/superpowers/
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: pytest-check
         name: pytest-check
         entry: coverage run --source=. -m pytest tests/unit
-        language: python
+        language: system
         pass_filenames: false
         types: [python]
         always_run: true

--- a/aixplain/v2/__init__.py
+++ b/aixplain/v2/__init__.py
@@ -53,6 +53,7 @@ from .enums import (
     EvolveType,
     CodeInterpreterModel,
     SplittingOptions,
+    ServiceVersion,
 )
 
 __all__ = [
@@ -123,6 +124,7 @@ __all__ = [
     "EvolveType",
     "CodeInterpreterModel",
     "SplittingOptions",
+    "ServiceVersion",
     # Actions / Inputs hierarchy
     "Input",
     "Inputs",

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -472,11 +472,15 @@ class Agent(
         self.tasks = [Task.from_dict(task) for task in self.tasks]
 
         # Deserialize inspectors to Inspector objects so mutate-and-save round-trips.
+        # Prebuilt inspectors travel as a lightweight {presetId, ...} reference
+        # (no "name"/"evaluator"), so dispatch on shape before deserializing.
         if self.inspectors:
-            from .inspector import Inspector
+            from .inspector import Inspector, PrebuiltInspector
 
             self.inspectors = [
-                Inspector.from_dict(inspector) if isinstance(inspector, dict) else inspector
+                (PrebuiltInspector.from_dict(inspector) if "presetId" in inspector else Inspector.from_dict(inspector))
+                if isinstance(inspector, dict)
+                else inspector
                 for inspector in self.inspectors
             ]
 

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -13,7 +13,7 @@ from dataclasses_json import dataclass_json, config
 
 from pydantic import BaseModel
 
-from .enums import AssetStatus, ResponseStatus
+from .enums import AssetStatus, ResponseStatus, ServiceVersion
 from .model import Model
 from .mixins import ToolableMixin
 from ..utils.user_info_utils import build_run_metadata
@@ -236,6 +236,9 @@ class AgentRunParams(BaseRunParams):
                         If None (default), progress tracking is disabled.
         progress_verbosity: Detail level - 1 (minimal), 2 (thoughts), 3 (full I/O)
         progress_truncate: Whether to truncate long text in progress display
+        service_version: Backend run service version. Accepts a ``ServiceVersion``
+            enum or a string ("V1", "V2", "V3"; case-insensitive). Defaults to
+            ``ServiceVersion.V2``.
     """
 
     session_id: NotRequired[Optional[Text]]
@@ -253,6 +256,7 @@ class AgentRunParams(BaseRunParams):
     progress_format: NotRequired[Optional[Text]]
     progress_verbosity: NotRequired[Optional[int]]
     progress_truncate: NotRequired[Optional[bool]]
+    service_version: NotRequired[Optional[Union[Text, ServiceVersion]]]
 
 
 @dataclass_json
@@ -1128,6 +1132,25 @@ class Agent(
             return self.llm.id
         raise TypeError(f"LLM must be a string id or Model, got {type(self.llm)}")
 
+    @staticmethod
+    def _resolve_service_version(value: Any) -> ServiceVersion:
+        """Normalize a user-supplied service_version to a ServiceVersion enum.
+
+        Accepts None (default V2), a ServiceVersion enum, or a string
+        (case-insensitive). Raises ValueError on unknown values.
+        """
+        if value is None:
+            return ServiceVersion.V2
+        if isinstance(value, ServiceVersion):
+            return value
+        if isinstance(value, str):
+            try:
+                return ServiceVersion(value.upper())
+            except ValueError:
+                pass
+        allowed = ", ".join(v.value for v in ServiceVersion)
+        raise ValueError(f"service_version must be one of: {allowed}, got {value!r}")
+
     def build_save_payload(self, **kwargs: Any) -> dict:
         """Build the payload for the save action."""
         # Import Inspector from v2 module
@@ -1264,6 +1287,11 @@ class Agent(
         # Handle run_response_generation with default value of False
         run_response_generation = kwargs.pop("run_response_generation", False)
 
+        # Resolve service_version (accepts enum or string; defaults to V2).
+        # Pop it out so the generic camelCase translation below does not
+        # double-emit it.
+        service_version = self._resolve_service_version(kwargs.pop("service_version", None))
+
         # Process variables for instruction/description placeholders (sent to backend for substitution)
         variables = kwargs.pop("variables", None) or {}
         query = kwargs.pop("query", None)
@@ -1288,6 +1316,7 @@ class Agent(
             "id": self.id,
             "executionParams": execution_params,
             "runResponseGeneration": run_response_generation,
+            "serviceVersion": service_version.value,
             "metaData": build_run_metadata(),
         }
 

--- a/aixplain/v2/enums.py
+++ b/aixplain/v2/enums.py
@@ -247,6 +247,18 @@ class SplittingOptions(str, Enum):
     LINE = "line"
 
 
+class ServiceVersion(str, Enum):
+    """Agent run service version selector.
+
+    Sent as the ``serviceVersion`` field in the run request payload to
+    select which backend run service handles the execution.
+    """
+
+    V1 = "V1"
+    V2 = "V2"
+    V3 = "V3"
+
+
 __all__ = [
     "AuthenticationScheme",
     "FileType",
@@ -268,4 +280,5 @@ __all__ = [
     "CodeInterpreterModel",
     "DataType",
     "SplittingOptions",
+    "ServiceVersion",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ model-builder = [
 ]
 test = [
     "pytest>=6.1.0",
+    "coverage>=7.0",
     "docker>=6.1.3",
     "requests-mock>=1.11.0",
     "pytest-mock>=3.10.0",

--- a/tests/functional/v2/conftest.py
+++ b/tests/functional/v2/conftest.py
@@ -2,6 +2,15 @@ import os
 import pytest
 
 
+def is_v3_run() -> bool:
+    """True when the suite is being routed through the V3 backend run service.
+
+    V3 has no response-generation phase, so tests that assert presence of a
+    response_generator step skip those assertions in V3 mode.
+    """
+    return os.getenv("AIXPLAIN_SERVICE_VERSION", "").upper() == "V3"
+
+
 @pytest.fixture(scope="module")
 def client():
     """Initialize Aixplain client with test configuration for v2 tests."""
@@ -32,3 +41,33 @@ def slack_token():
     if not token:
         pytest.skip("SLACK_TOKEN environment variable is required for Slack integration tests")
     return token
+
+
+@pytest.fixture(autouse=True)
+def _inject_service_version(monkeypatch):
+    """Route every Agent.run through a chosen serviceVersion when AIXPLAIN_SERVICE_VERSION is set.
+
+    Why: lets the whole v2 functional suite exercise the new backend run service
+    without editing each test. Tests that pass service_version explicitly win
+    (setdefault), so unit-style coverage of the param is preserved.
+    """
+    sv = os.getenv("AIXPLAIN_SERVICE_VERSION")
+    if not sv:
+        return
+
+    from aixplain.v2.agent import Agent
+    from aixplain.v2.enums import ServiceVersion
+
+    try:
+        target = ServiceVersion(sv.upper())
+    except ValueError:
+        allowed = ", ".join(v.value for v in ServiceVersion)
+        pytest.fail(f"AIXPLAIN_SERVICE_VERSION must be one of: {allowed}, got {sv!r}")
+
+    original_run = Agent.run
+
+    def patched_run(self, *args, **kwargs):
+        kwargs.setdefault("service_version", target)
+        return original_run(self, *args, **kwargs)
+
+    monkeypatch.setattr(Agent, "run", patched_run)

--- a/tests/functional/v2/inspector_functional_test.py
+++ b/tests/functional/v2/inspector_functional_test.py
@@ -30,6 +30,7 @@ from tests.functional.team_agent.test_utils import (
     read_data,
     verify_response_generator,
 )
+from tests.functional.v2.conftest import is_v3_run
 
 _DEFAULT_INPUT_TARGET = "input"
 _DEFAULT_OUTPUT_TARGET = "output"
@@ -114,21 +115,22 @@ def verify_inspector_steps(
         a = step.get("agent") or {}
         return (a.get("name") or "").lower()
 
-    rg_indices = [i for i, s in enumerate(steps) if agent_id(s) == "response_generator"]
-    assert len(rg_indices) == 1, f"Expected exactly one response_generator step, got {len(rg_indices)}"
-    rg_idx = rg_indices[0]
-
     inspector_indices = [i for i, s in enumerate(steps) if _is_inspector_step(s)]
     assert inspector_indices, "Expected at least one inspector step"
 
-    if InspectorTarget.OUTPUT in inspector_targets:
-        after = [i for i in inspector_indices if i > rg_idx]
-        assert after, "Expected inspector steps after response_generator for OUTPUT target"
+    if not is_v3_run():
+        rg_indices = [i for i, s in enumerate(steps) if agent_id(s) == "response_generator"]
+        assert len(rg_indices) == 1, f"Expected exactly one response_generator step, got {len(rg_indices)}"
+        rg_idx = rg_indices[0]
 
-        last_steps = steps[rg_idx + 1 :]
-        assert all(_is_inspector_step(s) for s in last_steps), (
-            "Not all steps after response_generator are inspector steps"
-        )
+        if InspectorTarget.OUTPUT in inspector_targets:
+            after = [i for i in inspector_indices if i > rg_idx]
+            assert after, "Expected inspector steps after response_generator for OUTPUT target"
+
+            last_steps = steps[rg_idx + 1 :]
+            assert all(_is_inspector_step(s) for s in last_steps), (
+                "Not all steps after response_generator are inspector steps"
+            )
 
     expected_n = len(inspector_names)
     actual_n = len(inspector_indices)
@@ -187,16 +189,19 @@ def test_output_inspector_abort(client, run_input_map, resource_tracker):
 
     _, steps = _run_and_get_steps(team_agent, "What's the biggest city in the world?")
 
-    response_generator_steps = [
-        s for s in steps if (s.get("agent") or {}).get("id", "").lower() == "response_generator"
-    ]
-    assert len(response_generator_steps) == 1, (
-        f"Expected exactly one response_generator step, got {len(response_generator_steps)}"
-    )
-    response_generator_index = steps.index(response_generator_steps[0])
+    if is_v3_run():
+        inspector_steps = [s for s in steps if _is_inspector_step(s)]
+    else:
+        response_generator_steps = [
+            s for s in steps if (s.get("agent") or {}).get("id", "").lower() == "response_generator"
+        ]
+        assert len(response_generator_steps) == 1, (
+            f"Expected exactly one response_generator step, got {len(response_generator_steps)}"
+        )
+        response_generator_index = steps.index(response_generator_steps[0])
+        inspector_steps = [s for s in steps[response_generator_index + 1 :] if _is_inspector_step(s)]
 
-    inspector_steps = [s for s in steps[response_generator_index + 1 :] if _is_inspector_step(s)]
-    assert len(inspector_steps) > 0, "Expected inspector step(s) after response_generator"
+    assert len(inspector_steps) > 0, "Expected at least one inspector step"
 
     assert (inspector_steps[-1].get("action") or "").lower() == "abort", (
         f"Expected abort, got {inspector_steps[-1].get('action')}"
@@ -234,12 +239,15 @@ def test_output_inspector_rerun_until_fixed(client, run_input_map, resource_trac
 
     assert "John" in (getattr(response.data, "output", "") or "")
 
-    rg_steps = [s for s in steps if (s.get("agent") or {}).get("id", "").lower() == "response_generator"]
-    assert len(rg_steps) == 2
-    rg_idx = steps.index(rg_steps[0])
+    if is_v3_run():
+        inspector_steps = [s for s in steps if _is_inspector_step(s)]
+    else:
+        rg_steps = [s for s in steps if (s.get("agent") or {}).get("id", "").lower() == "response_generator"]
+        assert len(rg_steps) == 2
+        rg_idx = steps.index(rg_steps[0])
+        inspector_steps = [s for s in steps[rg_idx + 1 :] if _is_inspector_step(s)]
 
-    inspector_steps = [s for s in steps[rg_idx + 1 :] if _is_inspector_step(s)]
-    assert inspector_steps, "Expected inspector steps after response_generator"
+    assert inspector_steps, "Expected at least one inspector step"
 
     assert any((s.get("action") or "").lower() == "rerun" for s in inspector_steps), (
         f"Expected at least one rerun action, got actions: {[s.get('action') for s in inspector_steps]}"

--- a/tests/functional/v2/test_agent.py
+++ b/tests/functional/v2/test_agent.py
@@ -244,6 +244,11 @@ def _has_response_generator(steps):
 
 def test_run_response_generation(client, test_agent):
     """Test that runResponseGeneration controls presence of response_generator step."""
+    from tests.functional.v2.conftest import is_v3_run
+
+    if is_v3_run():
+        pytest.skip("V3 has no response-generation phase")
+
     agent = client.Agent.get(test_agent.id)
 
     # Default (False): response_generator step should NOT be present

--- a/tests/functional/v2/test_arabic_agent.py
+++ b/tests/functional/v2/test_arabic_agent.py
@@ -313,16 +313,22 @@ def test_arabic_inspector_agent_across_llms(client, resource_tracker, model_name
     resource_tracker.extend(resources)
     team_agent = resources[-1]
 
+    from tests.functional.v2.conftest import is_v3_run
+
     response = team_agent.run(ARABIC_QUERIES["pure_arabic"])
     output, steps = _assert_success_response(response)
-    response_generator_steps = [
-        step for step in steps if ((step.get("agent") or {}).get("id") or "").lower() == "response_generator"
-    ]
-    assert len(response_generator_steps) == 1, "Expected exactly one response_generator step"
 
-    response_generator_index = steps.index(response_generator_steps[0])
-    inspector_steps = [step for step in steps[response_generator_index + 1 :] if _is_inspector_step(step)]
-    assert inspector_steps, "Expected inspector step(s) after response_generator"
+    if is_v3_run():
+        inspector_steps = [step for step in steps if _is_inspector_step(step)]
+    else:
+        response_generator_steps = [
+            step for step in steps if ((step.get("agent") or {}).get("id") or "").lower() == "response_generator"
+        ]
+        assert len(response_generator_steps) == 1, "Expected exactly one response_generator step"
+        response_generator_index = steps.index(response_generator_steps[0])
+        inspector_steps = [step for step in steps[response_generator_index + 1 :] if _is_inspector_step(step)]
+
+    assert inspector_steps, "Expected at least one inspector step"
 
     if _is_inspector_abort_message(output):
         return

--- a/tests/unit/v2/test_snake_case_conventions.py
+++ b/tests/unit/v2/test_snake_case_conventions.py
@@ -230,6 +230,71 @@ class TestBuildRunPayload:
 
 
 # =============================================================================
+# build_run_payload: serviceVersion handling
+# =============================================================================
+
+
+class TestBuildRunPayloadServiceVersion:
+    """Verify that build_run_payload emits serviceVersion correctly."""
+
+    def _make_agent(self):
+        agent = Agent.__new__(Agent)
+        agent.id = "agent-123"
+        agent.output_format = "text"
+        agent.max_tokens = 2048
+        agent.max_iterations = 5
+        agent.expected_output = ""
+        agent.context_overflow_strategy = None
+        return agent
+
+    def test_default_is_v2(self):
+        agent = self._make_agent()
+        payload = agent.build_run_payload(query="hello")
+        assert payload["serviceVersion"] == "V2"
+        assert "service_version" not in payload
+
+    def test_explicit_string_v3(self):
+        agent = self._make_agent()
+        payload = agent.build_run_payload(query="hello", service_version="V3")
+        assert payload["serviceVersion"] == "V3"
+        assert "service_version" not in payload
+
+    def test_enum_v3(self):
+        from aixplain.v2.enums import ServiceVersion
+
+        agent = self._make_agent()
+        payload = agent.build_run_payload(query="hello", service_version=ServiceVersion.V3)
+        assert payload["serviceVersion"] == "V3"
+
+    def test_enum_v1(self):
+        from aixplain.v2.enums import ServiceVersion
+
+        agent = self._make_agent()
+        payload = agent.build_run_payload(query="hello", service_version=ServiceVersion.V1)
+        assert payload["serviceVersion"] == "V1"
+
+    def test_lowercase_string_normalized(self):
+        agent = self._make_agent()
+        payload = agent.build_run_payload(query="hello", service_version="v3")
+        assert payload["serviceVersion"] == "V3"
+
+    def test_invalid_string_raises(self):
+        agent = self._make_agent()
+        with pytest.raises(ValueError, match="service_version must be one of"):
+            agent.build_run_payload(query="hello", service_version="V4")
+
+    def test_invalid_type_raises(self):
+        agent = self._make_agent()
+        with pytest.raises(ValueError, match="service_version must be one of"):
+            agent.build_run_payload(query="hello", service_version=99)
+
+    def test_typeddict_has_service_version(self):
+        hints = AgentRunParams.__annotations__
+        assert "service_version" in hints
+        assert "serviceVersion" not in hints
+
+
+# =============================================================================
 # _normalize_tool_dict_for_api: snake_case → camelCase at API boundary
 # =============================================================================
 

--- a/tests/unit/v2/test_v2_agent_v3_compat.py
+++ b/tests/unit/v2/test_v2_agent_v3_compat.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from aixplain.v2.agent import Agent
-from aixplain.v2.inspector import Inspector
+from aixplain.v2.inspector import Inspector, PrebuiltInspector
 
 
 def _agent_from_dict(**overrides):
@@ -87,3 +87,30 @@ class TestR3InspectorDeserialization:
 
         assert isinstance(agent.inspectors[0], Inspector)
         assert agent.inspectors[0].name == "Input Gate"
+
+    def test_prebuilt_inspector_payload_deserializes_to_prebuilt_inspector(self):
+        # PrebuiltInspector.to_dict() emits a lightweight reference with no
+        # "name" key; the backend echoes it back on save. __post_init__ must
+        # not route it through Inspector.from_dict (KeyError: 'name').
+        prebuilt_payload = PrebuiltInspector.prompt_injection_guard().to_dict()
+        assert "name" not in prebuilt_payload  # precondition for the regression
+
+        agent = _agent_from_dict(inspectors=[prebuilt_payload])
+
+        assert isinstance(agent.inspectors[0], PrebuiltInspector)
+        assert agent.inspectors[0].preset_id == "prompt_injection_guard"
+
+    def test_mixed_full_and_prebuilt_inspectors_deserialize(self):
+        full_payload = {
+            "name": "Input Gate",
+            "targets": ["input"],
+            "action": {"type": "abort"},
+            "evaluator": {"type": "asset", "assetId": "model-abc", "prompt": "PASS or FAIL"},
+        }
+        prebuilt_payload = {"presetId": "pii_redaction", "targets": ["output"]}
+
+        agent = _agent_from_dict(inspectors=[full_payload, prebuilt_payload])
+
+        assert isinstance(agent.inspectors[0], Inspector)
+        assert isinstance(agent.inspectors[1], PrebuiltInspector)
+        assert agent.inspectors[1].preset_id == "pii_redaction"


### PR DESCRIPTION
## Summary

- Adds a per-call `service_version` parameter to `Agent.run()` / `run_async()` that emits `serviceVersion` in the request body to `/sdk/agents/{id}/run`.
- New `ServiceVersion` enum (`V1`, `V2`, `V3`) re-exported from `aixplain.v2`.
- Default is `V2`, always sent explicitly so the chosen run service is unambiguous in logs and request traces.
- Accepts `ServiceVersion`, string (case-insensitive), or `None`. Unknown values raise `ValueError` at payload build time.
- URL, poll URL, and response shape are unchanged.

## Usage

```python
from aixplain.v2 import ServiceVersion

agent.run("Hello")                                       # serviceVersion: "V2"
agent.run("Hello", service_version="V3")                 # serviceVersion: "V3"
agent.run("Hello", service_version=ServiceVersion.V3)    # serviceVersion: "V3"
```

## Pre-commit / dev experience

The pre-commit `pytest-check` hook was failing locally because it ran in an isolated env that lacked runtime deps (e.g. `babel`). Switched it to `language: system` so it uses the active project venv. Added `coverage>=7.0` to the `test` extras (used by the same hook). Also gitignored `docs/superpowers/` for local design notes.

## Test plan

- [x] 8 new unit tests in `tests/unit/v2/test_snake_case_conventions.py` covering: default V2, explicit string V3, enum V3/V1, lowercase normalization, invalid string raises, invalid type raises, TypedDict shape.
- [x] All 606 `tests/unit/v2/` tests pass locally.
- [ ] Reviewer: smoke-test against dev backend with `service_version="V3"` to confirm end-to-end run.