### PR TITLE
fix(ENG-3044): force UTF-8 on SSE response in ModelResponseStreamer

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -171,6 +171,9 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
             response: A requests.Response object with streaming enabled
         """
         self._response = response
+        encoding = getattr(response, "encoding", None)
+        if encoding is None or encoding.lower() == "iso-8859-1":
+            response.encoding = "utf-8"
         self._iterator = response.iter_lines(decode_unicode=True)
         self.status = ResponseStatus.IN_PROGRESS
         self._done = False

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -11,7 +11,15 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from aixplain.v2.enums import Function, ResponseStatus
-from aixplain.v2.model import Message, Model, ModelResponseStreamer, ModelResult, StreamChunk, Usage, find_function_by_id
+from aixplain.v2.model import (
+    Message,
+    Model,
+    ModelResponseStreamer,
+    ModelResult,
+    StreamChunk,
+    Usage,
+    find_function_by_id,
+)
 
 
 # =============================================================================
@@ -805,3 +813,98 @@ class TestModelIntegrationGaps:
 
         with pytest.raises(StopIteration):
             next(streamer)
+
+
+class TestModelStreamerSseEncoding:
+    """Regression tests for SSE UTF-8 decoding (ENG-3044).
+
+    The aiXplain backend serves ``text/event-stream`` without a ``charset``
+    parameter — which is correct per the SSE spec (WHATWG HTML §9.2: SSE is
+    always UTF-8, ``charset`` is not allowed). ``requests`` doesn't know that
+    and falls back to ISO-8859-1 for any ``text/*`` body without an explicit
+    charset (RFC 2616), so multi-byte UTF-8 characters emitted by the model
+    (°, —, smart quotes, emojis) come back as mojibake when iterated via
+    ``iter_lines(decode_unicode=True)``.
+
+    ``ModelResponseStreamer`` knows it's consuming SSE, so it must override
+    the ``requests`` fallback before iteration begins.
+    """
+
+    @staticmethod
+    def _build_response(body: bytes, *, content_type: str = "text/event-stream") -> "requests.Response":
+        """Build a real ``requests.Response`` whose ``raw`` returns ``body``.
+
+        Mirrors what ``requests.adapters.HTTPAdapter.build_response`` produces:
+        for ``text/*`` without a ``charset`` parameter, ``response.encoding``
+        is set to ``ISO-8859-1`` — the bug surface this test exercises.
+        """
+        from io import BytesIO
+
+        import requests
+        from urllib3 import HTTPResponse
+
+        raw = HTTPResponse(body=BytesIO(body), preload_content=False)
+        response = requests.Response()
+        response.raw = raw
+        response.headers["Content-Type"] = content_type
+        response.encoding = "ISO-8859-1"
+        return response
+
+    def test_streamer_decodes_multibyte_utf8(self):
+        """End-to-end: multi-byte UTF-8 chars in the SSE body must decode correctly."""
+        # Degree sign (U+00B0 → 0xC2 0xB0), em dash (U+2014 → 0xE2 0x80 0x94),
+        # emoji (U+1F31E → 0xF0 0x9F 0x8C 0x9E).
+        body = b'data: {"data": "Lisbon: 22.5\xc2\xb0C \xe2\x80\x94 \xf0\x9f\x8c\x9e"}\n\n'
+        response = self._build_response(body)
+
+        streamer = ModelResponseStreamer(response)
+        chunks = list(streamer)
+
+        assert len(chunks) == 1
+        data = chunks[0].data
+        assert "22.5°C" in data
+        assert "—" in data
+        assert "🌞" in data
+        # Latin-1 mojibake signatures must not appear.
+        assert "Â°" not in data
+        assert "â\x80\x94" not in data
+
+    def test_streamer_overrides_requests_iso_8859_1_fallback(self):
+        """Override the ``requests`` ISO-8859-1 fallback with ``utf-8``.
+
+        ``response.encoding`` must be set to ``utf-8`` when the
+        ``requests`` ISO-8859-1 fallback is in effect.
+        """
+        response = self._build_response(b"data: [DONE]\n\n")
+        assert response.encoding == "ISO-8859-1"
+
+        ModelResponseStreamer(response)
+
+        assert response.encoding == "utf-8"
+
+    def test_streamer_overrides_none_encoding(self):
+        """Override a missing encoding with ``utf-8``.
+
+        ``response.encoding`` must be set to ``utf-8`` when no encoding is set
+        at all (e.g. a hand-built response or a custom transport).
+        """
+        response = self._build_response(b"data: [DONE]\n\n")
+        response.encoding = None
+
+        ModelResponseStreamer(response)
+
+        assert response.encoding == "utf-8"
+
+    def test_streamer_preserves_explicit_charset(self):
+        """Respect an explicit non-fallback charset.
+
+        If a future backend header or a custom adapter sets a non-fallback
+        charset, the streamer must respect it rather than silently clobbering
+        an explicit choice.
+        """
+        response = self._build_response(b"data: [DONE]\n\n")
+        response.encoding = "utf-16"
+
+        ModelResponseStreamer(response)
+
+        assert response.encoding == "utf-16"


### PR DESCRIPTION
## What's broken

Streamed LLM output mangles any multi-byte UTF-8 character — accents, em dashes, smart quotes, emojis. `22.5°C` shows up as `22.5Â°C`, `🌞` becomes `ð\x9f\x8c\x9e`, and so on. ASCII-only output is fine, which is why this only surfaced now.

Reproduced live on `openai/gpt-5.2/openai` and `anthropic/claude-opus-4.6/aws` against dev.

## Why

`ModelResponseStreamer.__init__` reads SSE bytes via:

```python
self._iterator = response.iter_lines(decode_unicode=True)
```

It tells `requests` to decode the body but never sets `response.encoding`. The backend correctly omits the `charset` parameter (per the SSE spec, `text/event-stream` is always UTF-8 and `charset` is forbidden), so `requests` applies its RFC 2616 fallback for `text/*` bodies and decodes everything as **ISO-8859-1**.

UTF-8 byte `0xC2 0xB0` is `°`. Decoded as latin-1 the same bytes become `Â°`. Same stream, wrong codec, mojibake.

The streamer is the only layer that knows it's consuming SSE, so this is the right place to fix it.

## Fix

Three lines in the streamer constructor — set `response.encoding = "utf-8"` whenever no encoding is set or `requests` picked its latin-1 fallback. An explicit non-fallback charset (a future `charset` header, a custom adapter) is preserved.

```python
self._response = response
encoding = getattr(response, "encoding", None)
if encoding is None or encoding.lower() == "iso-8859-1":
    response.encoding = "utf-8"
self._iterator = response.iter_lines(decode_unicode=True)
```

## Tests

New `TestModelStreamerSseEncoding` class (`tests/unit/v2/test_model.py`):

| Test | What it covers |
|---|---|
| `test_streamer_decodes_multibyte_utf8` | End-to-end with a real `requests.Response` carrying `°`, `—`, `🌞` — must decode cleanly, no mojibake |
| `test_streamer_overrides_requests_iso_8859_1_fallback` | Latin-1 fallback gets replaced with UTF-8 |
| `test_streamer_overrides_none_encoding` | Unset encoding gets replaced with UTF-8 |
| `test_streamer_preserves_explicit_charset` | An explicit charset (e.g. `utf-16`) is left untouched |

All 602 v2 unit tests pass; ruff clean.

## Verified against dev

Same prompt — "Output verbatim: `Lisbon: 22.5°C — sunny 🌞 today!`" — against `https://dev-models.aixplain.com` with `openai/gpt-5.2/openai`:

- **Before:** `Lisbon: 22.5Â°C â\x80\x94 sunny ð\x9f\x8c\x9e today!`
- **After:**  `Lisbon: 22.5°C — sunny 🌞 today!`

## Test plan

- [x] `pytest tests/unit/v2/` passes
- [x] Ruff clean
- [x] Live smoke against dev backend on a multi-byte prompt