### PR TITLE
fix(v2): V3-compat agent fixes — dict expected_output at run, json default, inspector deserialization

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -437,7 +437,7 @@ class Agent(
         default=OutputFormat.TEXT.value, metadata=config(field_name="outputFormat")
     )
     expected_output: Optional[Union[str, dict, BaseModel]] = field(
-        default="", metadata=config(field_name="expectedOutput")
+        default=None, metadata=config(field_name="expectedOutput")
     )
 
     # Metadata fields
@@ -466,6 +466,15 @@ class Agent(
     def __post_init__(self) -> None:
         """Initialize agent after dataclass creation."""
         self.tasks = [Task.from_dict(task) for task in self.tasks]
+
+        # Deserialize inspectors to Inspector objects so mutate-and-save round-trips.
+        if self.inspectors:
+            from .inspector import Inspector
+
+            self.inspectors = [
+                Inspector.from_dict(inspector) if isinstance(inspector, dict) else inspector
+                for inspector in self.inspectors
+            ]
 
         if self.subagents is not None:
             warnings.warn(
@@ -704,31 +713,36 @@ class Agent(
         return super().sync_poll(self._resolve_poll_url(poll_url), **kwargs)
 
     def _validate_expected_output(self) -> None:
-        # Skip validation if expected_output is None (it's optional)
-        if self.expected_output is None:
-            return
-
         if self.output_format == OutputFormat.JSON.value:
+            # JSON output requires an explicit schema; the empty default is not enough.
+            if self.expected_output is None or self.expected_output == "":
+                raise ValueError(
+                    "output_format='json' requires expected_output (a JSON string, dict, or Pydantic BaseModel)."
+                )
+
             # Check if expected_output is a valid JSON type
             is_valid = isinstance(self.expected_output, (str, dict, BaseModel)) or (
                 isinstance(self.expected_output, type) and issubclass(self.expected_output, BaseModel)
             )
             if not is_valid:
                 raise ValueError(
-                    "Expected output must be a valid JSON object, dict, string, or Pydantic BaseModel class/instance"
+                    "expected_output must be a valid JSON object, dict, string, or Pydantic BaseModel class/instance."
                 )
 
             if isinstance(self.expected_output, str):
                 try:
                     json.loads(self.expected_output)
                 except json.JSONDecodeError:
-                    raise ValueError("Expected output must be a valid JSON string or dict or pydantic model")
+                    raise ValueError("expected_output must be a valid JSON string, dict, or Pydantic BaseModel.")
         elif self.output_format in [
             OutputFormat.MARKDOWN.value,
             OutputFormat.TEXT.value,
         ]:
+            # expected_output is optional for TEXT/MARKDOWN.
+            if self.expected_output is None:
+                return
             if not isinstance(self.expected_output, str):
-                raise ValueError("Expected output must be a string for TEXT/MARKDOWN formats")
+                raise ValueError("expected_output must be a string for TEXT/MARKDOWN formats.")
 
     def save(self, *args: Any, **kwargs: Any) -> "Agent":
         """Save the agent with dependency management.
@@ -1243,6 +1257,9 @@ class Agent(
             execution_params["expectedOutput"] = expected_output.model_json_schema()
         elif isinstance(expected_output, BaseModel):
             execution_params["expectedOutput"] = expected_output.model_dump()
+        elif isinstance(expected_output, dict):
+            # Backend expects executionParams.expectedOutput as a string.
+            execution_params["expectedOutput"] = json.dumps(expected_output)
 
         # Handle run_response_generation with default value of False
         run_response_generation = kwargs.pop("run_response_generation", False)

--- a/tests/unit/v2/test_v2_agent_v3_compat.py
+++ b/tests/unit/v2/test_v2_agent_v3_compat.py
@@ -1,0 +1,89 @@
+"""V2 Agent backward-compat regression tests (V3 engine compatibility).
+
+Covers three SDK-side regressions surfaced during V3 DEV testing:
+- R5: dict ``expected_output`` accepted at save but rejected at run.
+- R6: ``output_format='json'`` crashes at save when ``expected_output`` is unset.
+- R3: inspectors deserialize as plain dicts instead of ``Inspector`` objects on ``get()``.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from aixplain.v2.agent import Agent
+from aixplain.v2.inspector import Inspector
+
+
+def _agent_from_dict(**overrides):
+    """Build a V2 Agent through ``from_dict`` with a mocked client context."""
+    base = {
+        "id": "agent-123",
+        "name": "Test Agent",
+        "instructions": "Do the thing.",
+        "llmId": "69b7e5f1b2fe44704ab0e7d0",
+        "tools": [],
+        "tasks": [],
+        "agents": [],
+        "outputFormat": "json",
+        "inspectorTargets": [],
+        "inspectors": [],
+        "maxIterations": 5,
+        "maxTokens": 2048,
+    }
+    base.update(overrides)
+    agent = Agent.from_dict(base)
+    agent.context = MagicMock()
+    return agent
+
+
+class TestR5DictExpectedOutputRunPayload:
+    """A dict ``expected_output`` must be serialized to a JSON string at run time."""
+
+    def test_dict_expected_output_becomes_json_string_in_run_payload(self):
+        schema = {"name": "string", "city": "string"}
+        agent = _agent_from_dict(outputFormat="json", expectedOutput=schema)
+
+        payload = agent.build_run_payload(query="hi", run_response_generation=True)
+
+        sent = payload["executionParams"]["expectedOutput"]
+        assert isinstance(sent, str), "dict expected_output must be JSON-stringified for the backend"
+        assert json.loads(sent) == schema
+
+
+class TestR6JsonRequiresExpectedOutput:
+    """``output_format='json'`` should default cleanly and fail with an actionable message."""
+
+    def test_expected_output_defaults_to_none(self):
+        agent = Agent(name="t", instructions="x", output_format="json")
+        assert agent.expected_output is None
+
+    def test_json_without_expected_output_raises_actionable_error(self):
+        agent = Agent(name="t", instructions="x", output_format="json")
+        with pytest.raises(ValueError, match="expected_output"):
+            agent._validate_expected_output()
+
+    def test_text_without_expected_output_is_valid(self):
+        agent = Agent(name="t", instructions="x", output_format="text")
+        # Must not raise: text/markdown agents don't require expected_output.
+        agent._validate_expected_output()
+
+    def test_json_with_dict_expected_output_is_valid(self):
+        agent = Agent(name="t", instructions="x", output_format="json", expected_output={"a": "b"})
+        agent._validate_expected_output()
+
+
+class TestR3InspectorDeserialization:
+    """Inspectors must round-trip as ``Inspector`` objects, not raw dicts."""
+
+    def test_inspectors_deserialize_to_inspector_objects(self):
+        inspector_payload = {
+            "name": "Input Gate",
+            "targets": ["input"],
+            "action": {"type": "abort"},
+            "evaluator": {"type": "asset", "assetId": "model-abc", "prompt": "PASS or FAIL"},
+        }
+        agent = _agent_from_dict(inspectors=[inspector_payload])
+
+        assert isinstance(agent.inspectors[0], Inspector)
+        assert agent.inspectors[0].name == "Input Gate"


### PR DESCRIPTION
## Summary

Fixes three SDK-side issues surfaced by V3 engine backward-compat testing on DEV (SDK 0.2.44), all live-validated against `dev-platform-api.aixplain.com`:

- **Dict `expected_output` rejected at run (R5)** — `Agent(..., expected_output=<dict>).save()` succeeded but `run(..., run_response_generation=True)` raised `APIError: executionParams.expectedOutput must be a string`. `build_run_payload` now serializes dict schemas with `json.dumps`, matching the save-side validation that already accepts dicts.
- **Cryptic save failure for JSON output (R6)** — `expected_output` defaulted to `""`, so `Agent(..., output_format='json').save()` crashed with `ValueError("Expected output must be a valid JSON string or dict or pydantic model")` from `json.loads("")`. The default is now `None`, and the JSON-format requirement raises an actionable message: `output_format='json' requires expected_output (a JSON string, dict, or Pydantic BaseModel).`
- **Inspectors deserialize as dicts (R3, SDK half)** — `Agent.get()` returned `inspectors` as raw dicts (unlike `tasks`, which round-trip as `Task` objects), so `inspector.name` raised `AttributeError` and broke mutate-and-save. `__post_init__` now converts dicts to `Inspector` objects.

Note: the backend-side half of R3 (`inspectorTargets` / `maxInspectors` dropped on persist) is not addressable in the SDK — the save payload provably includes both fields.

## Test Plan

- [x] 6 new unit tests in `tests/unit/v2/test_v2_agent_v3_compat.py` (TDD: watched fail, then pass)
- [x] Full unit suite green via pre-commit gate (1015 passed)
- [x] Live-verified on DEV: dict `expected_output` + `run_response_generation=True` now returns populated JSON; JSON-format save error is actionable; inspectors round-trip as `Inspector` objects after `get()`