### PR TITLE
docs: refresh SDK README for SDK 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Develop your way — **SDK, API, CLI, and MCP** environments all run on the same
 
 **One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, and a sandbox for code execution — with no per-vendor keys or contracts.
 
-**Build any kind of agent on one runtime** — with built-in database access, RAG and data ingestion, multimodality, and file handling.
+**Build any kind of agent on one runtime** — knowledge (RAG), data, custom-logic, integration, and team agents — with built-in multimodality and file handling.
 
 ## Why aixplain
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
   <a href="https://discord.gg/aixplain"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-**The operating system for autonomous AI — multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments.**
+**Build, deploy, and govern autonomous AI agents — in a few lines of Python.**
 
-aixplain is the operations layer over your AI stack, spanning **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. Agents plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
+aixplain is the operating system for autonomous AI — **multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments**. It spans the full lifecycle — **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. Agents plan, call models and tools, run code, and adapt at runtime, with **agents-in-the-loop** governance enforced on every execution.
 
-**Build any kind of agent on one runtime** — knowledge (RAG), data, custom-logic, integration, and team agents — with built-in multimodality and file handling.
+**Build any kind of agent on one runtime** — knowledge (RAG), data, custom-logic, integration, and team agents — with built-in memory, multimodality, and file handling.
 
 Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors** (OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, a code-execution sandbox, and more). **One API key, one bill**, pay as you go — no per-vendor keys or contracts.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Build the full range on one runtime — **multi-step agents**, **managed agents*
 Agentic OS is the portable runtime platform behind aixplain agents:
 
 - **Agent Engine** — orchestrates planning, execution, and delegation for autonomous agents.
-- **Asset Serving** — connects agents to models, tools, and data through a governed runtime layer.
+- **Asset Serving** — standardizes every model, tool, and data source behind a uniform interface, enabling swappability, governance, identity and auth, and rich telemetry.
 - **Observability** — captures traces, metrics, and monitoring for every production run.
 
 It runs across Cloud (instant) and on-prem deployments.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
   <a href="https://discord.gg/aixplain"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-**The operations layer for autonomous AI — multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments.**
+**The operating system for autonomous AI — multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments.**
 
-aixplain is the operations layer over your AI stack. One runtime takes a multi-agent system through its entire lifecycle — **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. The SDK gives you Python and REST access to that runtime: agents that plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
+aixplain is the operations layer over your AI stack, spanning **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. The SDK gives you Python and REST access to that runtime: agents that plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
 
-Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors**.
+Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an ecosystem of models, tools, and services: an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors**.
 
-**One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, and a sandbox for code execution — with no per-vendor keys or contracts.
+**One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, RAG data ingestion, and a sandbox for code execution — with no per-vendor keys or contracts.
 
 ## Why aixplain
 
@@ -39,11 +39,17 @@ Develop your way — **SDK, API, CLI, and MCP** environments all run on the same
 | Models and tools | 900+ models and tools with one API key | Provider-by-provider setup |
 | Deployment | Cloud (instant) or on-prem | Usually self-assembled runtime and infra |
 | Observability | Built-in traces and dashboards | Varies by framework |
-| Coding-agent workflows | Works natively with MCP-compatible coding agents and IDEs | Usually not a first-class workflow target |
+| [Coding-agent workflows](TODO-agent-builder-skill-url) | Works natively with MCP-compatible coding agents and IDEs | Usually not a first-class workflow target |
 
 ## Agentic OS
 
-Agentic OS is the portable runtime platform behind aixplain agents. AgentEngine orchestrates planning, execution, and delegation for autonomous agents. AssetServing connects agents to models, tools, and data through a governed runtime layer. Observability captures traces, metrics, and monitoring for every production run across Cloud (instant) and on-prem deployments.
+Agentic OS is the portable runtime platform behind aixplain agents:
+
+- **Agent Engine** — orchestrates planning, execution, and delegation for autonomous agents.
+- **Asset Serving** — connects agents to models, tools, and data through a governed runtime layer.
+- **Observability** — captures traces, metrics, and monitoring for every production run.
+
+It runs across Cloud (instant) and on-prem deployments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Agentic OS is the portable runtime platform behind aixplain agents — orchestra
 
 ## Quick start
 
