### PR TITLE
feat(v2): override aiXplain tool parameters in agent create/run payloads

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -235,6 +235,9 @@ class AgentRunParams(BaseRunParams):
             The backend performs the actual substitution.
         allow_history_and_session_id: Allow both history and session ID
         tasks: List of tasks for the agent
+        tools: Per-tool parameter overrides for this run, as a list of
+            ``{"id": <tool_id>, "parameters": {...}}`` dicts (or plain string
+            ids). Overrides the agent's persisted per-tool parameters by id.
         prompt: Custom prompt override
         history: Conversation history
         execution_params: Execution parameters (maxTokens, etc.)
@@ -253,6 +256,7 @@ class AgentRunParams(BaseRunParams):
     variables: NotRequired[Optional[Dict[str, Any]]]
     allow_history_and_session_id: NotRequired[Optional[bool]]
     tasks: NotRequired[Optional[List[Any]]]
+    tools: NotRequired[Optional[List[Union[str, Dict[str, Any]]]]]
     prompt: NotRequired[Optional[Text]]
     history: NotRequired[Optional[List[ConversationMessage]]]
     execution_params: NotRequired[Optional[Dict[str, Any]]]
@@ -1041,6 +1045,26 @@ class Agent(
 
         return super().search(**kwargs)
 
+    @classmethod
+    def _normalize_tool_for_api(cls, tool: Any) -> dict:
+        """Normalize one ``tools`` entry into the API dict shape.
+
+        Accepts the user-facing shapes shared by create and run (issue #966):
+        a plain string id, a ``{id, parameters: {...}}`` dict, or a
+        :class:`ToolableMixin` (e.g. a ``Model``) whose ``as_tool()`` snapshot
+        is used. Per-tool ``parameters`` are converted to the platform's
+        ``[{name, value}]`` shape inside :meth:`_normalize_tool_dict_for_api`.
+        """
+        if isinstance(tool, str):
+            return {"id": tool}
+        if isinstance(tool, ToolableMixin):
+            return cls._normalize_tool_dict_for_api(tool.as_tool())
+        if isinstance(tool, dict):
+            return cls._normalize_tool_dict_for_api(tool)
+        raise ValueError(
+            f"A tool must be a Tool, Model, ToolableMixin instance, a string id, or a dictionary, got {type(tool)}."
+        )
+
     @staticmethod
     def _normalize_tool_dict_for_api(tool_dict: dict) -> dict:
         """Convert snake_case keys in a tool dict to the camelCase the API expects."""
@@ -1052,7 +1076,14 @@ class Agent(
         result = {}
         for k, v in tool_dict.items():
             api_key = _KEY_MAP.get(k, k)
-            if api_key == "parameters" and isinstance(v, list):
+            if api_key == "parameters" and isinstance(v, dict):
+                # User-facing per-tool override shape ``{key: value}`` (issue
+                # #966) -> platform NameValue list. The LLM may override these
+                # at run time; the SDK only transports them.
+                result[api_key] = Agent._params_dict_to_namevalue_list(v)
+            elif api_key == "parameters" and isinstance(v, list):
+                # Snapshot from ``as_tool()`` -> list of full parameter
+                # definitions; normalize each definition's keys to camelCase.
                 result[api_key] = [Agent._normalize_parameter_for_api(p) for p in v]
             else:
                 result[api_key] = v
@@ -1276,14 +1307,7 @@ class Agent(
         converted_assets = []
         if self.tools:
             for tool in self.tools:
-                if isinstance(tool, ToolableMixin):
-                    converted_assets.append(self._normalize_tool_dict_for_api(tool.as_tool()))
-                elif isinstance(tool, dict):
-                    converted_assets.append(self._normalize_tool_dict_for_api(tool))
-                else:
-                    raise ValueError(
-                        "A tool in the agent must be a Tool, Model, ToolableMixin instance, or a dictionary."
-                    )
+                converted_assets.append(self._normalize_tool_for_api(tool))
 
         # Update the payload with converted assets
         payload["tools"] = converted_assets
@@ -1365,6 +1389,13 @@ class Agent(
         variables = kwargs.pop("variables", None) or {}
         query = kwargs.pop("query", None)
 
+        # Run-time per-tool parameter overrides (issue #966). Same user-facing
+        # shape as create — ``[{id, parameters: {...}}]`` — normalized to the
+        # API ``[{name, value}]`` shape. Overrides persisted per-tool params by
+        # tool id (the backend merges by id). Popped here so the generic kwargs
+        # loop below doesn't forward the raw, un-normalized list.
+        tools = kwargs.pop("tools", None)
+
         # Build input_data dict with query and variables
         if query is not None:
             if isinstance(query, dict):
@@ -1396,6 +1427,9 @@ class Agent(
             if value is not None:
                 api_key = self._SNAKE_TO_CAMEL.get(key, key)
                 payload[api_key] = value
+
+        if tools:
+            payload["tools"] = [self._normalize_tool_for_api(tool) for tool in tools]
 
         self._apply_llm_fields_to_run_payload(payload)
         return payload

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1481,6 +1481,7 @@ class Agent(
         evolve: Optional[str] = None,
         identifier: Optional[str] = None,
         run_response_generation: Optional[bool] = None,
+        tools: Optional[List[Union[str, Dict[str, Any]]]] = None,
     ) -> "Session":
         """Create a new backend-managed session for this agent.
 
@@ -1505,6 +1506,12 @@ class Agent(
                 messages.
             run_response_generation: Whether the agent should run its
                 final response-generation step.
+            tools: Session-level per-tool parameter overrides in the same
+                user-facing shape as ``agent.run`` — a list of
+                ``{"id": <tool_id>, "parameters": {...}}`` dicts (or plain
+                string ids). Persisted on the session's ``executionConfig``;
+                a per-message ``tools`` override (see ``add_message`` /
+                ``run(via_session=True, tools=...)``) wins over these by id.
 
         Returns:
             Session: The created Session instance, pre-populated with
@@ -1541,6 +1548,7 @@ class Agent(
             evolve=evolve,
             identifier=identifier,
             run_response_generation=run_response_generation,
+            tools=tools,
         )
 
         session = self.context.Session(agent_id=self.id, name=name, execution_config=config)
@@ -1557,28 +1565,33 @@ class Agent(
 
         return session
 
-    @staticmethod
+    @classmethod
     def _resolve_execution_config(
+        cls,
         execution_config: Optional[Union["ExecutionConfig", Dict[str, Any]]] = None,
         execution_params: Optional[Dict[str, Any]] = None,
         criteria: Optional[str] = None,
         evolve: Optional[str] = None,
         identifier: Optional[str] = None,
         run_response_generation: Optional[bool] = None,
+        tools: Optional[List[Union[str, Dict[str, Any]]]] = None,
     ) -> Optional["ExecutionConfig"]:
         """Combine the explicit and shortcut forms into one ExecutionConfig.
 
         Returns ``None`` when neither form supplies any value so the
-        Session save payload omits ``executionConfig`` entirely.
+        Session save payload omits ``executionConfig`` entirely. ``tools`` is
+        normalized to the platform ``[{id, parameters: [{name, value}]}]``
+        shape before being stored on the config.
         """
         from .session import ExecutionConfig
 
-        shortcut_values = {
+        shortcut_values: Dict[str, Any] = {
             "execution_params": execution_params,
             "criteria": criteria,
             "evolve": evolve,
             "identifier": identifier,
             "run_response_generation": run_response_generation,
+            "tools": [cls._normalize_tool_for_api(tool) for tool in tools] if tools is not None else None,
         }
         has_shortcut = any(v is not None for v in shortcut_values.values())
 
@@ -1586,7 +1599,7 @@ class Agent(
             raise ValueError(
                 "Pass either 'execution_config' or the individual shortcut "
                 "kwargs (execution_params, criteria, evolve, identifier, "
-                "run_response_generation), not both."
+                "run_response_generation, tools), not both."
             )
 
         if execution_config is not None:
@@ -1709,11 +1722,18 @@ class Agent(
                 run_response_generation=kwargs.get("run_response_generation"),
             )
 
+        # Run-time ``tools`` becomes the per-message override (issue #966 shape),
+        # winning over any session-level executionConfig.tools by tool id. Before
+        # this the via_session path silently dropped ``tools`` (PROD-2481).
+        run_tools = kwargs.get("tools")
+        message_tools = [self._normalize_tool_for_api(tool) for tool in run_tools] if run_tools else None
+
         user_msg = session.add_message(
             role="user",
             content=query,
             attachments=kwargs.get("attachments"),
             files=kwargs.get("files"),
+            tools=message_tools,
         )
         if not user_msg.request_id:
             raise ValueError(

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1054,16 +1054,65 @@ class Agent(
         :class:`ToolableMixin` (e.g. a ``Model``) whose ``as_tool()`` snapshot
         is used. Per-tool ``parameters`` are converted to the platform's
         ``[{name, value}]`` shape inside :meth:`_normalize_tool_dict_for_api`.
+
+        The string-id and ``{id, parameters}`` shapes carry no ``type``, which
+        the create payload requires. For those, resolve the asset by id to its
+        ``as_tool()`` snapshot (which carries the correct ``type``) and overlay
+        the per-tool ``parameters`` override. A dict that already has a ``type``
+        (e.g. a full ``as_tool()`` snapshot) is passed through unchanged.
         """
-        if isinstance(tool, str):
-            return {"id": tool}
         if isinstance(tool, ToolableMixin):
             return cls._normalize_tool_dict_for_api(tool.as_tool())
+        if isinstance(tool, str):
+            return cls._normalize_tool_dict_for_api(cls._resolve_tool_entry(tool, None))
         if isinstance(tool, dict):
-            return cls._normalize_tool_dict_for_api(tool)
+            if tool.get("type") or not tool.get("id"):
+                return cls._normalize_tool_dict_for_api(tool)
+            return cls._normalize_tool_dict_for_api(cls._resolve_tool_entry(tool["id"], tool))
         raise ValueError(
             f"A tool must be a Tool, Model, ToolableMixin instance, a string id, or a dictionary, got {type(tool)}."
         )
+
+    @classmethod
+    def _resolve_tool_entry(cls, tool_id: str, override: Optional[dict]) -> dict:
+        """Build a typed tool dict for ``tool_id`` from its ``as_tool()`` snapshot.
+
+        Resolves the asset by id (Tool, then Model) so the entry carries the
+        backend-required ``type`` and other snapshot fields, then overlays the
+        caller-provided keys (e.g. a ``parameters`` override) so the override
+        wins. Falls back to a bare ``{"id": tool_id}`` (plus any override) when
+        the id can't be resolved — preserving the prior behavior offline.
+        """
+        snapshot = cls._resolve_tool_snapshot(tool_id)
+        entry: dict = dict(snapshot) if snapshot else {}
+        entry["id"] = tool_id
+        if isinstance(override, dict):
+            for key, value in override.items():
+                if key != "id":
+                    entry[key] = value
+        return entry
+
+    @classmethod
+    def _resolve_tool_snapshot(cls, tool_id: str) -> Optional[dict]:
+        """Return the ``as_tool()`` snapshot for ``tool_id``, or ``None``.
+
+        Tries the ``Tool`` resource first, then ``Model`` (mirroring how the
+        platform resolves an asset id). Any failure (no client context,
+        unknown id, network error) yields ``None`` so normalization degrades
+        gracefully instead of raising.
+        """
+        context = getattr(cls, "context", None)
+        if context is None:
+            return None
+        for resource_name in ("Tool", "Model"):
+            resource = getattr(context, resource_name, None)
+            if resource is None:
+                continue
+            try:
+                return dict(resource.get(tool_id).as_tool())
+            except Exception:
+                continue
+        return None
 
     @staticmethod
     def _normalize_tool_dict_for_api(tool_dict: dict) -> dict:

--- a/aixplain/v2/session.py
+++ b/aixplain/v2/session.py
@@ -181,6 +181,10 @@ class ExecutionConfig:
             messages (e.g. for client-side correlation).
         run_response_generation: Whether the agent should run its final
             response-generation step.
+        tools: Session-level per-tool parameter overrides, already in the
+            platform ``[{id, parameters: [{name, value}]}]`` shape (normalized
+            by ``Agent._normalize_tool_for_api``). A per-message ``tools``
+            override on ``add_message`` wins over these by tool id.
     """
 
     execution_params: Optional[Dict[str, Any]] = field(default=None, metadata=config(field_name="executionParams"))
@@ -188,6 +192,7 @@ class ExecutionConfig:
     evolve: Optional[str] = None
     identifier: Optional[str] = None
     run_response_generation: Optional[bool] = field(default=None, metadata=config(field_name="runResponseGeneration"))
+    tools: Optional[List[Dict[str, Any]]] = None
 
     def to_api_dict(self) -> Dict[str, Any]:
         """Build the camelCase API payload, normalizing nested params.
@@ -207,6 +212,8 @@ class ExecutionConfig:
             out["identifier"] = self.identifier
         if self.run_response_generation is not None:
             out["runResponseGeneration"] = self.run_response_generation
+        if self.tools is not None:
+            out["tools"] = self.tools
         return out
 
     @classmethod
@@ -343,6 +350,7 @@ class Session(
         request_id: Optional[str] = None,
         attachments: Optional[List[Dict[str, Any]]] = None,
         files: Optional[List[Union[str, Path]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
     ) -> SessionMessage:
         """Add a message to this session.
 
@@ -352,6 +360,10 @@ class Session(
             request_id: Optional request ID to associate with the message.
             attachments: Pre-built attachment dicts with url, name, type keys.
             files: Local file paths to upload and attach.
+            tools: Per-message per-tool parameter overrides, already in the
+                platform ``[{id, parameters: [{name, value}]}]`` shape. These
+                win over the session's ``executionConfig.tools`` by tool id
+                for the run this message triggers.
 
         Returns:
             The created SessionMessage.
@@ -397,6 +409,8 @@ class Session(
             payload["requestId"] = request_id
         if all_attachments:
             payload["attachments"] = all_attachments
+        if tools:
+            payload["tools"] = tools
 
         path = f"{self.RESOURCE_PATH}/{self.encoded_id}/messages"
         try:

--- a/tests/unit/v2/test_agent_session_tool_parameters.py
+++ b/tests/unit/v2/test_agent_session_tool_parameters.py
@@ -1,0 +1,257 @@
+"""Unit tests for session-level / per-message tool-parameter overrides.
+
+PROD-2481. Sessions extend the per-tool override shape introduced for
+single-shot runs in #967 (``tools=[{"id": <id>, "parameters": {...}}]``):
+
+* A session may be created carrying session-level per-tool params, persisted
+  inside ``executionConfig.tools`` as the platform ``[{id, parameters:
+  [{name, value}]}]`` shape.
+* A message added to a session (or a ``via_session=True`` run) may override
+  those params per message — the message POST carries its own ``tools``,
+  which the backend merges over the session-level params by tool id.
+* ``via_session=True`` must no longer silently drop ``tools`` (the confirmed
+  bug): the run-time ``tools`` kwarg becomes the per-message override.
+
+These tests mock the HTTP/client layer and assert the payloads carry the
+normalized ``tools``. They mirror ``test_agent_tool_parameters.py`` and
+``test_agent_via_session.py``.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import Mock
+
+from aixplain.v2.agent import Agent
+from aixplain.v2.session import ExecutionConfig, Session, SessionMessage
+
+
+def _params_as_dict(parameters: List[dict]) -> Dict[str, Any]:
+    return {item["name"]: item["value"] for item in parameters}
+
+
+def _tool_by_id(tools: List[dict], tool_id: str) -> dict:
+    return next(t for t in tools if t.get("id") == tool_id or t.get("assetId") == tool_id)
+
+
+def _make_mock_context(**overrides):
+    client = Mock()
+    ctx = Mock(client=client, backend_url="https://platform-api.aixplain.com", api_key="test_key")
+    for k, v in overrides.items():
+        setattr(ctx, k, v)
+    return ctx
+
+
+def _bound_agent(ctx):
+    class BoundAgent(Agent):
+        context = ctx
+
+    return BoundAgent
+
+
+def _user_message(request_id="req_abc"):
+    return SessionMessage(
+        id="msg_user",
+        session_id="sess_abc",
+        role="user",
+        content="hi",
+        sequence=1,
+        request_id=request_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ExecutionConfig carries normalized tools into the session-create payload.
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionConfigTools:
+    def test_to_api_dict_includes_tools(self):
+        cfg = ExecutionConfig(
+            tools=[{"id": "tool-1", "parameters": [{"name": "top_k", "value": 5}]}],
+        )
+        api = cfg.to_api_dict()
+        tool = _tool_by_id(api["tools"], "tool-1")
+        assert _params_as_dict(tool["parameters"]) == {"top_k": 5}
+
+    def test_to_api_dict_omits_tools_when_unset(self):
+        assert "tools" not in ExecutionConfig(criteria="x").to_api_dict()
+
+    def test_coerce_dict_roundtrips_tools(self):
+        cfg = ExecutionConfig.coerce({"tools": [{"id": "tool-1", "parameters": [{"name": "lang", "value": "es"}]}]})
+        assert cfg.tools == [{"id": "tool-1", "parameters": [{"name": "lang", "value": "es"}]}]
+
+
+# ---------------------------------------------------------------------------
+# create_session forwards session-level tool params (normalized).
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSessionTools:
+    def test_create_session_normalizes_session_level_tools(self):
+        ctx = _make_mock_context()
+
+        class BoundSession(Session):
+            context = ctx
+
+        captured = {}
+
+        def fake_save(self, *a, **kw):
+            self.id = "sess_new"
+            captured["config"] = self.execution_config
+            return self
+
+        BoundSession.save = fake_save
+        ctx.Session = BoundSession
+
+        agent = _bound_agent(ctx)(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        agent.create_session(tools=[{"id": "tool-1", "parameters": {"top_k": 7}}])
+
+        cfg = captured["config"]
+        assert isinstance(cfg, ExecutionConfig)
+        tool = _tool_by_id(cfg.tools, "tool-1")
+        assert _params_as_dict(tool["parameters"]) == {"top_k": 7}
+
+    def test_create_session_string_tool_id(self):
+        ctx = _make_mock_context()
+
+        class BoundSession(Session):
+            context = ctx
+
+        captured = {}
+        BoundSession.save = lambda self, *a, **kw: (
+            setattr(self, "id", "s") or captured.update(config=self.execution_config) or self
+        )
+        ctx.Session = BoundSession
+
+        agent = _bound_agent(ctx)(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        agent.create_session(tools=["tool-1"])
+        assert captured["config"].tools == [{"id": "tool-1"}]
+
+
+# ---------------------------------------------------------------------------
+# add_message forwards a per-message tool override in the POST payload.
+# ---------------------------------------------------------------------------
+
+
+class TestAddMessageTools:
+    def test_add_message_payload_carries_tools(self):
+        ctx = _make_mock_context()
+        ctx.client.request.return_value = {"id": "m1", "role": "user", "content": "hi"}
+
+        session = Session(agent_id="agent_99", name="A")
+        session.context = ctx
+        session.id = "sess_abc"
+        session._update_saved_state()
+
+        tools = [{"id": "tool-1", "parameters": [{"name": "top_k", "value": 9}]}]
+        session.add_message(role="user", content="hi", tools=tools)
+
+        _, kwargs = ctx.client.request.call_args
+        assert kwargs["json"]["tools"] == tools
+
+    def test_add_message_without_tools_omits_key(self):
+        ctx = _make_mock_context()
+        ctx.client.request.return_value = {"id": "m1", "role": "user", "content": "hi"}
+
+        session = Session(agent_id="agent_99", name="A")
+        session.context = ctx
+        session.id = "sess_abc"
+        session._update_saved_state()
+
+        session.add_message(role="user", content="hi")
+        _, kwargs = ctx.client.request.call_args
+        assert "tools" not in kwargs["json"]
+
+
+# ---------------------------------------------------------------------------
+# via_session=True no longer drops tools; it routes them to the message.
+# ---------------------------------------------------------------------------
+
+
+class TestRunViaSessionTools:
+    def _wire_poll_success(self, ctx, request_id):
+        ctx.client.get.return_value = {
+            "status": "SUCCESS",
+            "completed": True,
+            "data": {"output": "ok", "session_id": "sess_new", "steps": []},
+            "sessionId": "sess_new",
+            "requestId": request_id,
+            "usedCredits": 0.0,
+            "runTime": 0.5,
+        }
+
+    def test_via_session_routes_tools_to_message_override(self):
+        ctx = _make_mock_context()
+
+        class BoundSession(Session):
+            context = ctx
+
+        add_calls = []
+        BoundSession.save = lambda self, *a, **kw: setattr(self, "id", "sess_new") or self
+
+        def fake_add_message(self, role, content, **kw):
+            add_calls.append(kw)
+            return _user_message(request_id="req_xyz")
+
+        BoundSession.add_message = fake_add_message
+        ctx.Session = BoundSession
+        self._wire_poll_success(ctx, "req_xyz")
+
+        agent = _bound_agent(ctx)(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        agent.run(
+            "hi",
+            via_session=True,
+            tools=[{"id": "tool-1", "parameters": {"top_k": 3}}],
+        )
+
+        assert len(add_calls) == 1
+        tool = _tool_by_id(add_calls[0]["tools"], "tool-1")
+        assert _params_as_dict(tool["parameters"]) == {"top_k": 3}
+
+    def test_via_session_without_tools_passes_none(self):
+        ctx = _make_mock_context()
+
+        class BoundSession(Session):
+            context = ctx
+
+        add_calls = []
+        BoundSession.save = lambda self, *a, **kw: setattr(self, "id", "sess_new") or self
+
+        def fake_add_message(self, role, content, **kw):
+            add_calls.append(kw)
+            return _user_message(request_id="req_xyz")
+
+        BoundSession.add_message = fake_add_message
+        ctx.Session = BoundSession
+        self._wire_poll_success(ctx, "req_xyz")
+
+        agent = _bound_agent(ctx)(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        agent.run("hi", via_session=True)
+        assert add_calls[0].get("tools") is None
+
+
+# ---------------------------------------------------------------------------
+# Single-shot (non-session) behavior from #967 is unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TestSingleShotUnchanged:
+    def test_run_payload_still_normalizes_tools(self):
+        agent = Agent(name="n", description="d")
+        agent.context = Mock()
+        agent.id = "agent-1"
+        payload = agent.build_run_payload(query="hi", tools=[{"id": "tool-1", "parameters": {"top_k": 8}}])
+        assert _params_as_dict(_tool_by_id(payload["tools"], "tool-1")["parameters"]) == {"top_k": 8}
+
+    def test_save_payload_still_normalizes_tools(self):
+        agent = Agent(name="n", description="d", tools=[{"id": "tool-1", "parameters": {"top_k": 5}}])
+        agent.context = Mock()
+        payload = agent.build_save_payload()
+        assert _params_as_dict(_tool_by_id(payload["tools"], "tool-1")["parameters"]) == {"top_k": 5}

--- a/tests/unit/v2/test_agent_tool_parameters.py
+++ b/tests/unit/v2/test_agent_tool_parameters.py
@@ -13,7 +13,7 @@ continue to serialize unchanged.
 
 from typing import Any, Dict, List
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aixplain.v2.agent import Agent
 
@@ -157,3 +157,55 @@ class TestRunPayloadToolParameters:
         agent.id = "agent-1"
         payload = agent.build_run_payload(query="hi", tools=["tool-1"])
         assert payload["tools"] == [{"id": "tool-1"}]
+
+
+class TestToolTypeResolution:
+    """String-id / ``{id, parameters}`` shapes carry no ``type``; the create
+    payload requires one, so the SDK resolves it from the asset's ``as_tool()``
+    snapshot (issue #966 follow-up)."""
+
+    def test_dict_without_type_resolves_type_and_keeps_override(self):
+        snap = {"id": "tool-1", "type": "tool", "name": "Web Search"}
+        with patch.object(Agent, "_resolve_tool_snapshot", return_value=snap):
+            entry = Agent._normalize_tool_for_api({"id": "tool-1", "parameters": {"num_results": 2}})
+        assert entry["type"] == "tool"
+        assert entry["id"] == "tool-1"
+        assert _params_as_dict(entry["parameters"]) == {"num_results": 2}
+
+    def test_string_id_resolves_type(self):
+        snap = {"id": "model-1", "type": "model", "name": "Translate"}
+        with patch.object(Agent, "_resolve_tool_snapshot", return_value=snap):
+            entry = Agent._normalize_tool_for_api("model-1")
+        assert entry["type"] == "model"
+        assert entry["id"] == "model-1"
+
+    def test_dict_with_explicit_type_is_not_resolved(self):
+        # An entry that already carries a type (e.g. an as_tool() snapshot)
+        # must pass through untouched — no asset resolution.
+        with patch.object(Agent, "_resolve_tool_snapshot", side_effect=AssertionError("must not resolve")):
+            entry = Agent._normalize_tool_for_api({"id": "tool-1", "type": "tool", "parameters": {"a": 1}})
+        assert entry["type"] == "tool"
+        assert _params_as_dict(entry["parameters"]) == {"a": 1}
+
+    def test_unresolvable_id_falls_back_to_bare_entry(self):
+        # No client context / unknown id -> resolution returns None; the entry
+        # degrades to the prior {id, parameters} shape instead of raising.
+        with patch.object(Agent, "_resolve_tool_snapshot", return_value=None):
+            entry = Agent._normalize_tool_for_api({"id": "tool-x", "parameters": {"a": 1}})
+        assert entry["id"] == "tool-x"
+        assert _params_as_dict(entry["parameters"]) == {"a": 1}
+        assert "type" not in entry
+
+    def test_resolve_snapshot_tries_tool_then_model(self):
+        # Tool.get fails -> Model.get succeeds; the snapshot comes from Model.
+        ctx = Mock()
+        ctx.Tool.get.side_effect = Exception("not a tool")
+        ctx.Model.get.return_value.as_tool.return_value = {"id": "a1", "type": "model"}
+
+        class _A(Agent):
+            context = ctx
+
+        snap = _A._resolve_tool_snapshot("a1")
+        assert snap == {"id": "a1", "type": "model"}
+        ctx.Tool.get.assert_called_once_with("a1")
+        ctx.Model.get.assert_called_once_with("a1")

--- a/tests/unit/v2/test_agent_tool_parameters.py
+++ b/tests/unit/v2/test_agent_tool_parameters.py
@@ -1,0 +1,159 @@
+"""Unit tests for per-tool parameter override in Agent save/run payloads.
+
+Issue #966 / PROD-2481. Tools attached to an agent may now carry their own
+``parameters`` in the user-facing ``{id, parameters: {...}}`` shape — the same
+shape role models already accept. On the wire, per-tool ``parameters`` are
+normalized into the platform's ``[{name, value}]`` ``NameValue`` list, both in
+the create (``build_save_payload``) and run (``build_run_payload``) payloads.
+
+Backward compatibility: plain string tool ids and existing ``as_tool()`` dicts
+(whose ``parameters`` is already a list of full parameter definitions) must
+continue to serialize unchanged.
+"""
+
+from typing import Any, Dict, List
+
+from unittest.mock import Mock
+
+from aixplain.v2.agent import Agent
+
+
+def _agent(**kwargs: Any) -> Agent:
+    """Build an :class:`Agent` that can run payload builders without a real client."""
+    agent = Agent(**kwargs)
+    agent.context = Mock()
+    return agent
+
+
+def _params_as_dict(parameters: List[dict]) -> Dict[str, Any]:
+    """Flatten ``[{name, value}]`` to ``{name: value}`` for ergonomic assertions."""
+    return {item["name"]: item["value"] for item in parameters}
+
+
+def _tool_by_id(tools: List[dict], tool_id: str) -> dict:
+    return next(t for t in tools if t.get("id") == tool_id or t.get("assetId") == tool_id)
+
+
+class TestSavePayloadToolParameters:
+    """``build_save_payload`` carries per-tool params in the NameValue shape."""
+
+    def test_tool_dict_with_param_dict_normalized_to_namevalue(self):
+        agent = _agent(
+            name="n",
+            description="d",
+            tools=[{"id": "tool-1", "parameters": {"top_k": 5, "language": "es"}}],
+        )
+        payload = agent.build_save_payload()
+
+        tool = _tool_by_id(payload["tools"], "tool-1")
+        assert tool["id"] == "tool-1"
+        assert _params_as_dict(tool["parameters"]) == {"top_k": 5, "language": "es"}
+
+    def test_multiple_tools_each_keep_their_own_params(self):
+        agent = _agent(
+            name="n",
+            description="d",
+            tools=[
+                {"id": "tool-1", "parameters": {"top_k": 5}},
+                {"id": "tool-2", "parameters": {"language": "es"}},
+            ],
+        )
+        payload = agent.build_save_payload()
+
+        assert _params_as_dict(_tool_by_id(payload["tools"], "tool-1")["parameters"]) == {"top_k": 5}
+        assert _params_as_dict(_tool_by_id(payload["tools"], "tool-2")["parameters"]) == {"language": "es"}
+
+    def test_empty_param_dict_becomes_empty_list(self):
+        agent = _agent(name="n", description="d", tools=[{"id": "tool-1", "parameters": {}}])
+        payload = agent.build_save_payload()
+        assert _tool_by_id(payload["tools"], "tool-1")["parameters"] == []
+
+    def test_nested_filter_value_is_preserved(self):
+        filters = {"field": "category", "op": "in", "values": ["a", "b"]}
+        agent = _agent(
+            name="n",
+            description="d",
+            tools=[{"id": "tool-1", "parameters": {"filters": filters}}],
+        )
+        payload = agent.build_save_payload()
+        params = _params_as_dict(_tool_by_id(payload["tools"], "tool-1")["parameters"])
+        assert params["filters"] == filters
+
+
+class TestSavePayloadBackwardCompat:
+    """Existing string-id / as_tool()-list shapes serialize unchanged."""
+
+    def test_plain_string_tool_id(self):
+        agent = _agent(name="n", description="d", tools=["tool-1"])
+        payload = agent.build_save_payload()
+        assert payload["tools"] == [{"id": "tool-1"}]
+
+    def test_tool_dict_without_parameters(self):
+        agent = _agent(name="n", description="d", tools=[{"id": "tool-1"}])
+        payload = agent.build_save_payload()
+        assert _tool_by_id(payload["tools"], "tool-1") == {"id": "tool-1"}
+
+    def test_as_tool_list_parameters_still_normalized(self):
+        """A dict whose ``parameters`` is a list of definitions keeps the legacy path."""
+        as_tool_dict = {
+            "id": "tool-1",
+            "asset_id": "tool-1",
+            "type": "model",
+            "parameters": [
+                {
+                    "name": "temperature",
+                    "value": "0.5",
+                    "allow_multi": False,
+                    "supports_variables": True,
+                }
+            ],
+        }
+        agent = _agent(name="n", description="d", tools=[as_tool_dict])
+        payload = agent.build_save_payload()
+        tool = _tool_by_id(payload["tools"], "tool-1")
+        assert tool["assetId"] == "tool-1"
+        # snake_case keys inside the parameter definition map to camelCase.
+        param = tool["parameters"][0]
+        assert param["name"] == "temperature"
+        assert param["value"] == "0.5"
+        assert param["allowMulti"] is False
+        assert param["supportsVariables"] is True
+
+
+class TestRunPayloadToolParameters:
+    """``build_run_payload`` forwards run-time per-tool overrides."""
+
+    def test_run_tools_param_dict_normalized(self):
+        agent = _agent(name="n", description="d")
+        agent.id = "agent-1"
+        payload = agent.build_run_payload(
+            query="hi",
+            tools=[{"id": "tool-1", "parameters": {"top_k": 8}}],
+        )
+        tool = _tool_by_id(payload["tools"], "tool-1")
+        assert _params_as_dict(tool["parameters"]) == {"top_k": 8}
+
+    def test_run_without_tools_omits_tools_key(self):
+        agent = _agent(name="n", description="d")
+        agent.id = "agent-1"
+        payload = agent.build_run_payload(query="hi")
+        assert "tools" not in payload
+
+    def test_run_multiple_tools_keyed_by_id(self):
+        agent = _agent(name="n", description="d")
+        agent.id = "agent-1"
+        payload = agent.build_run_payload(
+            query="hi",
+            tools=[
+                {"id": "tool-1", "parameters": {"top_k": 8}},
+                {"id": "tool-2", "parameters": {"language": "fr"}},
+            ],
+        )
+        assert _params_as_dict(_tool_by_id(payload["tools"], "tool-1")["parameters"]) == {"top_k": 8}
+        assert _params_as_dict(_tool_by_id(payload["tools"], "tool-2")["parameters"]) == {"language": "fr"}
+
+    def test_run_string_tool_id(self):
+        agent = _agent(name="n", description="d")
+        agent.id = "agent-1"
+        payload = agent.build_run_payload(query="hi", tools=["tool-1"])
+        assert payload["tools"] == [{"id": "tool-1"}]


### PR DESCRIPTION
## Summary

Closes #966.

Adds support for **per-tool parameter overrides** in both `Agent` create and run payloads, using a single user-facing shape shared across both paths:

```python
tools=[{"id": "<tool_id>", "parameters": {"key": "value"}}]
```

Plain string ids (`tools=["<tool_id>"]`) are also accepted. The SDK normalizes these into the platform's `[{name, value}]` parameter shape and forwards them. The backend merges by tool id, overriding the agent's persisted per-tool parameters.

## Changes

- **`AgentRunParams.tools`** — new optional field carrying run-time per-tool overrides (`List[Union[str, Dict[str, Any]]]`).
- **`_normalize_tool_for_api`** — extracted a shared classmethod that normalizes a single `tools` entry (string id, `{id, parameters}` dict, or `ToolableMixin`/`Model` snapshot via `as_tool()`) into the API dict shape. Used by both `create` and `run`, removing duplicated branching from the create path.
- **`_normalize_tool_dict_for_api`** — now handles the dict-shaped per-tool `parameters` (`{key: value}` → platform `[{name, value}]`) alongside the existing `as_tool()` snapshot list shape.
- **`run`** — pops `tools` from kwargs, normalizes each entry, and attaches them to the run payload (so the generic kwargs loop doesn't forward a raw, un-normalized list).

## Tests

- New `tests/unit/v2/test_agent_tool_parameters.py` covering the create and run normalization paths and the shared shapes.
- Full v2 unit suite passes locally.