### PR TITLE
final shape doesn't include url

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -686,7 +686,7 @@ class Model(
 
         if self.is_sync_only:
             result = self._run_sync_v2(**effective_params)
-            if result.url and not result.completed and self._is_poll_url(result.url):
+            if result.url and result.status == "IN_PROGRESS" and not result.completed and self._is_poll_url(result.url):
                 result = self.sync_poll(result.url, **effective_params)
             return result
         else:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -1326,25 +1326,29 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         Returns:
             Response instance from the configured response class
         """
-        # Check for polling URL in data field (legacy format)
-        if response.get("data") and isinstance(response["data"], str) and response["data"].startswith("http"):
+        status = response.get("status", "IN_PROGRESS")
+        data = response.get("data")
+
+        # Check for polling URL in data field (legacy format). A successful
+        # response may also contain a URL as final data, such as generated media.
+        if status == "IN_PROGRESS" and data and isinstance(data, str) and data.startswith("http"):
             # This is a polling URL case
             response_class = getattr(self, "RESPONSE_CLASS", Result)
             return response_class.from_dict(
                 {
-                    "status": response.get("status", "IN_PROGRESS"),
-                    "url": response["data"],
+                    "status": status,
+                    "url": data,
                     "completed": False,
                     "requestId": response.get("requestId"),
                 }
             )
-        elif response.get("status") == "IN_PROGRESS" and response.get("data"):
+        elif status == "IN_PROGRESS" and data:
             # This is a polling URL case
             response_class = getattr(self, "RESPONSE_CLASS", Result)
             return response_class.from_dict(
                 {
-                    "status": response["status"],
-                    "url": response["data"],
+                    "status": status,
+                    "url": data,
                     "completed": False,
                     "requestId": response.get("requestId"),
                 }
@@ -1352,7 +1356,6 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         else:
             # Direct response case - pass the entire response to let dataclass_json handle field mapping
             # Check for failed status and raise appropriate error
-            status = response.get("status", "IN_PROGRESS")
             if status == "FAILED":
                 raise create_operation_failed_error(response)
 

--- a/tests/functional/v2/test_model.py
+++ b/tests/functional/v2/test_model.py
@@ -986,8 +986,10 @@ def test_seedream_run_returns_non_poll_url_without_polling(client):
         wait_time=5,
     )
 
-    assert result.url
-    assert not model._is_poll_url(result.url)
+    assert result.status == "SUCCESS"
+    assert result.completed is True
+    assert result.data
+    assert result.url is None
 
 
 def test_sync_model_run_async(client, sync_model_id):

--- a/tests/unit/v2/test_resource.py
+++ b/tests/unit/v2/test_resource.py
@@ -842,6 +842,23 @@ class TestRunnableResourceMixin:
         assert result.url == "some-poll-id-not-a-url"
         assert result.completed is False
 
+    def test_handle_run_response_success_url_data_is_final_data(self):
+        """handle_run_response() should not treat successful URL data as a polling URL."""
+        resource = self._create_runnable_resource()
+
+        response = {
+            "status": "SUCCESS",
+            "completed": True,
+            "data": "https://example.com/generated-image.jpeg",
+        }
+        result = resource.handle_run_response(response)
+
+        assert isinstance(result, Result)
+        assert result.status == "SUCCESS"
+        assert result.completed is True
+        assert result.data == "https://example.com/generated-image.jpeg"
+        assert result.url is None
+
     def test_run_polls_when_in_progress_with_non_url_data(self):
         """run() should poll when handle_run_response returns IN_PROGRESS with non-URL data."""
         resource = self._create_runnable_resource()


### PR DESCRIPTION
URL should be None if the final (image) is detected, even if the standalone model doesn't try to fetch it and gives the final answer correctly, in the agent if URL is not none it will try to poll it. 
In v2/resource.py -> if result.url and not result.completed:
