### PR TITLE
ENG-3148: Add Index API to aixplain.v2 (v2 IndexFactory/IndexModel equivalent)

### DIFF
--- a/aixplain/v2/__init__.py
+++ b/aixplain/v2/__init__.py
@@ -5,6 +5,20 @@ from .rlm import RLM, RLMResult
 from .utility import Utility
 from .agent import Agent, ContextOverflowStrategy
 from .tool import Tool
+from .index import (
+    Index,
+    IndexResult,
+    Record,
+    IndexFilter,
+    IndexFilterOperator,
+    Splitter,
+    BaseIndexParams,
+    BaseIndexParamsWithEmbeddingModel,
+    AirParams,
+    VectaraParams,
+    GraphRAGParams,
+    ZeroEntropyParams,
+)
 from .actions import Input, Inputs, Action, Actions
 from .file import Resource
 from .upload_utils import FileUploader, upload_file, validate_file_for_upload
@@ -51,6 +65,9 @@ from .enums import (
     EvolveType,
     CodeInterpreterModel,
     SplittingOptions,
+    DataType,
+    EmbeddingModel,
+    IndexStores,
 )
 
 __all__ = [
@@ -61,6 +78,19 @@ __all__ = [
     "Agent",
     "ContextOverflowStrategy",
     "Tool",
+    # Index resource + types
+    "Index",
+    "IndexResult",
+    "Record",
+    "IndexFilter",
+    "IndexFilterOperator",
+    "Splitter",
+    "BaseIndexParams",
+    "BaseIndexParamsWithEmbeddingModel",
+    "AirParams",
+    "VectaraParams",
+    "GraphRAGParams",
+    "ZeroEntropyParams",
     "Resource",
     "FileUploader",
     "upload_file",
@@ -118,6 +148,9 @@ __all__ = [
     "EvolveType",
     "CodeInterpreterModel",
     "SplittingOptions",
+    "DataType",
+    "EmbeddingModel",
+    "IndexStores",
     # Actions / Inputs hierarchy
     "Input",
     "Inputs",

--- a/aixplain/v2/__init__.py
+++ b/aixplain/v2/__init__.py
@@ -106,7 +106,6 @@ __all__ = [
     "EvaluatorConfig",
     "EditorConfig",
     "PrebuiltInspector",
-    "ModelResponse",
     # Meta-agents
     "Debugger",
     "DebugResult",

--- a/aixplain/v2/core.py
+++ b/aixplain/v2/core.py
@@ -10,6 +10,7 @@ from .agent import Agent
 from .utility import Utility
 from .tool import Tool
 from .integration import Integration
+from .index import Index
 from .file import Resource
 from .inspector import Inspector
 from .meta_agents import Debugger
@@ -23,6 +24,7 @@ AgentType = TypeVar("AgentType", bound=Agent)
 UtilityType = TypeVar("UtilityType", bound=Utility)
 ToolType = TypeVar("ToolType", bound=Tool)
 IntegrationType = TypeVar("IntegrationType", bound=Integration)
+IndexType = TypeVar("IndexType", bound=Index)
 ResourceType = TypeVar("ResourceType", bound=Resource)
 InspectorType = TypeVar("InspectorType", bound=Inspector)
 DebuggerType = TypeVar("DebuggerType", bound=Debugger)
@@ -48,6 +50,7 @@ class Aixplain:
     Utility: UtilityType = None
     Tool: ToolType = None
     Integration: IntegrationType = None
+    Index: IndexType = None
     Resource: ResourceType = None
     Inspector: InspectorType = None
     Debugger: DebuggerType = None
@@ -58,6 +61,8 @@ class Aixplain:
     Supplier = enums.Supplier
     Language = enums.Language
     License = enums.License
+    EmbeddingModel = enums.EmbeddingModel
+    IndexStores = enums.IndexStores
 
     AssetStatus = enums.AssetStatus
     ErrorHandler = enums.ErrorHandler
@@ -128,6 +133,7 @@ class Aixplain:
         self.Utility = type("Utility", (Utility,), {"context": self})
         self.Tool = type("Tool", (Tool,), {"context": self})
         self.Integration = type("Integration", (Integration,), {"context": self})
+        self.Index = type("Index", (Index,), {"context": self})
         self.Resource = type("Resource", (Resource,), {"context": self})
         self.Inspector = type("Inspector", (Inspector,), {"context": self})
         self.Debugger = type("Debugger", (Debugger,), {"context": self})

--- a/aixplain/v2/enums.py
+++ b/aixplain/v2/enums.py
@@ -247,6 +247,56 @@ class SplittingOptions(str, Enum):
     LINE = "line"
 
 
+class EmbeddingModel(str, Enum):
+    """Enumeration of available embedding models in the aiXplain system.
+
+    Each member's value is the aiXplain model ID used to generate vector
+    representations of data when creating an index.
+
+    Attributes:
+        OPENAI_ADA002: OpenAI's Ada-002 text embedding model ID.
+        JINA_CLIP_V2_MULTIMODAL: Jina CLIP v2 multimodal embedding model ID.
+        MULTILINGUAL_E5_LARGE: Multilingual E5 Large text embedding model ID.
+        BGE_M3: BGE-M3 embedding model ID.
+    """
+
+    OPENAI_ADA002 = "6734c55df127847059324d9e"
+    JINA_CLIP_V2_MULTIMODAL = "67c5f705d8f6a65d6f74d732"
+    MULTILINGUAL_E5_LARGE = "67efd0772a0a850afa045af3"
+    BGE_M3 = "67efd4f92a0a850afa045af7"
+
+    def __str__(self) -> str:
+        """Return the embedding model ID as a string."""
+        return self._value_
+
+
+class IndexStores(Enum):
+    """Enumeration of available index store providers in the aiXplain system.
+
+    Each member holds the provider ``name`` and the aiXplain ``id`` of the
+    store model used to create collections of that type.
+
+    Attributes:
+        AIR: aiXplain Index and Retrieval store.
+        VECTARA: Vectara store.
+        GRAPHRAG: Graph-based RAG store.
+        ZERO_ENTROPY: Zero Entropy store.
+    """
+
+    AIR = {"name": "air", "id": "66eae6656eb56311f2595011"}
+    VECTARA = {"name": "vectara", "id": "655e20f46eb563062a1aa301"}
+    GRAPHRAG = {"name": "graphrag", "id": "67dd6d487cbf0a57cf4b72f3"}
+    ZERO_ENTROPY = {"name": "zeroentropy", "id": "6807949168e47e7844c1f0c5"}
+
+    def __str__(self) -> str:
+        """Return the index store name."""
+        return self.value["name"]
+
+    def get_model_id(self) -> str:
+        """Return the aiXplain model ID of the index store."""
+        return self.value["id"]
+
+
 __all__ = [
     "AuthenticationScheme",
     "FileType",
@@ -268,4 +318,6 @@ __all__ = [
     "CodeInterpreterModel",
     "DataType",
     "SplittingOptions",
+    "EmbeddingModel",
+    "IndexStores",
 ]

--- a/aixplain/v2/index.py
+++ b/aixplain/v2/index.py
@@ -1,0 +1,760 @@
+"""Index resource for the v2 API.
+
+This module provides a typed, v2-native Index API — the v2 equivalent of the
+legacy ``aixplain.factories.IndexFactory`` / ``aixplain.modules.model.IndexModel``.
+
+It covers both planes of index management:
+
+* **Control-plane** — :meth:`Index.create`, :meth:`Index.list`,
+  :meth:`Index.get`, :meth:`Index.delete`.
+* **Data-plane** — :meth:`Index.upsert`, :meth:`Index.search`,
+  :meth:`Index.count`, :meth:`Index.get_record`, :meth:`Index.delete_record`,
+  :meth:`Index.retrieve_records_with_filter`,
+  :meth:`Index.delete_records_by_date`.
+
+All operations return v2-native types (:class:`Index`, :class:`IndexResult`,
+:class:`~aixplain.v2.resource.Page`, :class:`~aixplain.v2.resource.DeleteResult`)
+and authenticate through the v2 :class:`~aixplain.v2.client.AixplainClient`, so
+consumers never need to import the legacy ``aixplain.factories`` API.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+from uuid import uuid4
+
+from dataclasses_json import config, dataclass_json
+from pydantic import BaseModel, ConfigDict
+from typing_extensions import Unpack
+
+from .enums import DataType, EmbeddingModel, IndexStores, ResponseStatus, SplittingOptions
+from .exceptions import ResourceError
+from .resource import (
+    BaseGetParams,
+    BaseResource,
+    BaseRunParams,
+    DeleteResult,
+    GetResourceMixin,
+    Page,
+    Result,
+    RunnableResourceMixin,
+)
+from .upload_utils import upload_file
+
+logger = logging.getLogger(__name__)
+
+#: Model used to parse non-text files (PDF, DOCX, ...) into text during upsert.
+DOCLING_MODEL_ID = "677bee6c6eb56331f9192a91"
+
+#: Image file extensions recognised by the index data-plane.
+_SUPPORTED_IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp")
+
+
+# ---------------------------------------------------------------------------
+# Storage / file helpers (v2-native; patchable in tests)
+# ---------------------------------------------------------------------------
+def _is_supported_image_type(value: str) -> bool:
+    """Return whether *value* points to a supported image format (by extension)."""
+    return isinstance(value, str) and value.lower().endswith(_SUPPORTED_IMAGE_EXTENSIONS)
+
+
+def _is_url(value: str) -> bool:
+    """Return whether *value* looks like a URL (scheme-based, with a validator fallback)."""
+    if not isinstance(value, str):
+        return False
+    if value.startswith(("s3://", "http://", "https://")):
+        return True
+    try:
+        import validators
+
+        return bool(validators.url(value))
+    except Exception:
+        return False
+
+
+def _check_storage_type(value: Any) -> str:
+    """Classify *value* as ``"file"`` (local path), ``"url"`` or ``"text"``."""
+    try:
+        if isinstance(value, (str, os.PathLike)) and os.path.exists(value) and os.path.isfile(value):
+            return "file"
+    except (TypeError, ValueError):
+        pass
+    if _is_url(value):
+        return "url"
+    return "text"
+
+
+def _to_link(value: str) -> str:
+    """Upload a local file and return its hosted link; pass through URLs/text unchanged."""
+    if _check_storage_type(value) == "file":
+        return upload_file(value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+class Record:
+    """A single record to be indexed.
+
+    Attributes:
+        value: The textual value of the record (for text records).
+        value_type: The data type of the record (``DataType.TEXT`` or ``DataType.IMAGE``).
+        id: The record identifier (a random UUID is generated when omitted).
+        uri: The URI of the record (required for image records).
+        attributes: Arbitrary metadata stored alongside the record.
+    """
+
+    def __init__(
+        self,
+        value: str = "",
+        value_type: Union[DataType, str] = DataType.TEXT,
+        id: Optional[str] = None,
+        uri: str = "",
+        attributes: Optional[dict] = None,
+    ) -> None:
+        """Initialize a new Record.
+
+        Args:
+            value: The textual value of the record.
+            value_type: The data type of the value. Defaults to ``DataType.TEXT``.
+            id: The record identifier. Defaults to a random UUID.
+            uri: The URI of the record.
+            attributes: Arbitrary metadata. Defaults to an empty dict.
+        """
+        self.value = value
+        self.value_type = value_type
+        self.id = id if id is not None else str(uuid4())
+        self.uri = uri
+        self.attributes = attributes if attributes is not None else {}
+
+    def to_dict(self) -> dict:
+        """Serialize the record into the backend ingest payload shape.
+
+        Returns:
+            dict: ``{data, dataType, document_id, uri, attributes}``.
+        """
+        return {
+            "data": self.value,
+            "dataType": str(self.value_type),
+            "document_id": self.id,
+            "uri": self.uri,
+            "attributes": self.attributes,
+        }
+
+    def validate(self) -> None:
+        """Validate the record and resolve local files to hosted links.
+
+        Mirrors the legacy ``Record.validate`` semantics: text records require a
+        value or a URI, image records require a URI, and local image files are
+        uploaded and rewritten to their hosted link (with ``value_type`` promoted
+        to ``DataType.IMAGE`` for recognised image files).
+
+        Raises:
+            AssertionError: If the value type is invalid or a required field is missing.
+        """
+        assert self.value_type in [DataType.TEXT, DataType.IMAGE], "Index Upsert Error: Invalid value type"
+        if self.value_type == DataType.IMAGE:
+            assert self.uri is not None and self.uri != "", "Index Upsert Error: URI is required for image records"
+        else:
+            assert (self.value is not None and self.value != "") or (self.uri is not None and self.uri != ""), (
+                "Index Upsert Error: Either value or uri is required for text records"
+            )
+
+        storage_type = _check_storage_type(self.uri)
+        if storage_type in ("file", "url"):
+            if _is_supported_image_type(self.uri):
+                self.value_type = DataType.IMAGE
+            self.uri = _to_link(self.uri) if storage_type == "file" else self.uri
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+class IndexFilterOperator(Enum):
+    """Comparison operators available for filtering index records."""
+
+    EQUALS = "=="
+    NOT_EQUALS = "!="
+    CONTAINS = "in"
+    NOT_CONTAINS = "not in"
+    GREATER_THAN = ">"
+    LESS_THAN = "<"
+    GREATER_THAN_OR_EQUALS = ">="
+    LESS_THAN_OR_EQUALS = "<="
+
+
+class IndexFilter:
+    """A filter used to search or retrieve records by field/value/operator.
+
+    Attributes:
+        field: The name of the field to filter on.
+        value: The value to compare against.
+        operator: The comparison operator (an :class:`IndexFilterOperator` or its string value).
+    """
+
+    def __init__(self, field: str, value: str, operator: Union[IndexFilterOperator, str]) -> None:
+        """Initialize a new IndexFilter.
+
+        Args:
+            field: The name of the field to filter on.
+            value: The value to compare against.
+            operator: The comparison operator to use.
+        """
+        self.field = field
+        self.value = value
+        self.operator = operator
+
+    def to_dict(self) -> dict:
+        """Serialize the filter into its backend payload shape.
+
+        Returns:
+            dict: ``{field, value, operator}`` with the operator coerced to its string value.
+        """
+        return {
+            "field": self.field,
+            "value": self.value,
+            "operator": self.operator.value if isinstance(self.operator, IndexFilterOperator) else self.operator,
+        }
+
+
+class Splitter:
+    """Configuration for splitting documents into chunks before indexing.
+
+    Attributes:
+        split: Whether to split documents.
+        split_by: The splitting unit (word, sentence, ...).
+        split_length: The length of each chunk.
+        split_overlap: The overlap between consecutive chunks.
+    """
+
+    def __init__(
+        self,
+        split: bool = False,
+        split_by: SplittingOptions = SplittingOptions.WORD,
+        split_length: int = 1,
+        split_overlap: int = 0,
+    ) -> None:
+        """Initialize a new Splitter.
+
+        Args:
+            split: Whether to split documents. Defaults to ``False``.
+            split_by: The splitting unit. Defaults to ``SplittingOptions.WORD``.
+            split_length: The length of each chunk. Defaults to ``1``.
+            split_overlap: The overlap between consecutive chunks. Defaults to ``0``.
+        """
+        self.split = split
+        self.split_by = split_by
+        self.split_length = split_length
+        self.split_overlap = split_overlap
+
+
+# ---------------------------------------------------------------------------
+# Index parameters (control-plane creation)
+# ---------------------------------------------------------------------------
+class BaseIndexParams(BaseModel, ABC):
+    """Abstract base for index creation parameters.
+
+    Attributes:
+        name: Name of the index collection.
+        description: Optional description of the index collection.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, validate_default=True)
+    name: str
+    description: Optional[str] = ""
+
+    def to_dict(self) -> Dict:
+        """Serialize the parameters for the create request (renaming ``name`` to ``data``)."""
+        data = self.model_dump(exclude_none=True)
+        data["data"] = data.pop("name")
+        return data
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """The aiXplain store-model ID used to create this index type."""
+        raise NotImplementedError
+
+
+class BaseIndexParamsWithEmbeddingModel(BaseIndexParams, ABC):
+    """Abstract base for index parameters that require an embedding model.
+
+    Attributes:
+        embedding_model: Embedding model to use. Defaults to ``EmbeddingModel.OPENAI_ADA002``.
+        embedding_size: Optional embedding size.
+    """
+
+    embedding_model: Optional[Union[EmbeddingModel, str]] = EmbeddingModel.OPENAI_ADA002
+    embedding_size: Optional[int] = None
+
+    def to_dict(self) -> Dict:
+        """Serialize the parameters, mapping embedding fields to the backend shape."""
+        data = super().to_dict()
+        data["model"] = data.pop("embedding_model")
+        if data.get("embedding_size"):
+            data["additional_params"] = {"embedding_size": data.pop("embedding_size")}
+        return data
+
+
+class AirParams(BaseIndexParamsWithEmbeddingModel):
+    """Parameters for creating an AIR (aiXplain Index and Retrieval) index."""
+
+    _id: str = IndexStores.AIR.get_model_id()
+
+    @property
+    def id(self) -> str:
+        """The AIR store-model ID."""
+        return self._id
+
+
+class VectaraParams(BaseIndexParams):
+    """Parameters for creating a Vectara index."""
+
+    _id: str = IndexStores.VECTARA.get_model_id()
+
+    @property
+    def id(self) -> str:
+        """The Vectara store-model ID."""
+        return self._id
+
+
+class ZeroEntropyParams(BaseIndexParams):
+    """Parameters for creating a Zero Entropy index."""
+
+    _id: str = IndexStores.ZERO_ENTROPY.get_model_id()
+
+    @property
+    def id(self) -> str:
+        """The Zero Entropy store-model ID."""
+        return self._id
+
+
+class GraphRAGParams(BaseIndexParamsWithEmbeddingModel):
+    """Parameters for creating a GraphRAG index.
+
+    Attributes:
+        llm: Optional ID of the LLM used for generation.
+    """
+
+    _id: str = IndexStores.GRAPHRAG.get_model_id()
+    llm: Optional[str] = None
+
+    @property
+    def id(self) -> str:
+        """The GraphRAG store-model ID."""
+        return self._id
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+@dataclass_json
+@dataclass(repr=False)
+class IndexResult(Result):
+    """Result of an index data-plane operation.
+
+    Extends :class:`~aixplain.v2.resource.Result` with the execution metadata the
+    model-serving backend returns. ``status``/``completed`` carry defaults because
+    some index actions (e.g. ``count``) return only ``status`` and ``data``.
+    """
+
+    status: str = ResponseStatus.SUCCESS.value
+    completed: bool = True
+    details: Optional[Any] = None
+    run_time: Optional[float] = field(default=None, metadata=config(field_name="runTime"))
+    used_credits: Optional[float] = field(default=None, metadata=config(field_name="usedCredits"))
+    usage: Optional[Any] = None
+
+
+class IndexRunParams(BaseRunParams):
+    """Run parameters for index data-plane actions (``timeout``, ``wait_time``)."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Index resource
+# ---------------------------------------------------------------------------
+@dataclass_json
+@dataclass(repr=False)
+class Index(
+    BaseResource,
+    GetResourceMixin[BaseGetParams, "Index"],
+    RunnableResourceMixin[IndexRunParams, IndexResult],
+):
+    """A vector index collection, with control-plane and data-plane operations.
+
+    Use the client-bound resource (``client.Index``) for all operations::
+
+        from aixplain.v2 import Aixplain
+        from aixplain.v2.index import AirParams, Record, IndexFilter, IndexFilterOperator
+
+        client = Aixplain()
+        index = client.Index.create(params=AirParams(name="docs", description="My docs"))
+        index.upsert([Record(value="Hello, world!")])
+        results = index.search("hello")
+        index.delete()
+    """
+
+    RESOURCE_PATH = "v2/models"
+    RESPONSE_CLASS = IndexResult
+
+    # Index-specific informational fields (populated from the model metadata).
+    version: Optional[Any] = None
+    embedding_model: Optional[str] = field(default=None, metadata=config(field_name="embedding_model"))
+    embedding_size: Optional[int] = field(default=None, metadata=config(field_name="embedding_size"))
+    collection_type: Optional[str] = field(default=None, metadata=config(field_name="collection_type"))
+
+    # -- enum / type re-exports for convenient access via the resource --------
+    EmbeddingModel = EmbeddingModel
+    IndexStores = IndexStores
+
+    # ------------------------------------------------------------------
+    # Run plumbing
+    # ------------------------------------------------------------------
+    def build_run_url(self, **kwargs: Unpack[IndexRunParams]) -> str:
+        """Build the model-execution URL for data-plane actions."""
+        self._ensure_valid_state()
+        return f"{self.context.model_url}/{self.id}"
+
+    def _run_index_action(
+        self,
+        action_payload: dict,
+        *,
+        timeout: int = 300,
+        wait_time: float = 0.5,
+    ) -> IndexResult:
+        """Execute an index action payload and poll until completion.
+
+        Args:
+            action_payload: The ``{"action": ..., "data": ...}`` payload to POST.
+            timeout: Maximum time in seconds to wait for async completion.
+            wait_time: Initial interval in seconds between poll attempts.
+
+        Returns:
+            IndexResult: The (completed) result of the action.
+
+        Raises:
+            OperationFailedError: If the backend reports a ``FAILED`` status.
+        """
+        self._ensure_valid_state()
+        run_url = self.build_run_url()
+        response = self.context.client.request("post", run_url, json=action_payload)
+        result = self.handle_run_response(response)
+        if result.url and not result.completed:
+            result = self.sync_poll(result.url, timeout=timeout, wait_time=wait_time)
+        return result
+
+    # ------------------------------------------------------------------
+    # Control-plane
+    # ------------------------------------------------------------------
+    @classmethod
+    def create(
+        cls,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        embedding_model: Union[EmbeddingModel, str] = EmbeddingModel.OPENAI_ADA002,
+        params: Optional[BaseIndexParams] = None,
+        timeout: int = 300,
+    ) -> "Index":
+        """Create a new index collection.
+
+        Prefer passing a typed ``params`` object (``AirParams``, ``VectaraParams``,
+        ``GraphRAGParams``, ``ZeroEntropyParams``). The legacy
+        ``name``/``description``/``embedding_model`` form creates an AIR index.
+
+        Args:
+            name: Name of the index (legacy form; mutually exclusive with ``params``).
+            description: Description of the index (legacy form).
+            embedding_model: Embedding model for the legacy form.
+            params: Typed index parameters (recommended).
+            timeout: Maximum time in seconds to wait for creation.
+
+        Returns:
+            Index: The created index collection.
+
+        Raises:
+            AssertionError: If the arguments are inconsistent.
+            ResourceError: If creation fails.
+        """
+        context = getattr(cls, "context", None)
+        if context is None:
+            raise ResourceError("Context is required for index creation")
+
+        if params is not None:
+            assert name is None and description is None, (
+                "Index creation: name and description must not be provided when params is provided"
+            )
+            store_model_id = params.id
+            data = params.to_dict()
+        else:
+            assert name is not None and description is not None and embedding_model is not None, (
+                "Index creation: name, description, and embedding_model must be provided when params is not"
+            )
+            model_value = embedding_model.value if isinstance(embedding_model, Enum) else embedding_model
+            data = {"data": name, "description": description, "model": model_value}
+            store_model_id = IndexStores.AIR.get_model_id()
+
+        # Run the store model with the create payload; the new collection ID is
+        # returned in the response ``data`` field.
+        store = cls(id=store_model_id)
+        result = store._run_index_action(data, timeout=timeout)
+        if result.status == ResponseStatus.SUCCESS and result.data:
+            return cls.get(result.data)
+
+        error_message = result.error_message or "An error occurred while creating the index collection."
+        raise ResourceError(f"Index creation failed: {error_message}")
+
+    @classmethod
+    def get(cls: type["Index"], id: str, **kwargs: Unpack[BaseGetParams]) -> "Index":
+        """Get an index collection by ID.
+
+        Args:
+            id: The index (model) ID.
+            **kwargs: Additional get parameters.
+
+        Returns:
+            Index: The retrieved index collection.
+        """
+        return super().get(id, **kwargs)
+
+    @classmethod
+    def list(
+        cls,
+        query: str = "",
+        page_number: int = 0,
+        page_size: int = 20,
+    ) -> Page["Index"]:
+        """List available index collections (function = ``SEARCH``).
+
+        Useful to resolve a collection by name (filter the returned page by
+        ``index.name``).
+
+        Args:
+            query: Optional search query to filter indexes by name.
+            page_number: Page number for pagination (0-indexed).
+            page_size: Number of results per page.
+
+        Returns:
+            Page[Index]: A page of index collections.
+        """
+        context = getattr(cls, "context", None)
+        if context is None:
+            raise ResourceError("Context is required for resource listing")
+
+        filters = {
+            "q": query or "",
+            "pageNumber": page_number,
+            "pageSize": page_size,
+            "functions": [{"id": "search"}],
+            "sort": [{}],
+        }
+        response = context.client.request("post", "v2/models/paginate", json=filters)
+
+        items = response.get("results")
+        if items is None:
+            items = response.get("items", [])
+
+        results: List["Index"] = []
+        for item in items:
+            try:
+                obj = cls.from_dict(item)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Skipping item during Index deserialization: %s", e)
+                continue
+            setattr(obj, "context", context)
+            obj._update_saved_state()
+            results.append(obj)
+
+        total = response.get("total", len(results))
+        page_total = response.get("pageTotal", len(results))
+        return Page(results=results, page_number=page_number, page_total=page_total, total=total)
+
+    def delete(self, **kwargs: Any) -> DeleteResult:
+        """Delete this index collection.
+
+        Returns:
+            DeleteResult: The result of the delete operation.
+
+        Raises:
+            APIError: If the deletion fails (e.g. the index does not exist or the
+                caller is not the owner).
+        """
+        self._ensure_valid_state()
+        deleted_id = self.id
+        url = f"sdk/models/{self.encoded_id}"
+        headers = {
+            "Authorization": f"Token {self.context.api_key}",
+            "Content-Type": "application/json",
+        }
+        self.context.client.request_raw("delete", url, headers=headers)
+
+        # Mark the resource as deleted.
+        self.id = None
+        self._deleted = True
+
+        return DeleteResult(status=ResponseStatus.SUCCESS.value, completed=True, deleted_id=deleted_id)
+
+    # ------------------------------------------------------------------
+    # Data-plane
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        query: str,
+        top_k: int = 10,
+        filters: Optional[List[IndexFilter]] = None,
+        score_threshold: float = 0.0,
+        timeout: int = 300,
+    ) -> IndexResult:
+        """Search for records in the index.
+
+        Args:
+            query: The query text, or a file path / URL for image search.
+            top_k: Number of results to return.
+            filters: Optional list of :class:`IndexFilter` to apply.
+            score_threshold: Minimum score threshold for results.
+            timeout: Maximum time in seconds to wait for completion.
+
+        Returns:
+            IndexResult: The search result (``result.data`` holds the matches).
+        """
+        filters = filters or []
+        uri, value_type = "", "text"
+        storage_type = _check_storage_type(query)
+        if storage_type in ("file", "url"):
+            uri = _to_link(query)
+            query = ""
+            value_type = "image"
+
+        data = {
+            "action": "search",
+            "data": query or uri,
+            "dataType": value_type,
+            "filters": [index_filter.to_dict() for index_filter in filters],
+            "payload": {
+                "uri": uri,
+                "value_type": value_type,
+                "top_k": top_k,
+                "score_threshold": score_threshold,
+            },
+        }
+        return self._run_index_action(data, timeout=timeout)
+
+    def upsert(
+        self,
+        documents: Union[List[Record], str],
+        splitter: Optional[Splitter] = None,
+        timeout: int = 300,
+    ) -> IndexResult:
+        """Upsert records into the index.
+
+        Args:
+            documents: A list of :class:`Record` objects, or a file path to ingest.
+            splitter: Optional :class:`Splitter` controlling chunking.
+            timeout: Maximum time in seconds to wait for completion.
+
+        Returns:
+            IndexResult: The upsert result; on success ``result.data`` holds the
+            list of ingested record payloads.
+        """
+        if isinstance(documents, str):
+            documents = [self.prepare_record_from_file(documents)]
+
+        for doc in documents:
+            doc.validate()
+
+        payloads = [doc.to_dict() for doc in documents]
+        data: Dict[str, Any] = {"action": "ingest", "data": payloads}
+        if splitter and splitter.split:
+            data["additional_params"] = {
+                "splitter": {
+                    "split": splitter.split,
+                    "split_by": splitter.split_by,
+                    "split_length": splitter.split_length,
+                    "split_overlap": splitter.split_overlap,
+                }
+            }
+
+        result = self._run_index_action(data, timeout=timeout)
+        if result.status == ResponseStatus.SUCCESS:
+            result.data = payloads
+        return result
+
+    def count(self, timeout: int = 300) -> int:
+        """Return the total number of records in the index."""
+        result = self._run_index_action({"action": "count", "data": ""}, timeout=timeout)
+        return int(result.data)
+
+    def get_record(self, record_id: str, timeout: int = 300) -> IndexResult:
+        """Retrieve a single record by ID."""
+        return self._run_index_action({"action": "get_document", "data": record_id}, timeout=timeout)
+
+    def delete_record(self, record_id: str, timeout: int = 300) -> IndexResult:
+        """Delete a single record by ID."""
+        return self._run_index_action({"action": "delete", "data": record_id}, timeout=timeout)
+
+    def retrieve_records_with_filter(self, index_filter: IndexFilter, timeout: int = 300) -> IndexResult:
+        """Retrieve records matching the given filter."""
+        return self._run_index_action(
+            {"action": "retrieve_by_filter", "data": index_filter.to_dict()}, timeout=timeout
+        )
+
+    def delete_records_by_date(self, date: float, timeout: int = 300) -> IndexResult:
+        """Delete records matching the given date (timestamp)."""
+        return self._run_index_action({"action": "delete_by_date", "data": date}, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # File ingestion helpers
+    # ------------------------------------------------------------------
+    def prepare_record_from_file(self, file_path: str, file_id: Optional[str] = None) -> Record:
+        """Parse a file into a text :class:`Record`.
+
+        Args:
+            file_path: Path to the file to ingest.
+            file_id: Optional record ID; a unique ID is generated when omitted.
+
+        Returns:
+            Record: A text record holding the parsed file content.
+        """
+        text = self.parse_file(file_path)
+        file_name = os.path.basename(file_path)
+        if not file_id:
+            file_id = file_name + "_" + str(uuid4())
+        return Record(value=text, value_type=DataType.TEXT, id=file_id, attributes={"file_name": file_name})
+
+    def parse_file(self, file_path: str, timeout: int = 300) -> str:
+        """Parse a file into text (plain read for ``.txt``, Docling otherwise).
+
+        Args:
+            file_path: Path to the file to parse.
+            timeout: Maximum time in seconds to wait for Docling parsing.
+
+        Returns:
+            str: The parsed text content.
+
+        Raises:
+            ResourceError: If the file does not exist or parsing fails.
+        """
+        if not os.path.exists(file_path):
+            raise ResourceError(f"File {file_path} does not exist")
+
+        if file_path.endswith(".txt"):
+            with open(file_path, "r") as handle:
+                return handle.read()
+
+        try:
+            link = _to_link(file_path)
+            run_url = f"{self.context.model_url}/{DOCLING_MODEL_ID}"
+            response = self.context.client.request("post", run_url, json={"data": link})
+            result = self.handle_run_response(response)
+            if result.url and not result.completed:
+                result = self.sync_poll(result.url, timeout=timeout)
+            return result.data
+        except Exception as e:
+            raise ResourceError(f"Failed to parse file: {e}")

--- a/aixplain/v2/index.py
+++ b/aixplain/v2/index.py
@@ -407,9 +407,9 @@ class Index(
 
     # Index-specific informational fields (populated from the model metadata).
     version: Optional[Any] = None
-    embedding_model: Optional[str] = field(default=None, metadata=config(field_name="embedding_model"))
-    embedding_size: Optional[int] = field(default=None, metadata=config(field_name="embedding_size"))
-    collection_type: Optional[str] = field(default=None, metadata=config(field_name="collection_type"))
+    embedding_model: Optional[str] = None
+    embedding_size: Optional[int] = None
+    collection_type: Optional[str] = None
 
     # -- enum / type re-exports for convenient access via the resource --------
     EmbeddingModel = EmbeddingModel

--- a/aixplain/v2/index.py
+++ b/aixplain/v2/index.py
@@ -552,14 +552,14 @@ class Index(
             "q": query or "",
             "pageNumber": page_number,
             "pageSize": page_size,
-            "functions": [{"id": "search"}],
-            "sort": [{}],
+            "functions": ["search"],
         }
-        response = context.client.request("post", "v2/models/paginate", json=filters)
+        headers = {"Authorization": f"Token {context.api_key}"}
+        response = context.client.request("post", "sdk/models/paginate", json=filters, headers=headers)
 
-        items = response.get("results")
+        items = response.get("items")
         if items is None:
-            items = response.get("items", [])
+            items = response.get("results", [])
 
         results: List["Index"] = []
         for item in items:

--- a/aixplain/v2/index.py
+++ b/aixplain/v2/index.py
@@ -449,7 +449,35 @@ class Index(
         result = self.handle_run_response(response)
         if result.url and not result.completed:
             result = self.sync_poll(result.url, timeout=timeout, wait_time=wait_time)
+            # The generic poll() copies only a whitelist of response fields and
+            # coerces a falsy ``data`` to ``{}``. Restore the index-specific
+            # fields from the raw poll response so async results match sync ones
+            # (e.g. search ``details`` and a zero ``count``).
+            raw = getattr(result, "_raw_data", None)
+            if isinstance(raw, dict):
+                if "data" in raw:
+                    result.data = raw["data"]
+                if result.details is None:
+                    result.details = raw.get("details")
         return result
+
+    def run(self, *args: Any, **kwargs: Any) -> IndexResult:
+        """Disabled: use the typed data-plane methods instead.
+
+        ``Index`` reuses the run machinery internally but does not expose a
+        generic ``run()`` — a raw payload would bypass the action protocol.
+        """
+        raise NotImplementedError(
+            "Index does not support a generic run(). Use the typed data-plane methods: "
+            "search(), upsert(), count(), get_record(), delete_record(), "
+            "retrieve_records_with_filter(), delete_records_by_date()."
+        )
+
+    def run_async(self, *args: Any, **kwargs: Any) -> IndexResult:
+        """Disabled: use the typed data-plane methods instead."""
+        raise NotImplementedError(
+            "Index does not support run_async(). Use the typed data-plane methods instead."
+        )
 
     # ------------------------------------------------------------------
     # Control-plane

--- a/aixplain/v2/index.py
+++ b/aixplain/v2/index.py
@@ -475,9 +475,7 @@ class Index(
 
     def run_async(self, *args: Any, **kwargs: Any) -> IndexResult:
         """Disabled: use the typed data-plane methods instead."""
-        raise NotImplementedError(
-            "Index does not support run_async(). Use the typed data-plane methods instead."
-        )
+        raise NotImplementedError("Index does not support run_async(). Use the typed data-plane methods instead.")
 
     # ------------------------------------------------------------------
     # Control-plane
@@ -729,9 +727,7 @@ class Index(
 
     def retrieve_records_with_filter(self, index_filter: IndexFilter, timeout: int = 300) -> IndexResult:
         """Retrieve records matching the given filter."""
-        return self._run_index_action(
-            {"action": "retrieve_by_filter", "data": index_filter.to_dict()}, timeout=timeout
-        )
+        return self._run_index_action({"action": "retrieve_by_filter", "data": index_filter.to_dict()}, timeout=timeout)
 
     def delete_records_by_date(self, date: float, timeout: int = 300) -> IndexResult:
         """Delete records matching the given date (timestamp)."""

--- a/aixplain/v2/upload_utils.py
+++ b/aixplain/v2/upload_utils.py
@@ -188,15 +188,32 @@ class S3Uploader:
 
     @classmethod
     def construct_s3_url(cls, presigned_url: str, path: str) -> str:
-        """Construct S3 URL from pre-signed URL and path."""
-        # Extract bucket name from presigned URL
-        bucket_match = re.findall(r"https://(.*?).s3.amazonaws.com", presigned_url)
-        if bucket_match:
-            bucket_name = bucket_match[0]
-            return f"s3://{bucket_name}/{path}"
-        else:
-            # Fallback: use the path directly
-            return f"s3://aixplain-uploads/{path}"
+        """Construct an ``s3://`` URL from a pre-signed upload URL and object key.
+
+        Handles both S3 addressing styles (and regional hosts):
+
+        * virtual-hosted-style: ``https://<bucket>.s3[.<region>].amazonaws.com/<key>``
+        * path-style:           ``https://s3[.<region>].amazonaws.com/<bucket>/<key>``
+
+        The previous implementation only recognised virtual-hosted-style URLs and
+        silently fell back to a hardcoded ``aixplain-uploads`` bucket for anything
+        else (e.g. the path-style URLs returned by some backends), producing links
+        that point at the wrong bucket.
+        """
+        base = presigned_url.split("?", 1)[0]
+
+        # virtual-hosted-style: bucket is the label before ".s3"
+        vh = re.match(r"https?://([^/.]+)\.s3[^/]*\.amazonaws\.com", base)
+        if vh:
+            return f"s3://{vh.group(1)}/{path}"
+
+        # path-style: bucket is the first path segment after the host
+        ps = re.match(r"https?://s3[^/]*\.amazonaws\.com/([^/?]+)", base)
+        if ps:
+            return f"s3://{ps.group(1)}/{path}"
+
+        # Fallback: use the path directly
+        return f"s3://aixplain-uploads/{path}"
 
 
 class ConfigManager:

--- a/tests/functional/v2/test_index.py
+++ b/tests/functional/v2/test_index.py
@@ -19,7 +19,7 @@ from aixplain.v2.index import (
     IndexFilterOperator,
     Record,
 )
-from aixplain.v2.enums import EmbeddingModel, ResponseStatus
+from aixplain.v2.enums import DataType, EmbeddingModel, ResponseStatus
 
 
 def _unique_name(prefix: str) -> str:
@@ -176,6 +176,77 @@ def test_index_upsert_pdf_file_via_docling(client, index, tmp_path):
     assert any(
         kw in str(res.details).lower() for kw in ("photosynth", "chlorophyll", "glucose")
     )
+
+
+def _make_png(path, base_rgb, block_rgb, w=96, h=96):
+    """Write a valid PNG (solid base color with a contrasting centered block)."""
+    import struct
+    import zlib
+
+    rows = bytearray()
+    for y in range(h):
+        rows.append(0)  # filter type 0
+        for x in range(w):
+            in_block = (w // 4 <= x < 3 * w // 4) and (h // 4 <= y < 3 * h // 4)
+            r, g, b = block_rgb if in_block else base_rgb
+            rows += bytes((r, g, b))
+
+    def chunk(typ, data):
+        c = typ + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+    png += chunk(b"IEND", b"")
+    with open(path, "wb") as f:
+        f.write(png)
+    return str(path)
+
+
+def test_index_image_upsert_and_text_search(client, tmp_path):
+    """Multimodal index: upsert local image files, then query by text (CLIP cross-modal).
+
+    Covers the image data path end-to-end: local image files are uploaded and stored
+    as ``image`` records, and a text query searches the image vectors. (Image-*as-query*
+    search is intentionally not asserted — it is not currently accepted by the backend
+    and fails for the legacy SDK too.)
+    """
+    images = {
+        "img-red": _make_png(tmp_path / "red.png", (200, 30, 30), (255, 255, 255)),
+        "img-green": _make_png(tmp_path / "green.png", (30, 160, 60), (0, 0, 0)),
+        "img-blue": _make_png(tmp_path / "blue.png", (30, 60, 200), (255, 255, 0)),
+    }
+
+    index = client.Index.create(
+        params=AirParams(
+            name=_unique_name("eng3148-img"),
+            description="ENG-3148 image functional test",
+            embedding_model=EmbeddingModel.JINA_CLIP_V2_MULTIMODAL,
+        )
+    )
+    try:
+        up = index.upsert(
+            [Record(uri=path, value_type=DataType.IMAGE, id=rid, attributes={"id": rid}) for rid, path in images.items()]
+        )
+        assert up.status == ResponseStatus.SUCCESS
+        assert isinstance(up.data, list) and len(up.data) == 3
+        assert all(rec["dataType"] == "image" for rec in up.data)
+        assert all(rec["uri"] for rec in up.data)  # local files were uploaded to a link
+
+        count = _wait_until(index.count, lambda c: c and c >= 3)
+        assert count >= 3
+
+        res = _wait_until(
+            lambda: index.search("a mostly red picture", top_k=3),
+            lambda r: r.status == ResponseStatus.SUCCESS and r.details,
+        )
+        assert res.status == ResponseStatus.SUCCESS
+        assert isinstance(res.details, list) and len(res.details) > 0
+        # results reference the stored image records
+        assert any(isinstance(d, dict) and d.get("document") for d in res.details)
+    finally:
+        index.delete()
 
 
 def test_index_list_resolves_by_name(client, index):

--- a/tests/functional/v2/test_index.py
+++ b/tests/functional/v2/test_index.py
@@ -1,0 +1,223 @@
+"""Functional (live) tests for the v2 Index API (ENG-3148).
+
+These exercise the full control-plane + data-plane against a real backend using
+the module-scoped ``client`` fixture (which skips when no API key is set).
+
+The final test demonstrates the ENG-3148 acceptance criterion: an
+``AiXplainVectorStore``-style wrapper implemented with **only** ``aixplain.v2``
+(no ``aixplain.factories`` import).
+"""
+
+import time
+
+import pytest
+
+from aixplain.v2.index import (
+    AirParams,
+    Index,
+    IndexFilter,
+    IndexFilterOperator,
+    Record,
+)
+from aixplain.v2.enums import EmbeddingModel, ResponseStatus
+
+
+def _unique_name(prefix: str) -> str:
+    return f"{prefix}-{int(time.time() * 1000)}"
+
+
+def _wait_until(fn, predicate, attempts: int = 12, delay: float = 2.0):
+    """Poll ``fn`` until ``predicate`` is satisfied (tolerates indexing delay)."""
+    value = None
+    for _ in range(attempts):
+        value = fn()
+        if predicate(value):
+            return value
+        time.sleep(delay)
+    return value
+
+
+@pytest.fixture()
+def index(client):
+    """Create a fresh AIR index and delete it after the test."""
+    created = client.Index.create(
+        params=AirParams(
+            name=_unique_name("eng3148-fn"),
+            description="ENG-3148 functional test",
+            embedding_model=EmbeddingModel.MULTILINGUAL_E5_LARGE,
+        )
+    )
+    try:
+        yield created
+    finally:
+        if created.id:
+            try:
+                created.delete()
+            except Exception:
+                pass
+
+
+def test_index_create_returns_v2_index(client, index):
+    """create() returns a v2-native Index instance with an ID and name."""
+    assert isinstance(index, Index)
+    assert index.id
+    assert index.name
+
+
+def test_index_data_plane_lifecycle(client, index):
+    """upsert -> count -> search -> filter -> retrieve -> get_record -> delete_record."""
+    records = [
+        Record(value="The Eiffel Tower is in Paris, France.", id="doc-1", attributes={"category": "landmark"}),
+        Record(value="The Colosseum is in Rome, Italy.", id="doc-2", attributes={"category": "landmark"}),
+        Record(value="Python is a popular programming language.", id="doc-3", attributes={"category": "tech"}),
+    ]
+    up = index.upsert(records)
+    assert up.status == ResponseStatus.SUCCESS
+    assert isinstance(up.data, list) and len(up.data) == 3
+
+    count = _wait_until(index.count, lambda c: c and c >= 3)
+    assert count >= 3
+
+    res = _wait_until(
+        lambda: index.search("where is the eiffel tower", top_k=3),
+        lambda r: r.status == ResponseStatus.SUCCESS and r.details,
+    )
+    assert res.status == ResponseStatus.SUCCESS
+    # Structured matches are returned in ``details``.
+    assert isinstance(res.details, list) and len(res.details) > 0
+
+    filtered = index.search(
+        "language",
+        top_k=5,
+        filters=[IndexFilter("category", "tech", IndexFilterOperator.EQUALS)],
+    )
+    assert filtered.status == ResponseStatus.SUCCESS
+
+    retrieved = index.retrieve_records_with_filter(
+        IndexFilter("category", "landmark", IndexFilterOperator.EQUALS)
+    )
+    assert retrieved.status == ResponseStatus.SUCCESS
+
+    got = index.get_record("doc-1")
+    assert got.status == ResponseStatus.SUCCESS
+
+    deleted = index.delete_record("doc-3")
+    assert deleted.status == ResponseStatus.SUCCESS
+
+
+def test_index_list_resolves_by_name(client, index):
+    """list() returns Index instances and resolves the collection by name."""
+    # Allow the freshly created index to propagate to the catalog.
+    match = _wait_until(
+        lambda: [ix for ix in client.Index.list(query=index.name, page_size=50) if ix.name == index.name],
+        lambda m: bool(m),
+    )
+    assert match, f"index {index.name!r} not resolvable by name"
+    assert isinstance(match[0], Index)
+    assert match[0].id == index.id
+
+
+def test_index_create_validation(client):
+    """create() rejects inconsistent argument combinations (mirrors legacy)."""
+    with pytest.raises(AssertionError):
+        client.Index.create(
+            name="x",
+            description="x",
+            params=AirParams(name="x", description="x"),
+        )
+    with pytest.raises(AssertionError):
+        client.Index.create(name="x")  # missing description
+
+
+def test_v2_only_vector_store(client):
+    """ENG-3148 acceptance: an AiXplainVectorStore built with only aixplain.v2.
+
+    This mirrors the agents-framework ``AiXplainVectorStore`` surface, proving it
+    can be implemented without the legacy ``aixplain.factories`` API.
+    """
+
+    class AiXplainVectorStore:
+        """Minimal vector store backed entirely by the v2 Index API."""
+
+        def __init__(self, aixplain_client, *, name, description="", embedding_model=EmbeddingModel.MULTILINGUAL_E5_LARGE):
+            self._client = aixplain_client
+            # Resolve an existing collection by name, else create one.
+            existing = [ix for ix in self._client.Index.list(query=name, page_size=50) if ix.name == name]
+            if existing:
+                self._index = self._client.Index.get(existing[0].id)
+            else:
+                self._index = self._client.Index.create(
+                    params=AirParams(name=name, description=description, embedding_model=embedding_model)
+                )
+
+        @property
+        def collection_id(self):
+            return self._index.id
+
+        def add(self, texts_with_ids):
+            recs = [Record(value=t, id=i, attributes=a or {}) for (i, t, a) in texts_with_ids]
+            return self._index.upsert(recs)
+
+        def query(self, text, top_k=5, category=None):
+            filters = [IndexFilter("category", category, IndexFilterOperator.EQUALS)] if category else []
+            return self._index.search(text, top_k=top_k, filters=filters)
+
+        def delete(self, record_id):
+            return self._index.delete_record(record_id)
+
+        def destroy(self):
+            return self._index.delete()
+
+    store = AiXplainVectorStore(client, name=_unique_name("eng3148-vs"), description="v2-only vector store")
+    try:
+        assert store.collection_id
+
+        add_result = store.add(
+            [
+                ("a1", "Mount Everest is the tallest mountain on Earth.", {"category": "geo"}),
+                ("a2", "The Pacific is the largest ocean.", {"category": "geo"}),
+                ("a3", "Rust is a systems programming language.", {"category": "tech"}),
+            ]
+        )
+        assert add_result.status == ResponseStatus.SUCCESS
+
+        _wait_until(store._index.count, lambda c: c and c >= 3)
+
+        result = _wait_until(
+            lambda: store.query("what is the tallest mountain", top_k=3),
+            lambda r: r.status == ResponseStatus.SUCCESS and r.details,
+        )
+        assert result.status == ResponseStatus.SUCCESS
+        assert isinstance(result.details, list) and len(result.details) > 0
+
+        tech = store.query("programming", category="tech")
+        assert tech.status == ResponseStatus.SUCCESS
+    finally:
+        store.destroy()
+
+
+def test_v2_index_module_has_no_legacy_factories_import():
+    """The v2 Index module must not *import* the legacy aixplain.factories/modules API.
+
+    Uses AST (not a substring scan) so docstring references to the legacy
+    equivalents do not produce false positives.
+    """
+    import ast
+    import inspect
+
+    import aixplain.v2.index as index_module
+
+    tree = ast.parse(inspect.getsource(index_module))
+    legacy_imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            head = node.module.split(".")
+            if head[:2] in (["aixplain", "factories"], ["aixplain", "modules"], ["aixplain", "v1"]):
+                legacy_imports.append(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                head = alias.name.split(".")
+                if head[:2] in (["aixplain", "factories"], ["aixplain", "modules"], ["aixplain", "v1"]):
+                    legacy_imports.append(alias.name)
+
+    assert not legacy_imports, f"v2 Index module imports legacy API: {legacy_imports}"

--- a/tests/functional/v2/test_index.py
+++ b/tests/functional/v2/test_index.py
@@ -105,6 +105,79 @@ def test_index_data_plane_lifecycle(client, index):
     assert deleted.status == ResponseStatus.SUCCESS
 
 
+def _make_minimal_pdf(lines) -> bytes:
+    """Build a tiny but valid single-page PDF (with /MediaBox) from text lines."""
+    text = b"BT /F1 18 Tf 72 720 Td "
+    text += b" ".join(b"(" + line.encode() + b") Tj 0 -26 Td" for line in lines)
+    text += b" ET"
+    objs = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        b"<< /Length " + str(len(text)).encode() + b" >>\nstream\n" + text + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    pdf = b"%PDF-1.4\n"
+    offsets = []
+    for i, obj in enumerate(objs, start=1):
+        offsets.append(len(pdf))
+        pdf += str(i).encode() + b" 0 obj\n" + obj + b"\nendobj\n"
+    xref_pos = len(pdf)
+    pdf += b"xref\n0 " + str(len(objs) + 1).encode() + b"\n0000000000 65535 f \n"
+    for off in offsets:
+        pdf += ("%010d 00000 n \n" % off).encode()
+    pdf += b"trailer\n<< /Size " + str(len(objs) + 1).encode() + b" /Root 1 0 R >>\nstartxref\n"
+    pdf += str(xref_pos).encode() + b"\n%%EOF"
+    return pdf
+
+
+def test_index_upsert_txt_file(client, index, tmp_path):
+    """upsert(path) ingests a .txt file via the client-side plain-read path."""
+    f = tmp_path / "quokka.txt"
+    f.write_text("The quokka is a small marsupial native to Western Australia.")
+
+    up = index.upsert(str(f))
+    assert up.status == ResponseStatus.SUCCESS
+    assert isinstance(up.data, list) and len(up.data) == 1
+    assert "quokka" in up.data[0]["data"].lower()
+
+    _wait_until(index.count, lambda c: c and c >= 1)
+    res = _wait_until(
+        lambda: index.search("where do quokkas live", top_k=2),
+        lambda r: r.status == ResponseStatus.SUCCESS and r.details,
+    )
+    assert res.details and "quokka" in str(res.details).lower()
+
+
+def test_index_upsert_pdf_file_via_docling(client, index, tmp_path):
+    """upsert(path) ingests a .pdf by uploading and parsing it server-side (Docling)."""
+    f = tmp_path / "photosynthesis.pdf"
+    f.write_bytes(
+        _make_minimal_pdf(
+            [
+                "Photosynthesis converts sunlight into chemical energy.",
+                "Chlorophyll absorbs light and plants produce glucose and oxygen.",
+            ]
+        )
+    )
+
+    up = index.upsert(str(f))
+    assert up.status == ResponseStatus.SUCCESS
+    assert isinstance(up.data, list) and len(up.data) == 1
+    assert "photosynth" in up.data[0]["data"].lower()
+
+    _wait_until(index.count, lambda c: c and c >= 1)
+    res = _wait_until(
+        lambda: index.search("how do plants make energy from sunlight", top_k=2),
+        lambda r: r.status == ResponseStatus.SUCCESS and r.details,
+    )
+    assert res.details
+    assert any(
+        kw in str(res.details).lower() for kw in ("photosynth", "chlorophyll", "glucose")
+    )
+
+
 def test_index_list_resolves_by_name(client, index):
     """list() returns Index instances and resolves the collection by name."""
     # Allow the freshly created index to propagate to the catalog.

--- a/tests/unit/v2/test_index.py
+++ b/tests/unit/v2/test_index.py
@@ -274,6 +274,42 @@ class TestDataPlane:
         with pytest.raises(Exception):
             idx.count()
 
+    def test_count_async_zero_does_not_crash(self):
+        """A zero count via the async-poll path must return 0, not raise on int({})."""
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "IN_PROGRESS", "data": "https://poll.test/c"})
+        # poll() coerces falsy data to {}; backfill from raw must restore 0.
+        ctx.client.get = Mock(return_value={"status": "SUCCESS", "completed": True, "data": 0})
+        idx = _index(ctx)
+
+        assert idx.count(timeout=5) == 0
+
+    def test_search_async_preserves_details(self):
+        """Structured `details` must survive the async-poll path (poll() drops them)."""
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "IN_PROGRESS", "data": "https://poll.test/s"})
+        ctx.client.get = Mock(
+            return_value={
+                "status": "SUCCESS",
+                "completed": True,
+                "data": "top match",
+                "details": [{"score": 0.9, "data": "top match"}],
+            }
+        )
+        idx = _index(ctx)
+
+        result = idx.search("q", timeout=5)
+        assert result.data == "top match"
+        assert result.details == [{"score": 0.9, "data": "top match"}]
+
+    def test_generic_run_disabled(self):
+        """Index.run()/run_async() must raise, not send a malformed payload."""
+        idx = _index()
+        with pytest.raises(NotImplementedError):
+            idx.run(query="x")
+        with pytest.raises(NotImplementedError):
+            idx.run_async(query="x")
+
 
 # ---------------------------------------------------------------------------
 # Control-plane

--- a/tests/unit/v2/test_index.py
+++ b/tests/unit/v2/test_index.py
@@ -330,7 +330,7 @@ class TestControlPlane:
         ctx = _ctx()
         ctx.client.request = Mock(
             return_value={
-                "results": [
+                "items": [
                     {"id": "a", "name": "alpha"},
                     {"id": "b", "name": "beta"},
                 ],
@@ -345,10 +345,11 @@ class TestControlPlane:
         names = [ix.name for ix in page]
         assert names == ["alpha", "beta"]
         assert all(isinstance(ix, Index) for ix in page)
-        # function filter is SEARCH and endpoint is the paginate endpoint
+        # function filter is SEARCH and endpoint is the proven paginate endpoint
         method, url = ctx.client.request.call_args[0]
-        assert (method, url) == ("post", "v2/models/paginate")
-        assert ctx.client.request.call_args.kwargs["json"]["functions"] == [{"id": "search"}]
+        assert (method, url) == ("post", "sdk/models/paginate")
+        assert ctx.client.request.call_args.kwargs["json"]["functions"] == ["search"]
+        assert ctx.client.request.call_args.kwargs["headers"]["Authorization"] == "Token test-key"
 
     def test_delete(self):
         ctx = _ctx()

--- a/tests/unit/v2/test_index.py
+++ b/tests/unit/v2/test_index.py
@@ -1,0 +1,368 @@
+"""Unit tests for the v2 Index resource (ENG-3148).
+
+These tests exercise the typed v2 Index API (control-plane + data-plane and the
+supporting types) with a mocked client context, mirroring the coverage of the
+legacy ``tests/unit/index_model_test.py`` without performing any network I/O.
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from aixplain.v2.enums import DataType, EmbeddingModel, ResponseStatus
+from aixplain.v2.index import (
+    AirParams,
+    GraphRAGParams,
+    Index,
+    IndexFilter,
+    IndexFilterOperator,
+    IndexResult,
+    Record,
+    Splitter,
+    VectaraParams,
+    ZeroEntropyParams,
+)
+
+MODEL_URL = "https://models.test/api/v2/execute"
+INDEX_ID = "idx-1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _ctx():
+    """Build a mocked Aixplain context."""
+    ctx = Mock()
+    ctx.model_url = MODEL_URL
+    ctx.api_key = "test-key"
+    ctx.client = Mock()
+    return ctx
+
+
+def _index(ctx=None, index_id=INDEX_ID, name="my-index"):
+    """Build an Index instance bound to a (mocked) context."""
+    ctx = ctx or _ctx()
+    idx = Index.from_dict({"id": index_id, "name": name})
+    idx.context = ctx
+    return idx
+
+
+def _index_cls(ctx):
+    """Build a context-bound Index subclass (as the client does dynamically)."""
+    return type("Index", (Index,), {"context": ctx})
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+class TestRecord:
+    def test_to_dict_text(self):
+        record = Record(value="test", value_type=DataType.TEXT, id="0", uri="", attributes={})
+        d = record.to_dict()
+        assert d == {"data": "test", "dataType": "text", "document_id": "0", "uri": "", "attributes": {}}
+
+    def test_to_dict_image(self):
+        record = Record(value="", value_type=DataType.IMAGE, id="0", uri="https://x.com/a.jpg")
+        d = record.to_dict()
+        assert d["dataType"] == "image"
+        assert d["uri"] == "https://x.com/a.jpg"
+
+    def test_auto_id(self):
+        assert Record(value="x").id  # a UUID is generated
+
+    def test_validate_text_ok(self):
+        Record(value="hello").validate()  # no raise
+
+    def test_validate_invalid_type(self):
+        with pytest.raises(AssertionError) as e:
+            Record(value="x", value_type="video").validate()
+        assert str(e.value) == "Index Upsert Error: Invalid value type"
+
+    def test_validate_image_requires_uri(self):
+        with pytest.raises(AssertionError) as e:
+            Record(value="x", value_type=DataType.IMAGE, uri="").validate()
+        assert str(e.value) == "Index Upsert Error: URI is required for image records"
+
+    def test_validate_text_requires_value_or_uri(self):
+        with pytest.raises(AssertionError) as e:
+            Record(value="", value_type=DataType.TEXT, uri="").validate()
+        assert str(e.value) == "Index Upsert Error: Either value or uri is required for text records"
+
+    def test_validate_local_image_uploaded_and_promoted(self, monkeypatch):
+        import aixplain.v2.index as index_mod
+
+        monkeypatch.setattr(index_mod, "_check_storage_type", lambda v: "file")
+        monkeypatch.setattr(index_mod, "_is_supported_image_type", lambda v: True)
+        monkeypatch.setattr(index_mod, "upload_file", lambda v: "https://hosted/test.jpg")
+
+        record = Record(value="", value_type=DataType.IMAGE, uri="test.jpg")
+        record.validate()
+        assert record.value_type == DataType.IMAGE
+        assert record.uri == "https://hosted/test.jpg"
+
+
+class TestFilterAndSplitter:
+    def test_index_filter_to_dict(self):
+        f = IndexFilter(field="category", value="world", operator=IndexFilterOperator.EQUALS)
+        assert f.to_dict() == {"field": "category", "value": "world", "operator": "=="}
+
+    def test_index_filter_string_operator(self):
+        f = IndexFilter(field="c", value="v", operator="!=")
+        assert f.to_dict()["operator"] == "!="
+
+    def test_splitter(self):
+        s = Splitter(split=True, split_by="sentence", split_length=100, split_overlap=5)
+        assert (s.split, s.split_by, s.split_length, s.split_overlap) == (True, "sentence", 100, 5)
+
+
+class TestParams:
+    def test_air_params(self):
+        p = AirParams(name="docs", description="d")
+        assert p.id == "66eae6656eb56311f2595011"
+        assert p.to_dict() == {
+            "description": "d",
+            "data": "docs",
+            "model": EmbeddingModel.OPENAI_ADA002.value,
+        }
+
+    def test_air_params_with_size(self):
+        p = AirParams(name="docs", description="d", embedding_model=EmbeddingModel.BGE_M3, embedding_size=1024)
+        d = p.to_dict()
+        assert d["model"] == EmbeddingModel.BGE_M3.value
+        assert d["additional_params"] == {"embedding_size": 1024}
+
+    def test_vectara_params(self):
+        p = VectaraParams(name="v", description="d")
+        assert p.id == "655e20f46eb563062a1aa301"
+        assert "model" not in p.to_dict()
+
+    def test_zeroentropy_params(self):
+        p = ZeroEntropyParams(name="z", description="d")
+        assert p.id == "6807949168e47e7844c1f0c5"
+
+    def test_graphrag_params(self):
+        p = GraphRAGParams(name="g", description="d", llm="some-llm")
+        assert p.id == "67dd6d487cbf0a57cf4b72f3"
+        assert p.to_dict()["llm"] == "some-llm"
+
+
+class TestIndexResult:
+    def test_from_minimal_dict(self):
+        r = IndexResult.from_dict({"status": "SUCCESS", "data": 4})
+        assert r.status == "SUCCESS"
+        assert r.completed is True
+        assert r.data == 4
+
+
+# ---------------------------------------------------------------------------
+# Data-plane
+# ---------------------------------------------------------------------------
+class TestDataPlane:
+    def test_search_text(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": [{"id": "1"}], "completed": True})
+        idx = _index(ctx)
+
+        result = idx.search("hello", top_k=3)
+
+        assert isinstance(result, IndexResult)
+        assert result.status == ResponseStatus.SUCCESS
+        method, url = ctx.client.request.call_args[0]
+        payload = ctx.client.request.call_args.kwargs["json"]
+        assert method == "post"
+        assert url == f"{MODEL_URL}/{INDEX_ID}"
+        assert payload["action"] == "search"
+        assert payload["data"] == "hello"
+        assert payload["dataType"] == "text"
+        assert payload["payload"]["top_k"] == 3
+        assert payload["filters"] == []
+
+    def test_search_with_filters(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": [], "completed": True})
+        idx = _index(ctx)
+
+        idx.search("q", filters=[IndexFilter("category", "tech", IndexFilterOperator.EQUALS)])
+
+        payload = ctx.client.request.call_args.kwargs["json"]
+        assert payload["filters"] == [{"field": "category", "value": "tech", "operator": "=="}]
+
+    def test_upsert_text_echoes_payloads(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "completed": True})
+        idx = _index(ctx)
+
+        records = [Record(value="a", id="1"), Record(value="b", id="2")]
+        result = idx.upsert(records)
+
+        payload = ctx.client.request.call_args.kwargs["json"]
+        assert payload["action"] == "ingest"
+        assert len(payload["data"]) == 2
+        # On success, the result echoes the ingested payloads.
+        assert isinstance(result.data, list) and len(result.data) == 2
+        assert result.data[0]["document_id"] == "1"
+
+    def test_upsert_with_splitter(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "completed": True})
+        idx = _index(ctx)
+
+        idx.upsert([Record(value="a", id="1")], splitter=Splitter(split=True, split_length=400, split_overlap=50))
+
+        payload = ctx.client.request.call_args.kwargs["json"]
+        assert payload["additional_params"]["splitter"]["split"] is True
+        assert payload["additional_params"]["splitter"]["split_length"] == 400
+
+    def test_count(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": 4})
+        idx = _index(ctx)
+
+        assert idx.count() == 4
+        assert ctx.client.request.call_args.kwargs["json"] == {"action": "count", "data": ""}
+
+    def test_get_record(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": {"id": "1"}, "completed": True})
+        idx = _index(ctx)
+
+        result = idx.get_record("1")
+        assert result.status == ResponseStatus.SUCCESS
+        assert ctx.client.request.call_args.kwargs["json"] == {"action": "get_document", "data": "1"}
+
+    def test_delete_record(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "completed": True})
+        idx = _index(ctx)
+
+        idx.delete_record("1")
+        assert ctx.client.request.call_args.kwargs["json"] == {"action": "delete", "data": "1"}
+
+    def test_retrieve_records_with_filter(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": [], "completed": True})
+        idx = _index(ctx)
+
+        idx.retrieve_records_with_filter(IndexFilter("category", "world", IndexFilterOperator.EQUALS))
+        payload = ctx.client.request.call_args.kwargs["json"]
+        assert payload["action"] == "retrieve_by_filter"
+        assert payload["data"] == {"field": "category", "value": "world", "operator": "=="}
+
+    def test_delete_records_by_date(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "completed": True})
+        idx = _index(ctx)
+
+        idx.delete_records_by_date(1717708800)
+        assert ctx.client.request.call_args.kwargs["json"] == {"action": "delete_by_date", "data": 1717708800}
+
+    def test_search_async_polls(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "IN_PROGRESS", "data": "https://poll.test/abc"})
+        ctx.client.get = Mock(return_value={"status": "SUCCESS", "completed": True, "data": [{"id": "1"}]})
+        idx = _index(ctx)
+
+        result = idx.search("q", timeout=5)
+        assert result.completed is True
+        assert result.status == ResponseStatus.SUCCESS
+        ctx.client.get.assert_called_with("https://poll.test/abc")
+
+    def test_failed_action_raises(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "FAILED", "error_message": "boom", "completed": True})
+        idx = _index(ctx)
+
+        with pytest.raises(Exception):
+            idx.count()
+
+
+# ---------------------------------------------------------------------------
+# Control-plane
+# ---------------------------------------------------------------------------
+class TestControlPlane:
+    def test_create_with_params(self):
+        ctx = _ctx()
+        # store-model run returns the new collection ID in `data`
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": "new-collection-id", "completed": True})
+        # subsequent get of the new collection
+        ctx.client.get = Mock(return_value={"id": "new-collection-id", "name": "docs"})
+        cls = _index_cls(ctx)
+
+        index = cls.create(params=AirParams(name="docs", description="d"))
+
+        assert isinstance(index, Index)
+        assert index.id == "new-collection-id"
+        # store model run hit the AIR model id
+        run_url = ctx.client.request.call_args[0][1]
+        assert run_url == f"{MODEL_URL}/66eae6656eb56311f2595011"
+        assert ctx.client.request.call_args.kwargs["json"]["data"] == "docs"
+
+    def test_create_legacy_args(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": "new-id", "completed": True})
+        ctx.client.get = Mock(return_value={"id": "new-id", "name": "n"})
+        cls = _index_cls(ctx)
+
+        index = cls.create(name="n", description="d", embedding_model=EmbeddingModel.OPENAI_ADA002)
+        assert index.id == "new-id"
+        payload = ctx.client.request.call_args.kwargs["json"]
+        assert payload == {"data": "n", "description": "d", "model": EmbeddingModel.OPENAI_ADA002.value}
+
+    def test_create_rejects_params_and_name(self):
+        cls = _index_cls(_ctx())
+        with pytest.raises(AssertionError):
+            cls.create(name="n", description="d", params=AirParams(name="n", description="d"))
+
+    def test_create_requires_legacy_fields(self):
+        cls = _index_cls(_ctx())
+        with pytest.raises(AssertionError):
+            cls.create(name="n")  # missing description
+
+    def test_create_failure_raises(self):
+        from aixplain.v2.exceptions import ResourceError
+
+        ctx = _ctx()
+        ctx.client.request = Mock(return_value={"status": "SUCCESS", "data": "", "completed": True})
+        cls = _index_cls(ctx)
+        with pytest.raises(ResourceError):
+            cls.create(params=AirParams(name="n", description="d"))
+
+    def test_list_resolves_by_name(self):
+        ctx = _ctx()
+        ctx.client.request = Mock(
+            return_value={
+                "results": [
+                    {"id": "a", "name": "alpha"},
+                    {"id": "b", "name": "beta"},
+                ],
+                "total": 2,
+                "pageTotal": 2,
+            }
+        )
+        cls = _index_cls(ctx)
+
+        page = cls.list(query="alpha")
+        assert page.total == 2
+        names = [ix.name for ix in page]
+        assert names == ["alpha", "beta"]
+        assert all(isinstance(ix, Index) for ix in page)
+        # function filter is SEARCH and endpoint is the paginate endpoint
+        method, url = ctx.client.request.call_args[0]
+        assert (method, url) == ("post", "v2/models/paginate")
+        assert ctx.client.request.call_args.kwargs["json"]["functions"] == [{"id": "search"}]
+
+    def test_delete(self):
+        ctx = _ctx()
+        ctx.client.request_raw = Mock(return_value=Mock(status_code=200))
+        idx = _index(ctx, index_id="to-delete")
+
+        result = idx.delete()
+
+        assert result.deleted_id == "to-delete"
+        assert result.status == ResponseStatus.SUCCESS
+        assert idx.is_deleted is True
+        method, url = ctx.client.request_raw.call_args[0]
+        assert method == "delete"
+        assert url == "sdk/models/to-delete"
+        # legacy-compatible auth header
+        headers = ctx.client.request_raw.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Token test-key"

--- a/tests/unit/v2/test_upload_utils.py
+++ b/tests/unit/v2/test_upload_utils.py
@@ -1,0 +1,41 @@
+"""Unit tests for v2 upload_utils.S3Uploader.construct_s3_url (ENG-3148).
+
+Regression coverage for the bucket-extraction bug: path-style presigned URLs
+(returned by some backends, e.g. dev) were not recognised and silently fell
+back to a hardcoded ``aixplain-uploads`` bucket, producing wrong-bucket links
+that broke downstream file fetches (e.g. Docling parsing during index upsert).
+"""
+
+from aixplain.v2.upload_utils import S3Uploader
+
+KEY = "1/sdk/1700000000-doc.pdf"
+
+
+def test_path_style_url_extracts_real_bucket():
+    """Path-style URL (the dev shape) must yield the real bucket, not the fallback."""
+    url = (
+        "https://s3.amazonaws.com/aixplain-platform-backend-temp-dev/"
+        "1/sdk/1700000000-doc.pdf?AWSAccessKeyId=ABC&Expires=1&Signature=z"
+    )
+    assert S3Uploader.construct_s3_url(url, KEY) == f"s3://aixplain-platform-backend-temp-dev/{KEY}"
+
+
+def test_path_style_regional_url():
+    url = "https://s3.us-east-1.amazonaws.com/my-bucket/key?X=y"
+    assert S3Uploader.construct_s3_url(url, KEY) == f"s3://my-bucket/{KEY}"
+
+
+def test_virtual_hosted_url_preserved():
+    url = "https://aixplain-uploads.s3.amazonaws.com/1/sdk/doc.pdf?sig=1"
+    assert S3Uploader.construct_s3_url(url, KEY) == f"s3://aixplain-uploads/{KEY}"
+
+
+def test_virtual_hosted_regional_url():
+    """Regional virtual-hosted URLs were also unhandled by the old regex."""
+    url = "https://my-bucket.s3.eu-west-1.amazonaws.com/key?sig=1"
+    assert S3Uploader.construct_s3_url(url, KEY) == f"s3://my-bucket/{KEY}"
+
+
+def test_unrecognized_url_falls_back():
+    url = "https://example.com/whatever"
+    assert S3Uploader.construct_s3_url(url, KEY) == f"s3://aixplain-uploads/{KEY}"


### PR DESCRIPTION
## What

Adds an **Index API to `aixplain.v2`** — the v2 equivalent of the legacy `IndexFactory` / `IndexModel`. Exposed as `client.Index` and returns v2-native types throughout.

- **Control-plane:** `Index.create(params=...)`, `Index.list(query=...)` (resolve a collection by name), `Index.get(id)`, `index.delete()`
- **Data-plane:** `upsert`, `search(query, top_k, filters)`, `count`, `get_record`, `delete_record`, `retrieve_records_with_filter`, `delete_records_by_date`
- **Typed primitives:** `Record`, `IndexFilter` / `IndexFilterOperator`, `Splitter`, the index params (`AirParams`, `VectaraParams`, `GraphRAGParams`, `ZeroEntropyParams`), and new `EmbeddingModel` / `IndexStores` enums
- **File ingestion:** `upsert("notes.txt")` (read locally) and `upsert("doc.pdf")` (uploaded + parsed server-side via Docling)
- Drive-by fix: `upload_utils.construct_s3_url` now handles path-style S3 presigned URLs (it previously only matched virtual-hosted-style and fell back to the wrong bucket) — this is what was breaking file uploads on dev.

## Why

The agents framework is v2-only (`from aixplain.v2 import Aixplain`) and must not touch `aixplain.factories`. Until now `aixplain.v2` had no Index API, so the VectorStore work (ENG-3105) was forced to fall back to the legacy `IndexFactory` / `IndexModel` behind a documented seam. This fills that gap so `AiXplainVectorStore` can be rewritten to use **only** `aixplain.v2`.

Jira: ENG-3148.

## How

- `Index` is a self-contained `BaseResource` + `GetResourceMixin` + `RunnableResourceMixin`. Data-plane methods post `{"action", "data"}` to the model-run endpoint and reuse the existing run/poll machinery; `create` runs the store model and resolves the new collection; `list` hits `sdk/models/paginate` filtered to search models; `delete` hits `sdk/models/{id}`.
- No v1 imports — guarded by the existing `tests/unit/v2/test_no_v1_imports.py`, so authenticating via `Aixplain()` never pulls in the legacy env-var chain.
- Tests: unit tests with a mocked client, plus live functional tests (full lifecycle, a v2-only `AiXplainVectorStore` demo, and `.txt` / `.pdf` file ingestion).

## How to test

```python
from aixplain.v2 import Aixplain
from aixplain.v2.index import AirParams, Record

ix = Aixplain().Index.create(params=AirParams(name="demo", description="demo"))
ix.upsert([Record(value="Paris is the capital of France.")])
print(ix.search("capital of France").details)
ix.delete()
```

Unit: `pytest tests/unit/v2/test_index.py` — Live: `TEAM_API_KEY=... pytest tests/functional/v2/test_index.py`

## Notes

- **Images / multimodal:** indexing images works — local image files are uploaded and stored as `image` records on a JINA CLIP v2 index, and **text→image** search works (covered by a functional test). **Image-as-query** search is *not* currently accepted by the backend (`"Either query or query_embedding is required"`); the legacy `IndexModel.search` fails the same way, so this is a backend limitation rather than something introduced here.
- The `construct_s3_url` fix is what makes file/image uploads resolve to the correct bucket on environments that hand back path-style presigned URLs (e.g. dev).
