### PR TITLE
fix(v2): surface diagnostic error codes nested under data in AgentRunResult

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -324,6 +324,7 @@ class AgentResponseData:
     steps: Optional[List[Dict[str, Any]]] = field(default_factory=list)
     session_id: Optional[str] = None
     execution_stats: Optional[Dict[str, Any]] = field(default=None, metadata=config(field_name="executionStats"))
+    diagnostic_error_codes: List[str] = field(default_factory=list, metadata=config(field_name="diagnosticErrorCodes"))
     critiques: Optional[str] = ""
     governance: Optional[Dict[str, Any]] = None
     _governance_status: Optional[str] = field(
@@ -357,6 +358,35 @@ class AgentRunResult(Result):
     used_credits: float = field(default=0.0, metadata=config(field_name="usedCredits"))
     run_time: float = field(default=0.0, metadata=config(field_name="runTime"))
     diagnostic_error_codes: List[str] = field(default_factory=list, metadata=config(field_name="diagnosticErrorCodes"))
+
+    def __post_init__(self) -> None:
+        """Promote diagnostic codes the backend nests under ``data``.
+
+        The poll body carries them at ``data.diagnosticErrorCodes`` (or only
+        inside ``executionStats`` on older builds), never top-level.
+        """
+        if not self.diagnostic_error_codes:
+            self.diagnostic_error_codes = self._codes_from_data()
+
+    def _codes_from_data(self) -> List[str]:
+        """Extract diagnostic codes from ``data`` or its execution stats."""
+        data = self.data
+        if isinstance(data, AgentResponseData):
+            if data.diagnostic_error_codes:
+                return list(data.diagnostic_error_codes)
+            stats = data.execution_stats
+        elif isinstance(data, dict):
+            codes = data.get("diagnosticErrorCodes") or data.get("diagnostic_error_codes")
+            if codes:
+                return list(codes)
+            stats = data.get("executionStats") or data.get("execution_stats")
+        else:
+            return []
+        if isinstance(stats, dict):
+            codes = stats.get("diagnostic_error_codes") or stats.get("diagnosticErrorCodes")
+            if codes:
+                return list(codes)
+        return []
 
     # Internal reference to client context for debug() method
     _context: Optional[Any] = field(

--- a/tests/unit/v2/test_agent_polling.py
+++ b/tests/unit/v2/test_agent_polling.py
@@ -58,6 +58,53 @@ class TestAgentRunResultExecutionId:
 
         assert result.diagnostic_error_codes == ["MAX_TOKENS_REACHED", "TOOL_FAILED"]
 
+    def test_diagnostic_error_codes_promoted_from_data(self):
+        """The backend poll body carries the codes at data.diagnosticErrorCodes,
+        not top-level — they must surface on the result."""
+        result = AgentRunResult.from_dict(
+            {
+                "status": "SUCCESS",
+                "completed": True,
+                "data": {
+                    "input": "q",
+                    "output": "truncated text",
+                    "diagnosticErrorCodes": ["MAX_TOKENS_REACHED"],
+                    "executionStats": {"diagnostic_error_codes": ["MAX_TOKENS_REACHED"]},
+                },
+            }
+        )
+
+        assert result.diagnostic_error_codes == ["MAX_TOKENS_REACHED"]
+        assert result.data.diagnostic_error_codes == ["MAX_TOKENS_REACHED"]
+
+    def test_diagnostic_error_codes_fall_back_to_execution_stats(self):
+        """Older backends only carry the codes inside executionStats."""
+        result = AgentRunResult.from_dict(
+            {
+                "status": "SUCCESS",
+                "completed": True,
+                "data": {
+                    "input": "q",
+                    "output": "truncated text",
+                    "executionStats": {"diagnostic_error_codes": ["MAX_TOKENS_REACHED"]},
+                },
+            }
+        )
+
+        assert result.diagnostic_error_codes == ["MAX_TOKENS_REACHED"]
+
+    def test_top_level_diagnostic_error_codes_win_over_data(self):
+        result = AgentRunResult.from_dict(
+            {
+                "status": "SUCCESS",
+                "completed": True,
+                "diagnosticErrorCodes": ["TOOL_FAILED"],
+                "data": {"diagnosticErrorCodes": ["MAX_TOKENS_REACHED"]},
+            }
+        )
+
+        assert result.diagnostic_error_codes == ["TOOL_FAILED"]
+
     def test_execution_id_from_request_id(self):
         """Should return request_id directly when available."""
         result = AgentRunResult(


### PR DESCRIPTION
## Problem

`AgentRunResult.diagnostic_error_codes` is always `[]` even when the run reported codes — they only appear buried in `data.execution_stats`:

```
AgentRunResult(..., diagnostic_error_codes=[],
  data=AgentResponseData(..., execution_stats={..., 'diagnostic_error_codes': ['MAX_TOKENS_REACHED']}))
```

The backend poll body (`/sdk/agents/{id}/result`) has only `{completed, data, status}` at the top level; the codes live at `data.diagnosticErrorCodes` (and `data.executionStats.diagnostic_error_codes`). The v2 dataclass field maps to a **top-level** `diagnosticErrorCodes` key that the backend never sends, and `AgentResponseData` had no field for the nested one, so it was dropped on parse. (v1 handles this via `_extract_diagnostic_error_codes`, which checks `data` first; v2 missed it.)

## Fix

- `AgentResponseData` gains `diagnostic_error_codes` (wire: `diagnosticErrorCodes`), so the nested codes survive parsing.
- `AgentRunResult.__post_init__` promotes them to the top-level field when it is empty: `data.diagnosticErrorCodes` first, falling back to `executionStats` (both key casings). Explicit top-level codes still win.

## Verification

- New unit tests cover promotion from `data`, fallback to `executionStats`, and top-level precedence (`tests/unit/v2/test_agent_polling.py`).
- Full `tests/unit/v2` suite: 956 passed, 4 skipped.
- Replayed the real dev poll body for run `35772816-0064-4215-8588-3e46684ec55d` through `Agent.poll()`: `diagnostic_error_codes` now resolves to `['MAX_TOKENS_REACHED']` at both `result` and `result.data` levels.

Related: PROD-2511, aixplain-agents#219