-> **This is the aixplain SDK 2.** SDK 1 (the legacy factory API) keeps running until **end of July 2026**; after that, SDK 2 is the only supported surface. <!-- TODO: confirm SDK 2 release version/date -->
+> **This README documents SDK v2, the default API.** SDK v1 (the legacy factory API) keeps working until **end of July 2026**, after which v2 is the only supported surface.
 
 ```bash
 pip install aixplain

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Develop your way — **SDK, API, CLI, and MCP** environments all run on the same
 
 ## Why aixplain
 
-- **Ship faster** — one runtime spans the full lifecycle (build, evaluate, deploy, monitor, evolve); no glue code to assemble.
-- **Multi-agent orchestration** — delegate work to specialized subagents that plan, reflect, and adapt at runtime.
-- **Runtime governance by default** — allow-list assets and per-asset actions, set rate and usage limits, enforce enterprise RBAC, and block pip installs or network access mid-execution.
-- **One key, one bill** — [900+ models, tools, and integrations](#mcp-server-marketplace) from 70+ vendors, billed in one place.
-- **Production observability** — step-level traces, tool calls, and outcomes for fast debugging.
-- **Develop your way** — SDK, API, CLI, and MCP clients on the same runtime layer.
-- **Deploy anywhere** — the same agent definition runs serverless, on-prem, at the edge, or fully air-gapped.
+Less to build, less to operate:
+
+- **Deploy with one call** — `agent.save()` promotes an agent to a persistent, versioned endpoint; no Dockerfiles, queues, or autoscaling to manage.
+- **No integration glue** — reach [900+ models, tools, and integrations](#mcp-server-marketplace) through one key; skip per-provider SDKs, auth, and rate-limit handling.
+- **Governance you don't have to code** — allow-lists, per-asset permissions, rate and usage limits, and enterprise RBAC enforced at runtime.
+- **Self-debugging** — step-level traces of every plan, tool call, and outcome.
+- **Run it anywhere** — the same definition runs serverless, on-prem, at the edge, or fully air-gapped.
 
 | | aixplain SDK | Other agent frameworks |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Build the full range on one runtime — **multi-step agents**, **managed agents*
 
 - **Ship faster** — one runtime spans the full lifecycle (build, evaluate, deploy, monitor, evolve); no glue code to assemble.
 - **Multi-agent orchestration** — delegate work to specialized subagents that plan, reflect, and adapt at runtime.
-- **Runtime governance by default** — policy enforced on every run (e.g. block pip installs or network access mid-execution).
+- **Runtime governance by default** — allow-list assets and per-asset actions, set rate and usage limits, enforce enterprise RBAC, and block pip installs or network access mid-execution.
 - **One key, one bill** — [900+ models, tools, and integrations](#mcp-server-marketplace) from 70+ vendors, billed in one place.
 - **Production observability** — step-level traces, tool calls, and outcomes for fast debugging.
 - **Develop your way** — SDK, API, CLI, and MCP clients on the same runtime layer.
@@ -37,7 +37,7 @@ Build the full range on one runtime — **multi-step agents**, **managed agents*
 
 | | aixplain SDK | Other agent frameworks |
 |---|---|---|
-| Governance | Runtime access and policy enforcement built in | Usually custom code or external guardrails |
+| Governance | Asset/action allow-lists, per-asset permissions, rate and usage limits, and enterprise RBAC | Usually custom code or external guardrails |
 | Models and tools | 900+ models and tools with one API key | Provider-by-provider setup |
 | Deployment | Cloud (instant) or on-prem | Usually self-assembled runtime and infra |
 | Observability | Built-in traces and dashboards | Varies by framework |
@@ -215,6 +215,7 @@ aixplain applies runtime governance and enterprise controls by default:
 - **No data retained by default** — agent memory is opt-in (short-term and long-term).
 - **SOC 2 Type II certified** — enterprise security and compliance posture.
 - **Runtime policy enforcement** — Inspector and Bodyguard govern every agent execution (e.g. block pip installs or network access during code runs).
+- **Granular access controls** — allow-lists for assets and actions, per-asset permissions, rate and usage limits, and RBAC for enterprise.
 - **Portable deployment options** — Cloud (instant) or on-prem (including VPC and air-gapped environments).
 - **Encryption** — TLS 1.2+ in transit and encrypted storage at rest.
 

--- a/README.md
+++ b/README.md
@@ -15,25 +15,23 @@
   <a href="https://discord.gg/aixplain"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-**Build, deploy, and govern autonomous AI agents for your business operations.**
+**The operations layer for autonomous AI — multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments.**
 
-aixplain SDK provides Python and REST APIs for agents that plan, use tools, call models and data, run code, and adapt at runtime. It also works natively with MCP-compatible coding agents and IDEs.
+aixplain is the operations layer over your AI stack. One runtime takes a multi-agent system through its entire lifecycle — **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. The SDK gives you Python and REST access to that runtime: agents that plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
 
-> **Become an agentic-first organization**
->
-> Designed for business operations: autonomous, governed, MCP-compatible, and built for context management. Your interactive AI assistant is [a click away](https://auth.aixplain.com/).
->
-> _We operate our business with aixplain agents, using them across product, business development, and marketing._
+Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors**.
+
+**One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, and a sandbox for code execution — with no per-vendor keys or contracts.
 
 ## Why aixplain
 
-- **Autonomous runtime loop** — plan, call tools and models, reflect, and continue without fixed flowcharts.
-- **Multi-agent execution** — delegate work to specialized subagents at runtime.
-- **Governance by default** — runtime access and policy enforcement on every run.
-- **Production observability** — inspect step-level traces, tool calls, and outcomes for debugging.
-- **Model and tool portability** — swap assets without rewriting application glue code.
-- **MCP-native access** — connect MCP clients to [900+ aixplain-hosted assets](#mcp-servers) with one PAYG API key.
-- **Flexible deployment** — run the same agent definition serverless or private.
+- **Ship faster** — one runtime spans the full lifecycle (build, evaluate, deploy, monitor, evolve); no glue code to assemble.
+- **Multi-agent orchestration** — delegate work to specialized subagents that plan, reflect, and adapt at runtime.
+- **Runtime governance by default** — policy enforced on every run (e.g. block pip installs or network access mid-execution).
+- **One key, one bill** — [900+ models, tools, and integrations](#mcp-server-marketplace) from 70+ vendors, billed in one place.
+- **Production observability** — step-level traces, tool calls, and outcomes for fast debugging.
+- **Develop your way** — SDK, API, CLI, and MCP clients on the same runtime layer.
+- **Deploy anywhere** — the same agent definition runs serverless, on-prem, at the edge, or fully air-gapped.
 
 | | aixplain SDK | Other agent frameworks |
 |---|---|---|
@@ -163,7 +161,7 @@ print(response.data.output)
 ```
 
 <div align="center">
-  <img src="docs/assets/aixplain-workflow-teamagent.png" alt="aixplain team-agent runtime flow" title="aixplain"/>
+  <img src="docs/assets/aixplain-workflow-teamagent.png" alt="aixplain team-agent runtime flow" title="aixplain" width="70%"/>
 </div>
 
 Execution order:
@@ -191,10 +189,11 @@ Team agent
 |---|---|
 | **Agent** | An autonomous entity that reasons, plans, and uses tools to complete a task. |
 | **Team agent** | Multiple specialized agents coordinated by a planner and orchestrator at runtime. |
-| **Tool** | A capability an agent can invoke — a model, a pipeline, an integration, or code (Python/SQL). |
+| **Tool** | A capability an agent can invoke — a model, an integration, or code (Python/SQL). |
 | **Model** | An LLM, utility, or index asset from the [marketplace](https://studio.aixplain.com/browse). |
-| **Pipeline** | A fixed-order workflow connecting models and tools. |
-| **Microagents** | Built-in governance components: Mentalist (planning), Orchestrator (routing), Inspector (validation), Bodyguard (security), Responder (formatting). |
+| **Integration** | A connector to an external service (Slack, Airtable, Gmail, and more) that an agent can act through. |
+| **Micro-agents** | Built-in governance components that run inline on every execution: Mentalist (planning), Orchestrator (routing), Inspector (validation — e.g. block pip installs or network access), Bodyguard (security), Responder (formatting). |
+| **Meta-agent** | An agent that improves other agents — the Evolver monitors KPIs and refines behavior over time. |
 
 See the [documentation](https://docs.aixplain.com) for the full API reference.
 
@@ -207,7 +206,7 @@ aixplain applies runtime governance and enterprise controls by default:
 - **We do not train on your data** — your data is not used to train foundation models.
 - **No data retained by default** — agent memory is opt-in (short-term and long-term).
 - **SOC 2 Type II certified** — enterprise security and compliance posture.
-- **Runtime policy enforcement** — Inspector and Bodyguard govern every agent execution.
+- **Runtime policy enforcement** — Inspector and Bodyguard govern every agent execution (e.g. block pip installs or network access during code runs).
 - **Portable deployment options** — Cloud (instant) or on-prem (including VPC and air-gapped environments).
 - **Encryption** — TLS 1.2+ in transit and encrypted storage at rest.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/aixplain-logo-light.png">
     <source media="(prefers-color-scheme: light)" srcset="docs/assets/aixplain-logo-dark.png">
-    <img src="docs/assets/aixplain-logo-dark.png" alt="aiXplain" width="520">
+    <img src="docs/assets/aixplain-logo-dark.png" alt="aixplain" width="520">
   </picture>
 </p>
 
-<h1 align="center">aiXplain SDK</h1>
+<h1 align="center">aixplain SDK</h1>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-2ea44f?style=flat-square" alt="License"></a>
@@ -17,25 +17,25 @@
 
 **Build, deploy, and govern autonomous AI agents for your business operations.**
 
-aiXplain SDK provides Python and REST APIs for agents that plan, use tools, call models and data, run code, and adapt at runtime. It also works natively with MCP-compatible coding agents and IDEs.
+aixplain SDK provides Python and REST APIs for agents that plan, use tools, call models and data, run code, and adapt at runtime. It also works natively with MCP-compatible coding agents and IDEs.
 
 > **Become an agentic-first organization**
 >
 > Designed for business operations: autonomous, governed, MCP-compatible, and built for context management. Your interactive AI assistant is [a click away](https://auth.aixplain.com/).
 >
-> _We operate our business with aiXplain agents, using them across product, business development, and marketing._
+> _We operate our business with aixplain agents, using them across product, business development, and marketing._
 
-## Why aiXplain
+## Why aixplain
 
 - **Autonomous runtime loop** — plan, call tools and models, reflect, and continue without fixed flowcharts.
 - **Multi-agent execution** — delegate work to specialized subagents at runtime.
 - **Governance by default** — runtime access and policy enforcement on every run.
 - **Production observability** — inspect step-level traces, tool calls, and outcomes for debugging.
 - **Model and tool portability** — swap assets without rewriting application glue code.
-- **MCP-native access** — connect MCP clients to [900+ aiXplain-hosted assets](#mcp-servers) with one PAYG API key.
+- **MCP-native access** — connect MCP clients to [900+ aixplain-hosted assets](#mcp-servers) with one PAYG API key.
 - **Flexible deployment** — run the same agent definition serverless or private.
 
-| | aiXplain SDK | Other agent frameworks |
+| | aixplain SDK | Other agent frameworks |
 |---|---|---|
 | Governance | Runtime access and policy enforcement built in | Usually custom code or external guardrails |
 | Models and tools | 900+ models and tools with one API key | Provider-by-provider setup |
@@ -43,19 +43,15 @@ aiXplain SDK provides Python and REST APIs for agents that plan, use tools, call
 | Observability | Built-in traces and dashboards | Varies by framework |
 | Coding-agent workflows | Works natively with MCP-compatible coding agents and IDEs | Usually not a first-class workflow target |
 
-## AgenticOS
+## Agentic OS
 
-AgenticOS is the portable runtime platform behind aiXplain agents. AgentEngine orchestrates planning, execution, and delegation for autonomous agents. AssetServing connects agents to models, tools, and data through a governed runtime layer. Observability captures traces, metrics, and monitoring for every production run across Cloud (instant) and on-prem deployments.
-
-<div align="center">
-  <img src="docs/assets/aixplain-agentic-os-architecture.svg" alt="aiXplain AgenticOS architecture" title="aiXplain"/>
-</div>
+Agentic OS is the portable runtime platform behind aixplain agents. AgentEngine orchestrates planning, execution, and delegation for autonomous agents. AssetServing connects agents to models, tools, and data through a governed runtime layer. Observability captures traces, metrics, and monitoring for every production run across Cloud (instant) and on-prem deployments.
 
 ---
 
 ## MCP Server Marketplace
 
-[aiXplain Marketplace](https://studio.aixplain.com/browse) now also exposes MCP servers for **900+ models and tools**, allowing external clients to access selected **tool, integration, and model assets**, for example **Opus 4.6, Kimi, Qwen, Airtable, and Slack**, through **aiXplain-hosted MCP endpoints** with a single API key 🔑.
+[aixplain Marketplace](https://studio.aixplain.com/browse) now also exposes MCP servers for **900+ models and tools**, allowing external clients to access selected **tool, integration, and model assets**, for example **Opus 4.6, Kimi, Qwen, Airtable, and Slack**, through **aixplain-hosted MCP endpoints** with a single API key 🔑.
 
 Read the full MCP setup guide in the [MCP servers docs](https://docs.aixplain.com/api-reference/mcp-servers).
 
@@ -75,22 +71,25 @@ Read the full MCP setup guide in the [MCP servers docs](https://docs.aixplain.co
 
 ## Quick start
 
+> **This is the aixplain SDK 2.** SDK 1 (the legacy factory API) keeps running until **end of July 2026**; after that, SDK 2 is the only supported surface. <!-- TODO: confirm SDK 2 release version/date -->
+
 ```bash
 pip install aixplain
 ```
 
-Get your API key from your [aiXplain account](https://console.aixplain.com/settings/keys).
+Get your API key from your [aixplain account](https://console.aixplain.com/settings/keys), then expose it to the SDK:
 
-<details open>
-  <summary><strong>v2 (default)</strong></summary>
+```bash
+export AIXPLAIN_API_KEY=<your-key>
+```
 
-### Create and run your first agent (v2)
+### Create and run your first agent
 
 ```python
 from uuid import uuid4
 from aixplain import Aixplain
 
-aix = Aixplain(api_key="<AIXPLAIN_API_KEY>")
+aix = Aixplain()  # reads AIXPLAIN_API_KEY from the environment
 
 search_tool = aix.Tool.get("tavily/tavily-web-search/tavily")
 search_tool.allowed_actions = ["search"]
@@ -109,14 +108,16 @@ result = agent.run(
 print(result.data.output)
 ```
 
-### Build a multi-agent team (v2)
+> Runs return typed objects — read outputs with `result.data.output`, not dict indexing.
+
+### Build a multi-agent team
 
 ```python
 from uuid import uuid4
 from aixplain import Aixplain
 from aixplain.v2 import EditorConfig, EvaluatorConfig, EvaluatorType, Inspector, InspectorAction, InspectorActionConfig, InspectorSeverity, InspectorTarget
 
-aix = Aixplain(api_key="<AIXPLAIN_API_KEY>")
+aix = Aixplain()  # reads AIXPLAIN_API_KEY from the environment
 search_tool = aix.Tool.get("tavily/tavily-web-search/tavily")
 search_tool.allowed_actions = ["search"]
 
@@ -162,7 +163,7 @@ print(response.data.output)
 ```
 
 <div align="center">
-  <img src="docs/assets/aixplain-workflow-teamagent.png" alt="aiXplain team-agent runtime flow" title="aiXplain"/>
+  <img src="docs/assets/aixplain-workflow-teamagent.png" alt="aixplain team-agent runtime flow" title="aixplain"/>
 </div>
 
 Execution order:
@@ -179,38 +180,29 @@ Team agent
 ├── Orchestrator: decides whether another pass is needed
 └── Responder: returns one final answer
 ```
-</details>
 
-<details>
-  <summary><strong>v1 (legacy)</strong></summary>
+> **SDK 1 (legacy):** available until end of July 2026 — see the [SDK 1 docs](https://docs.aixplain.com/1.0/).
 
-### Create and run your first agent (v1)
+---
 
-```python
-from aixplain.factories import AgentFactory, ModelFactory
+## Core concepts
 
-weather_tool = ModelFactory.get("66f83c216eb563266175e201")
+| Concept | What it is |
+|---|---|
+| **Agent** | An autonomous entity that reasons, plans, and uses tools to complete a task. |
+| **Team agent** | Multiple specialized agents coordinated by a planner and orchestrator at runtime. |
+| **Tool** | A capability an agent can invoke — a model, a pipeline, an integration, or code (Python/SQL). |
+| **Model** | An LLM, utility, or index asset from the [marketplace](https://studio.aixplain.com/browse). |
+| **Pipeline** | A fixed-order workflow connecting models and tools. |
+| **Microagents** | Built-in governance components: Mentalist (planning), Orchestrator (routing), Inspector (validation), Bodyguard (security), Responder (formatting). |
 
-agent = AgentFactory.create(
-    name="Weather Agent",
-    description="Answers weather queries.",
-    instructions="Use the weather tool to answer user questions.",
-    tools=[weather_tool],
-)
-
-result = agent.run("What is the weather in Liverpool, UK?")
-print(result["data"]["output"])
-```
-
-You can still access legacy docs at [docs.aixplain.com/1.0](https://docs.aixplain.com/1.0/).
-
-</details>
+See the [documentation](https://docs.aixplain.com) for the full API reference.
 
 ---
 
 ## Data handling and deployment
 
-aiXplain applies runtime governance and enterprise controls by default:
+aixplain applies runtime governance and enterprise controls by default:
 
 - **We do not train on your data** — your data is not used to train foundation models.
 - **No data retained by default** — agent memory is opt-in (short-term and long-term).
@@ -219,7 +211,7 @@ aiXplain applies runtime governance and enterprise controls by default:
 - **Portable deployment options** — Cloud (instant) or on-prem (including VPC and air-gapped environments).
 - **Encryption** — TLS 1.2+ in transit and encrypted storage at rest.
 
-Learn more at aiXplain [Security](https://aixplain.com/security/) and aiXplain [pricing](https://aixplain.com/pricing/).
+Learn more at aixplain [Security](https://aixplain.com/security/) and aixplain [pricing](https://aixplain.com/pricing/).
 
 ---
 
@@ -231,7 +223,7 @@ Start free, then scale with usage-based pricing.
 - **Subscription plans** — reduce effective consumption-based rates.
 - **Custom enterprise pricing** — available for advanced scale and deployment needs.
 
-Learn more at aiXplain [pricing](https://aixplain.com/pricing/).
+Learn more at aixplain [pricing](https://aixplain.com/pricing/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://discord.gg/aixplain"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-**Build, deploy, and govern autonomous AI agents — in a few lines of Python.**
+**The fastest way to deploy managed, multi-agent systems with runtime governance — on any infrastructure.**
 
 aixplain is the operating system for autonomous AI — **multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments**. It spans the full lifecycle — **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. Agents plan, call models and tools, run code, and adapt at runtime, with **agents-in-the-loop** governance enforced on every execution.
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@
 
 aixplain is the operations layer over your AI stack, spanning **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. The SDK gives you Python and REST access to that runtime: agents that plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
 
-Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an ecosystem of models, tools, and services: an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors**.
-
-**One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, and a sandbox for code execution — with no per-vendor keys or contracts.
+Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors** (OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, a code-execution sandbox, and more). **One API key, one bill**, pay as you go — no per-vendor keys or contracts.
 
 **Build any kind of agent on one runtime** — knowledge (RAG), data, custom-logic, integration, and team agents — with built-in multimodality and file handling.
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@ Develop your way — **SDK, API, CLI, and MCP** environments all run on the same
 
 **One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, and a sandbox for code execution — with no per-vendor keys or contracts.
 
-**Build any kind of agent** on one runtime:
-
-- **Multi-step agents** — chain reasoning and tool calls to complete complex tasks.
-- **Managed agents** — fully hosted and operated on the aixplain runtime.
-- **Deployed agents** — published as production API endpoints.
-
-**Built-in capabilities:** database access, RAG and data ingestion, multimodality (text, audio, image), and file handling.
+**Build any kind of agent on one runtime** — with built-in database access, RAG and data ingestion, multimodality, and file handling.
 
 ## Why aixplain
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,7 @@ Develop your way — **SDK, API, CLI, and MCP** environments all run on the same
 
 ## Agentic OS
 
-Agentic OS is the portable runtime platform behind aixplain agents:
-
-- **Agent Engine** — orchestrates planning, execution, and delegation for autonomous agents.
-- **Asset Serving** — standardizes every model, tool, and data source behind a uniform interface, enabling swappability, governance, identity and auth, and rich telemetry.
-- **Observability** — captures traces, metrics, and monitoring for every production run.
-
-It runs across Cloud (instant) and on-prem deployments.
+Agentic OS is the portable runtime platform behind aixplain agents — orchestration, governed asset serving, and observability across Cloud (instant), on-prem, edge, and air-gapped deployments. See the [documentation](https://docs.aixplain.com) for the full architecture.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-2ea44f?style=flat-square" alt="License"></a>
   <a href="https://studio.aixplain.com/browse"><img src="https://img.shields.io/badge/Marketplace-900%2B%20models%20%26%20tools-0b74de?style=flat-square" alt="Marketplace size"></a>
-  <a href="https://console.aixplain.com/settings/keys"><img src="https://img.shields.io/badge/%F0%9F%94%91%20PAYG%20API%20key-Console-0b74de?style=flat-square" alt="PAYG API key"></a>
+  <a href="https://console.aixplain.com/settings/keys"><img src="https://img.shields.io/badge/%F0%9F%94%91%20PAYG%20API%20key-Settings-0b74de?style=flat-square" alt="PAYG API key"></a>
   <a href="https://discord.gg/aixplain"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
@@ -22,6 +22,8 @@ aixplain is the operations layer over your AI stack, spanning **development → 
 Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an ecosystem of models, tools, and services: an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors**.
 
 **One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, RAG data ingestion, and a sandbox for code execution — with no per-vendor keys or contracts.
+
+Build the full range on one runtime — **multi-step agents**, **managed agents**, and **deployed agents**.
 
 ## Why aixplain
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Less to build, less to operate:
 | Models and tools | 900+ models and tools with one API key | Provider-by-provider setup |
 | Deployment | Cloud (instant) or on-prem | Usually self-assembled runtime and infra |
 | Observability | Built-in traces and dashboards | Varies by framework |
-| [Coding-agent workflows](TODO-agent-builder-skill-url) | Works natively with MCP-compatible coding agents and IDEs | Usually not a first-class workflow target |
+| [Coding-agent workflows](https://github.com/aixplain/aiXplain/tree/main/skills/aixplain-agent-builder) | Works natively with MCP-compatible coding agents and IDEs | Usually not a first-class workflow target |
 
 ## Agentic OS
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ aixplain is the operations layer over your AI stack, spanning **development → 
 
 Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an ecosystem of models, tools, and services: an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors**.
 
-**One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, RAG data ingestion, and a sandbox for code execution — with no per-vendor keys or contracts.
+**One API key. One bill.** Pay as you go across every provider and tool — OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, and a sandbox for code execution — with no per-vendor keys or contracts.
 
-Build the full range on one runtime — **multi-step agents**, **managed agents**, and **deployed agents**.
+**Build any kind of agent** on one runtime:
+
+- **Multi-step agents** — chain reasoning and tool calls to complete complex tasks.
+- **Managed agents** — fully hosted and operated on the aixplain runtime.
+- **Deployed agents** — published as production API endpoints.
+
+**Built-in capabilities:** database access, RAG and data ingestion, multimodality (text, audio, image), and file handling.
 
 ## Why aixplain
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,7 @@ aixplain applies runtime governance and enterprise controls by default:
 - **We do not train on your data** — your data is not used to train foundation models.
 - **No data retained by default** — agent memory is opt-in (short-term and long-term).
 - **SOC 2 Type II certified** — enterprise security and compliance posture.
-- **Runtime policy enforcement** — Inspector and Bodyguard govern every agent execution (e.g. block pip installs or network access during code runs).
-- **Granular access controls** — allow-lists for assets and actions, per-asset permissions, rate and usage limits, and RBAC for enterprise.
+- **Runtime policy enforcement** — Inspector and Bodyguard govern every agent execution, with allow-lists for assets and actions, per-asset permissions, rate and usage limits, and enterprise RBAC.
 - **Portable deployment options** — Cloud (instant) or on-prem (including VPC and air-gapped environments).
 - **Encryption** — TLS 1.2+ in transit and encrypted storage at rest.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
   <a href="https://discord.gg/aixplain"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-**The fastest way to deploy managed, multi-agent systems with runtime governance — on any infrastructure.**
+**Build, deploy, and govern autonomous AI agents — in a few lines of Python.**
+
+_The fastest way to deploy managed, multi-agent systems with runtime governance — on any infrastructure._
 
 aixplain is the operating system for autonomous AI — **multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments**. It spans the full lifecycle — **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. Agents plan, call models and tools, run code, and adapt at runtime, with **agents-in-the-loop** governance enforced on every execution.
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 **The operating system for autonomous AI — multi-agent orchestration and runtime governance across cloud, on-prem, edge, and fully air-gapped environments.**
 
-aixplain is the operations layer over your AI stack, spanning **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. The SDK gives you Python and REST access to that runtime: agents that plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
-
-Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors** (OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, a code-execution sandbox, and more). **One API key, one bill**, pay as you go — no per-vendor keys or contracts.
+aixplain is the operations layer over your AI stack, spanning **development → evaluation → deployment → monitoring → evolution** — so you ship faster instead of stitching tools together. Agents plan, call models and tools, run code, and adapt at runtime, with governance enforced on every execution.
 
 **Build any kind of agent on one runtime** — knowledge (RAG), data, custom-logic, integration, and team agents — with built-in multimodality and file handling.
+
+Develop your way — **SDK, API, CLI, and MCP** environments all run on the same runtime layer, backed by an integrated marketplace of **900+ AI models, tools, and integrations from 70+ vendors** (OpenAI, Anthropic, Gemini, Firecrawl, Tavily, SerpAPI, a code-execution sandbox, and more). **One API key, one bill**, pay as you go — no per-vendor keys or contracts.
 
 ## Why aixplain
 

--- a/README.md
+++ b/README.md
@@ -61,26 +61,6 @@ It runs across Cloud (instant) and on-prem deployments.
 
 ---
 
-## MCP Server Marketplace
-
-[aixplain Marketplace](https://studio.aixplain.com/browse) now also exposes MCP servers for **900+ models and tools**, allowing external clients to access selected **tool, integration, and model assets**, for example **Opus 4.6, Kimi, Qwen, Airtable, and Slack**, through **aixplain-hosted MCP endpoints** with a single API key 🔑.
-
-Read the full MCP setup guide in the [MCP servers docs](https://docs.aixplain.com/api-reference/mcp-servers).
-
-```json
-{
-  "ms1": {
-    "url": "https://models-mcp.aixplain.com/mcp/<AIXPLAIN_ASSET_ID>",
-    "headers": {
-      "Authorization": "Bearer <AIXPLAIN_APIKEY>",
-      "Accept": "application/json, text/event-stream"
-    }
-  }
-}
-```
-
----
-
 ## Quick start
 
 > **This is the aixplain SDK 2.** SDK 1 (the legacy factory API) keeps running until **end of July 2026**; after that, SDK 2 is the only supported surface. <!-- TODO: confirm SDK 2 release version/date -->
@@ -194,6 +174,26 @@ Team agent
 ```
 
 > **SDK 1 (legacy):** available until end of July 2026 — see the [SDK 1 docs](https://docs.aixplain.com/1.0/).
+
+---
+
+## MCP Server Marketplace
+
+[aixplain Marketplace](https://studio.aixplain.com/browse) now also exposes MCP servers for **900+ models and tools**, allowing external clients to access selected **tool, integration, and model assets**, for example **Opus 4.6, Kimi, Qwen, Airtable, and Slack**, through **aixplain-hosted MCP endpoints** with a single API key 🔑.
+
+Read the full MCP setup guide in the [MCP servers docs](https://docs.aixplain.com/api-reference/mcp-servers).
+
+```json
+{
+  "ms1": {
+    "url": "https://models-mcp.aixplain.com/mcp/<AIXPLAIN_ASSET_ID>",
+    "headers": {
+      "Authorization": "Bearer <AIXPLAIN_APIKEY>",
+      "Accept": "application/json, text/event-stream"
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes the SDK v1 (legacy) quickstart and adds a banner noting v1 keeps working until **end of July 2026** (v2 is the default API; there is no separate "2.0" release — both surfaces ship in the 0.2.x package).
- Red-teamed the positioning: leads with the core definition (multi-agent orchestration + runtime governance across cloud, on-prem, edge, air-gapped), framed as the operating system / operations layer over the AI stack.
- "Why aixplain" reframed as concrete developer benefits (one-call deploy via `save()`, no integration glue, built-in governance, self-debugging) with overlap against the overview removed.
- Brand/style: `aiXplain` → `aixplain`, `AgenticOS` → `Agentic OS` (trimmed to a one-line summary), Agent Engine / Asset Serving spaced.
- Quickstart uses env-var auth (`AIXPLAIN_API_KEY` + `Aixplain()`).
- Concepts cleaned up: dropped Pipeline, added Integration and Meta-agent, `Microagents` → `Micro-agents`.
- MCP Server Marketplace moved below the quickstart; governance points deduped in Data handling.
- Coding-agent workflows row now links to the published aixplain-agent-builder skill.

## Test plan
- [ ] README renders correctly on GitHub (tables, banner, code blocks)
- [ ] All links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)