### PR TITLE
feat(v2): manage sessions via aix.Session; polymorphic agent.run(session=)

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -231,11 +231,13 @@ class AgentRunParams(BaseRunParams):
     """Parameters for running an agent.
 
     Attributes:
-        session_id: Session ID for conversation continuity
+        session: Conversation thread to run within. A
+            :class:`~aixplain.v2.session.Session` instance or a session id
+            string. Omit for a one-shot, stateless run. Replaces the removed
+            ``via_session`` flag and id-only ``session_id``.
         query: The query to run
         variables: Variables to replace {{variable}} placeholders in instructions and description.
             The backend performs the actual substitution.
-        allow_history_and_session_id: Allow both history and session ID
         tasks: List of tasks for the agent
         prompt: Custom prompt override
         history: Conversation history
@@ -259,10 +261,9 @@ class AgentRunParams(BaseRunParams):
         progress_truncate: Whether to truncate long text in progress display
     """
 
-    session_id: NotRequired[Optional[Text]]
+    session: NotRequired[Optional[Union["Session", Text]]]
     query: NotRequired[Optional[Union[Dict, Text]]]
     variables: NotRequired[Optional[Dict[str, Any]]]
-    allow_history_and_session_id: NotRequired[Optional[bool]]
     tasks: NotRequired[Optional[List[Any]]]
     prompt: NotRequired[Optional[Text]]
     history: NotRequired[Optional[List[ConversationMessage]]]
@@ -272,7 +273,6 @@ class AgentRunParams(BaseRunParams):
     identifier: NotRequired[Optional[Text]]
     inspectors: NotRequired[Optional[List[Dict]]]
     run_response_generation: NotRequired[Optional[bool]]
-    via_session: NotRequired[Optional[bool]]
     attachments: NotRequired[Optional[List[Union[str, Dict[str, Any]]]]]
     files: NotRequired[Optional[List[Any]]]
     progress_format: NotRequired[Optional[Text]]
@@ -832,8 +832,6 @@ class Agent(
         return None  # Return original result
 
     _SNAKE_TO_CAMEL: ClassVar[Dict[str, str]] = {
-        "session_id": "sessionId",
-        "allow_history_and_session_id": "allowHistoryAndSessionId",
         "execution_params": "executionParams",
         "run_response_generation": "runResponseGeneration",
     }
@@ -926,15 +924,16 @@ class Agent(
         Args:
             *args: Positional arguments (first arg is treated as query)
             query: The query to run
-            via_session: When True, opt into the new sessions+messages
-                run path: a Session is created (or reused via
-                ``session_id``) carrying the supplied execution params
-                as its ``executionConfig``, the user message is posted,
-                and the run is awaited via session message polling.
-                Default False keeps the legacy
-                ``/v2/agents/{id}/run`` path. Sessions auto-created by
-                ``via_session=True`` persist; clean up via
-                ``agent.list_sessions()`` and ``session.delete()``.
+            session: Run within a conversation thread. Accepts a
+                :class:`~aixplain.v2.session.Session` instance or a session id
+                string. When supplied, the run routes through the session path:
+                the user message is posted to
+                ``POST /v1/sessions/{id}/messages`` (carrying the session's
+                ``executionConfig`` plus any per-run execution overrides) and the
+                triggered agent run is awaited. Omit ``session`` for a one-shot,
+                stateless run over ``POST /v2/agents/{id}/run``. There is no
+                ``via_session`` flag and no id-only ``session_id`` — manage
+                threads through ``aix.Session`` and pass them here.
             progress_format: Display format - "status" or "logs". If None (default),
                            progress tracking is disabled.
             progress_verbosity: Detail level 1-3 (default: 1)
@@ -948,8 +947,9 @@ class Agent(
             kwargs["query"] = args[0]
             args = args[1:]
 
-        if kwargs.pop("via_session", False):
-            return self._run_via_session(**kwargs)
+        session = kwargs.pop("session", None)
+        if session is not None:
+            return self._run_with_session(session, **kwargs)
 
         return super().run(*args, **kwargs)
 
@@ -972,9 +972,9 @@ class Agent(
             kwargs["query"] = args[0]
             args = args[1:]
 
-        if kwargs.get("via_session"):
+        if kwargs.pop("session", None) is not None:
             raise NotImplementedError(
-                "via_session=True is sync-only for now; use agent.run(...) or "
+                "session=… runs are sync-only for now; use agent.run(...) or "
                 "session.add_message() + session.messages() directly."
             )
 
@@ -2049,175 +2049,11 @@ class Agent(
                         values[name] = value
         return values
 
-    def generate_session_id(self, history: Optional[List[ConversationMessage]] = None) -> str:
-        """Generate a session ID for agent conversations.
-
-        .. deprecated::
-            Use :meth:`create_session` instead, which returns a full
-            backend-managed :class:`~aixplain.v2.session.Session` object.
-            This method is a thin backward-compatible shim that delegates
-            to ``create_session`` and returns only the new session's ID.
-            It will be removed in a future release.
-
-        Args:
-            history: Optional conversation history to seed the session with.
-                Each message must have 'role' and 'content' keys.
-
-        Returns:
-            str: The ID of the newly created backend-managed session.
-
-        Raises:
-            ValueError: If the history format is invalid.
-        """
-        warnings.warn(
-            "generate_session_id() is deprecated and will be removed in a "
-            "future release. Use create_session() instead, which returns a "
-            "backend-managed Session object.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        # Preserve the legacy auto-save behavior: callers relied on this
-        # method persisting an unsaved agent for them. create_session()
-        # itself requires a saved agent and would otherwise raise.
-        if not self.id:
-            self.save(as_draft=True)
-
-        session = self.create_session(history=history)
-        return session.id
-
-    def create_session(
-        self,
-        name: Optional[str] = None,
-        history: Optional[List[ConversationMessage]] = None,
-        execution_config: Optional[Union["ExecutionConfig", Dict[str, Any]]] = None,
-        execution_params: Optional[Dict[str, Any]] = None,
-        criteria: Optional[str] = None,
-        evolve: Optional[str] = None,
-        identifier: Optional[str] = None,
-        run_response_generation: Optional[bool] = None,
-    ) -> "Session":
-        """Create a new backend-managed session for this agent.
-
-        Args:
-            name: Optional human-readable name for the session.
-            history: Optional conversation history to seed the session with.
-                Each message must have 'role' and 'content' keys.
-                Messages may also include optional 'attachments'
-                (pre-built dicts with url/name/type) and/or 'files'
-                (local file paths to upload).
-            execution_config: Full ExecutionConfig (or equivalent dict) to
-                attach to the session. Subsequent user messages will run
-                the agent with these parameters. Mutually exclusive with
-                the individual ``execution_params``/``criteria``/etc.
-                shortcuts below.
-            execution_params: Backend execution params (output format, max
-                tokens, etc.). Mirrors the ``execution_params`` argument
-                accepted by ``agent.run()``.
-            criteria: Free-form evaluation criteria sent to the agent.
-            evolve: Evolution config as a JSON string.
-            identifier: Free-form identifier the backend can echo back on
-                messages.
-            run_response_generation: Whether the agent should run its
-                final response-generation step.
-
-        Returns:
-            Session: The created Session instance, pre-populated with
-            history messages when provided.
-
-        Raises:
-            ValueError: If the agent has not been saved yet, if history
-                format is invalid, or if both ``execution_config`` and
-                shortcut kwargs are provided.
-
-        Example:
-            >>> session = agent.create_session(
-            ...     name="My Chat",
-            ...     execution_params={"max_tokens": 1024, "max_iterations": 10},
-            ...     criteria="Be concise",
-            ...     run_response_generation=True,
-            ...     history=[
-            ...         {"role": "user", "content": "Analyze this",
-            ...          "files": ["/tmp/data.csv"]},
-            ...         {"role": "assistant", "content": "Here are the results..."},
-            ...     ],
-            ... )
-        """
-        if not self.id:
-            raise ValueError("Agent must be saved before creating a session. Call agent.save() first.")
-
-        if history:
-            validate_history(history)
-
-        config = self._resolve_execution_config(
-            execution_config=execution_config,
-            execution_params=execution_params,
-            criteria=criteria,
-            evolve=evolve,
-            identifier=identifier,
-            run_response_generation=run_response_generation,
-        )
-
-        session = self.context.Session(agent_id=self.id, name=name, execution_config=config)
-        session.save()
-
-        if history:
-            for message in history:
-                session.add_message(
-                    role=message["role"],
-                    content=message["content"],
-                    attachments=message.get("attachments"),
-                    files=message.get("files"),
-                )
-
-        return session
-
-    @classmethod
-    def _resolve_execution_config(
-        cls,
-        execution_config: Optional[Union["ExecutionConfig", Dict[str, Any]]] = None,
-        execution_params: Optional[Dict[str, Any]] = None,
-        criteria: Optional[str] = None,
-        evolve: Optional[str] = None,
-        identifier: Optional[str] = None,
-        run_response_generation: Optional[bool] = None,
-    ) -> Optional["ExecutionConfig"]:
-        """Combine the explicit and shortcut forms into one ExecutionConfig.
-
-        Returns ``None`` when neither form supplies any value so the
-        Session save payload omits ``executionConfig`` entirely.
-        """
-        from .session import ExecutionConfig
-
-        shortcut_values: Dict[str, Any] = {
-            "execution_params": execution_params,
-            "criteria": criteria,
-            "evolve": evolve,
-            "identifier": identifier,
-            "run_response_generation": run_response_generation,
-        }
-        has_shortcut = any(v is not None for v in shortcut_values.values())
-
-        if execution_config is not None and has_shortcut:
-            raise ValueError(
-                "Pass either 'execution_config' or the individual shortcut "
-                "kwargs (execution_params, criteria, evolve, identifier, "
-                "run_response_generation), not both."
-            )
-
-        if execution_config is not None:
-            return ExecutionConfig.coerce(execution_config)
-
-        if has_shortcut:
-            return ExecutionConfig(**shortcut_values)
-
-        return None
-
     @staticmethod
     def _apply_run_overrides_to_session(session: "Session", kwargs: Dict[str, Any]) -> None:
-        """Apply per-run execution overrides onto a reused session.
+        """Apply per-run execution overrides onto a session.
 
-        When a caller reuses an existing ``session_id`` but also passes
+        When a caller runs within a ``session`` but also passes
         per-run execution kwargs (``execution_params`` / ``criteria`` /
         ``evolve`` / ``identifier`` / ``run_response_generation``), those
         overrides would otherwise be silently dropped — the run would
@@ -2258,9 +2094,9 @@ class Agent(
 
         warnings.warn(
             f"Per-run execution overrides ({', '.join(sorted(provided))}) were "
-            f"passed alongside an existing session_id '{session.id}'. Updating "
-            f"the session's stored executionConfig so the overrides take effect; "
-            f"this also applies to every subsequent message in this session.",
+            f"passed alongside session '{session.id}'. Updating the session's "
+            f"stored executionConfig so the overrides take effect; this also "
+            f"applies to every subsequent message in this session.",
             UserWarning,
             stacklevel=3,
         )
@@ -2273,37 +2109,50 @@ class Agent(
         "inspectors",
         "history",
         "variables",
-        "allow_history_and_session_id",
     )
 
-    def _run_via_session(self, **kwargs: Any) -> AgentRunResult:
-        """Run the agent through a session, using the legacy result endpoint.
+    def _resolve_session(self, session: Any) -> "Session":
+        """Resolve the ``session=`` run argument to a bound :class:`Session`.
+
+        Accepts a :class:`~aixplain.v2.session.Session` instance (bound to this
+        agent's context if it isn't already) or a session id string (fetched via
+        ``Session.get``). Any other type is a ``TypeError``.
+        """
+        from .session import Session
+
+        if isinstance(session, Session):
+            if getattr(session, "context", None) is None:
+                session.context = self.context
+            return session
+        if isinstance(session, str):
+            return self.context.Session.get(session)
+        raise TypeError(f"session must be a Session instance or a session id string, got {type(session).__name__}")
+
+    def _run_with_session(self, session: Any, **kwargs: Any) -> AgentRunResult:
+        """Run the agent within a session, awaiting the triggered run.
 
         Flow:
-        1. Get-or-create a Session carrying the supplied ``executionConfig``.
+        1. Resolve ``session`` (a Session object or id) to a bound Session and
+           merge any per-run execution overrides onto its ``executionConfig``.
         2. POST a ``role="user"`` message via ``session.add_message`` — this
            triggers the agent run on the backend with the session's
            ``executionConfig``. Any ``attachments`` / ``files`` passed to
            ``run`` are forwarded onto the user message so the agent receives
            them (uploaded and attached by ``add_message``).
-        3. Pull the agent run's ``requestId`` off the user message and
-           hand it to ``self.sync_poll`` (the legacy
-           ``/sdk/agents/{request_id}/result`` endpoint), which returns a
-           fully populated ``AgentRunResult`` including ``data.steps``,
-           ``execution_stats``, ``used_credits``, and ``run_time``.
+        3. Pull the agent run's ``requestId`` off the user message and hand it to
+           ``self.sync_poll`` (the ``/sdk/agents/{request_id}/result`` endpoint),
+           which returns a fully populated ``AgentRunResult`` including
+           ``data.steps``, ``execution_stats``, ``used_credits``, and ``run_time``.
 
-        We don't poll session messages for the assistant reply — the
-        backend's session→assistant-message persistence is incomplete on
-        dev today, but the legacy result endpoint is fully populated for
-        the run that the user message triggered.
+        We don't poll session messages for the assistant reply — the run result
+        endpoint is fully populated for the run the user message triggered.
         """
         self._validate_run_dependencies()
 
         offending = [k for k in self._LEGACY_ONLY_RUN_KWARGS if kwargs.get(k) is not None]
         if offending:
             raise ValueError(
-                f"via_session=True does not support legacy run kwargs: {offending}. "
-                "Drop them or run without via_session=True."
+                f"session=… runs do not support legacy run kwargs: {offending}. Drop them or run without a session."
             )
 
         query = kwargs.get("query")
@@ -2312,23 +2161,13 @@ class Agent(
         # The query is optional when attachments carry the turn's input (e.g. an
         # audio clip that is itself the prompt); otherwise a text query is required.
         if query is None and not (attachments or files):
-            raise ValueError("via_session=True requires a query or attachments.")
+            raise ValueError("A session run requires a query or attachments.")
         if query is not None and not isinstance(query, str):
-            raise ValueError("via_session=True only supports string queries.")
+            raise ValueError("session=… only supports string queries.")
         query = query or ""
 
-        session_id = kwargs.get("session_id")
-        if session_id:
-            session = self.context.Session.get(session_id)
-            self._apply_run_overrides_to_session(session, kwargs)
-        else:
-            session = self.create_session(
-                execution_params=kwargs.get("execution_params"),
-                criteria=kwargs.get("criteria"),
-                evolve=kwargs.get("evolve"),
-                identifier=kwargs.get("identifier"),
-                run_response_generation=kwargs.get("run_response_generation"),
-            )
+        session = self._resolve_session(session)
+        self._apply_run_overrides_to_session(session, kwargs)
 
         # The agent's current per-tool parameter state (set by mutating
         # ``agent.tools[i].actions[...].inputs[...]``) becomes the per-message
@@ -2348,7 +2187,7 @@ class Agent(
                 f"session '{session.id}'; cannot poll the agent run result."
             )
 
-        # Same progress-tracker plumbing as the legacy path: sync_poll calls
+        # Same progress-tracker plumbing as the direct path: sync_poll calls
         # self.on_poll(...) on every iteration, which forwards to the tracker.
         self._start_progress_tracker(kwargs)
         try:
@@ -2362,10 +2201,9 @@ class Agent(
             raise
         self._finish_progress_tracker(result)
 
-        # The legacy /sdk/agents/{id}/result response doesn't always echo
-        # back identifiers at the top level — back-fill from what we know
-        # locally so result.session_id / result.request_id are not None
-        # for via_session callers.
+        # The /sdk/agents/{id}/result response doesn't always echo back
+        # identifiers at the top level — back-fill from what we know locally so
+        # result.session_id / result.request_id are not None for session callers.
         if not result.session_id:
             result.session_id = session.id
         if result.data is not None and getattr(result.data, "session_id", None) in (None, ""):
@@ -2374,23 +2212,6 @@ class Agent(
             result.request_id = user_msg.request_id
         result._context = self.context
         return result
-
-    def list_sessions(self, status: Optional[str] = None) -> list:
-        """List sessions for this agent.
-
-        Args:
-            status: Optional status filter (e.g. "active", "completed").
-
-        Returns:
-            List of Session instances belonging to this agent.
-
-        Raises:
-            ValueError: If the agent has not been saved yet.
-        """
-        if not self.id:
-            raise ValueError("Agent must be saved before listing sessions. Call agent.save() first.")
-
-        return self.context.Session.list(agent_id=self.id, status=status)
 
 
 # ``@dataclass_json`` injects its own ``from_dict`` onto the class, which would

--- a/aixplain/v2/session.py
+++ b/aixplain/v2/session.py
@@ -4,7 +4,8 @@ import os
 import logging
 import mimetypes
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, InitVar
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
 
@@ -16,8 +17,11 @@ from .resource import (
     BaseResource,
     GetResourceMixin,
     DeleteResourceMixin,
+    SearchResourceMixin,
     BaseGetParams,
     BaseDeleteParams,
+    BaseSearchParams,
+    Page,
 )
 
 logger = logging.getLogger(__name__)
@@ -260,6 +264,31 @@ def _deserialize(cls, data: dict, description: str):
         raise ResourceError(f"Failed to parse {description}: {e}. Response data: {str(data)[:200]}")
 
 
+def _resolve_agent_id(agent: Any) -> Optional[str]:
+    """Resolve an ``agent`` argument (Agent instance or id string) to its id.
+
+    Accepts ``None`` (returns ``None``), a plain id string, or any object
+    exposing an ``id`` attribute (an :class:`~aixplain.v2.agent.Agent`). Used by
+    both ``Session(agent=…)`` and ``Session.search(agent=…)`` so callers can pass
+    an agent object interchangeably with its id.
+    """
+    if agent is None:
+        return None
+    if isinstance(agent, str):
+        return agent
+    agent_id = getattr(agent, "id", None)
+    if not agent_id:
+        raise ResourceError("agent must be a saved Agent (with an id) or an agent id string")
+    return agent_id
+
+
+def _to_iso(value: Any) -> str:
+    """Serialize a date filter value (``datetime`` or string) to an ISO string."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
 @dataclass_json
 @dataclass
 class SessionMessageAttachment:
@@ -460,10 +489,28 @@ class Session(
     BaseResource,
     GetResourceMixin[BaseGetParams, "Session"],
     DeleteResourceMixin[BaseDeleteParams, "Session"],
+    SearchResourceMixin[BaseSearchParams, "Session"],
 ):
-    """Session resource for managing agent conversation sessions."""
+    """Session resource for managing agent conversation sessions.
+
+    Sessions are the single entry point for conversation threads: create with
+    ``aix.Session(agent=…)`` + ``save()``, find with ``aix.Session.search(agent=…)``,
+    and drive with ``agent.run(query, session=…)``. Each session is bound to one
+    agent (``agent_id``).
+    """
 
     RESOURCE_PATH = "v1/sessions"
+
+    # The session list endpoint is a plain ``GET /v1/sessions`` with query-param
+    # filters — not the standard ``POST {path}/paginate``. ``search`` is fully
+    # overridden below to honor that shape while still returning a ``Page``.
+    PAGINATE_PATH = ""
+    PAGINATE_METHOD = "get"
+
+    # ``agent`` is an init-only convenience: ``Session(agent=agent_or_id)`` sets
+    # ``agent_id``. Not a serialized field (InitVar), so it never appears on the
+    # wire and deserialization (which never passes it) keeps the stored id.
+    agent: InitVar[Optional[Any]] = None
 
     user_id: str = field(default="", metadata=config(field_name="userId"))
     agent_id: str = field(default="", metadata=config(field_name="agentId"))
@@ -477,8 +524,12 @@ class Session(
     updated_at: str = field(default="", metadata=config(field_name="updatedAt"))
     execution_config: Optional[ExecutionConfig] = field(default=None, metadata=config(field_name="executionConfig"))
 
-    def __post_init__(self) -> None:
-        """Coerce dict execution_config (e.g. from kwargs) into ExecutionConfig."""
+    def __post_init__(self, agent: Optional[Any] = None) -> None:
+        """Resolve the ``agent`` convenience arg and coerce ``execution_config``."""
+        if agent is not None:
+            resolved = _resolve_agent_id(agent)
+            if resolved:
+                self.agent_id = resolved
         if self.execution_config is not None and not isinstance(self.execution_config, ExecutionConfig):
             self.execution_config = ExecutionConfig.coerce(self.execution_config)
 
@@ -520,24 +571,47 @@ class Session(
         return payload
 
     @classmethod
-    def list(
+    def search(
         cls,
-        agent_id: Optional[str] = None,
+        agent: Optional[Any] = None,
         status: Optional[str] = None,
         user_id: Optional[str] = None,
-    ) -> List["Session"]:
-        """List sessions with optional filters.
+        created_after: Optional[Union[str, datetime]] = None,
+        created_before: Optional[Union[str, datetime]] = None,
+        memory_enabled: Optional[bool] = None,
+        page_number: int = 0,
+        page_size: int = 20,
+        **kwargs: Any,
+    ) -> Page["Session"]:
+        """Search sessions with optional filters, returning a paginated ``Page``.
+
+        The single, standard way to list sessions (there is no ``agent.list_sessions()``
+        and no bespoke ``Session.list()``). Mirrors the ``search`` on every other
+        asset, but hits the session list endpoint (a plain ``GET /v1/sessions``
+        with query-param filters) and wraps the result in a ``Page``.
 
         Args:
-            agent_id: Filter by agent ID.
-            status: Filter by session status.
-            user_id: Filter by user ID.
+            agent: Filter by agent — an :class:`~aixplain.v2.agent.Agent` instance
+                or an agent id string.
+            status: Filter by session status (e.g. ``"active"``).
+            user_id: Filter by owning user id.
+            created_after: Lower bound on the session's creation time
+                (``datetime`` or ISO string).
+            created_before: Upper bound on the session's creation time.
+            memory_enabled: When ``True`` return memory-on threads (sessions with
+                persisted traces); when ``False`` return memory-off runs. ``None``
+                (default) applies no memory filter. *(Backend filter delivery is a
+                follow-up; the SDK forwards the parameter today.)*
+            page_number: Zero-indexed page number (default 0).
+            page_size: Page size (default 20).
+            **kwargs: Accepted for forward compatibility with the standard
+                search signature; ignored by the session list endpoint.
 
         Returns:
-            List of Session instances.
+            Page[Session]: A page of Session instances.
 
         Raises:
-            ResourceError: If the API response is not a list or
+            ResourceError: If the API response cannot be parsed or
                 deserialization fails.
             APIError: If the API request fails.
         """
@@ -545,29 +619,49 @@ class Session(
         if context is None:
             raise ResourceError("Context is required for resource operations")
 
-        params: Dict[str, str] = {}
+        params: Dict[str, Any] = {}
+        agent_id = _resolve_agent_id(agent)
         if agent_id is not None:
             params["agentId"] = agent_id
         if status is not None:
             params["status"] = status
         if user_id is not None:
             params["userId"] = user_id
+        if created_after is not None:
+            params["createdAfter"] = _to_iso(created_after)
+        if created_before is not None:
+            params["createdBefore"] = _to_iso(created_before)
+        if memory_enabled is not None:
+            params["memoryEnabled"] = memory_enabled
+        params["pageNumber"] = page_number
+        params["pageSize"] = page_size
 
         try:
             response = context.client.request("get", cls.RESOURCE_PATH, params=params)
         except APIError:
             raise
         except Exception as e:
-            raise ResourceError(f"Failed to list sessions: {e}")
+            raise ResourceError(f"Failed to search sessions: {e}")
 
-        items = _parse_list_response(response, "sessions")
-        sessions = []
+        # The backend returns a bare JSON array today; tolerate a paginated dict
+        # too so a future backend change (envelope with total/pageTotal) still works.
+        if isinstance(response, dict):
+            items = response.get(cls.PAGINATE_ITEMS_KEY) or response.get("items") or []
+            total = response.get(cls.PAGINATE_TOTAL_KEY, len(items))
+            page_total = response.get(cls.PAGINATE_PAGE_TOTAL_KEY, 1)
+        else:
+            items = _parse_list_response(response, "sessions")
+            total = len(items)
+            page_total = 1
+
+        results: List["Session"] = []
         for item in items:
             session = _deserialize(cls, item, "session")
             session.context = context
             session._update_saved_state()
-            sessions.append(session)
-        return sessions
+            results.append(session)
+
+        return Page(results=results, page_number=page_number, page_total=page_total, total=total)
 
     def messages(self) -> List[SessionMessage]:
         """Get all messages in this session.
@@ -621,7 +715,7 @@ class Session(
             tools: Per-message per-tool parameter overrides in the platform
                 ``[{id, parameters: [{name, value}]}]`` shape, applied to the
                 run this message triggers. Normally populated automatically from
-                the agent's tool objects by ``run(via_session=True)``.
+                the agent's tool objects by ``agent.run(query, session=…)``.
 
         Returns:
             The created SessionMessage.

--- a/tests/functional/v2/test_session.py
+++ b/tests/functional/v2/test_session.py
@@ -37,6 +37,13 @@ def test_agent(client):
         pass
 
 
+def _make_session(client, agent, name=None, **kwargs):
+    """Create and persist a session bound to ``agent`` (the single create path)."""
+    session = client.Session(agent=agent, name=name, **kwargs)
+    session.save()
+    return session
+
+
 # ---------------------------------------------------------------------------
 # Session CRUD
 # ---------------------------------------------------------------------------
@@ -45,9 +52,9 @@ def test_agent(client):
 class TestSessionCRUD:
     """End-to-end session create / get / list / update / delete."""
 
-    def test_create_session_via_agent(self, client, test_agent):
-        """Creating a session through an agent should return a saved Session."""
-        session = test_agent.create_session(name="Func Test Session")
+    def test_create_session_with_agent_object(self, client, test_agent):
+        """Creating a session with ``Session(agent=…)`` returns a saved Session."""
+        session = _make_session(client, test_agent, name="Func Test Session")
 
         assert session.id is not None
         assert isinstance(session, Session)
@@ -61,9 +68,9 @@ class TestSessionCRUD:
         except Exception:
             pass
 
-    def test_create_session_directly(self, client, test_agent):
-        """Creating a Session instance directly and calling .save()."""
-        session = client.Session(agent_id=test_agent.id, name="Direct Create")
+    def test_create_session_with_agent_id(self, client, test_agent):
+        """``Session(agent=…)`` also accepts a bare agent id string."""
+        session = client.Session(agent=test_agent.id, name="Direct Create")
         session.save()
 
         assert session.id is not None
@@ -77,7 +84,7 @@ class TestSessionCRUD:
 
     def test_get_session(self, client, test_agent):
         """Retrieving a session by ID should return the same session."""
-        session = test_agent.create_session(name="Get Test")
+        session = _make_session(client, test_agent, name="Get Test")
         fetched = client.Session.get(session.id)
 
         assert fetched.id == session.id
@@ -90,15 +97,15 @@ class TestSessionCRUD:
         except Exception:
             pass
 
-    def test_list_sessions_for_agent(self, client, test_agent):
-        """Listing sessions for an agent should include the created session."""
-        session = test_agent.create_session(name="List Test")
+    def test_search_sessions_for_agent(self, client, test_agent):
+        """Session.search(agent=…) returns a Page including the created session."""
+        session = _make_session(client, test_agent, name="List Test")
 
-        sessions = test_agent.list_sessions()
+        page = client.Session.search(agent=test_agent)
 
-        assert isinstance(sessions, list)
-        session_ids = [s.id for s in sessions]
+        session_ids = [s.id for s in page.results]
         assert session.id in session_ids
+        assert page.total >= 1
 
         # Cleanup
         try:
@@ -106,12 +113,12 @@ class TestSessionCRUD:
         except Exception:
             pass
 
-    def test_list_sessions_with_status_filter(self, client, test_agent):
+    def test_search_sessions_with_status_filter(self, client, test_agent):
         """Filtering by status should only return matching sessions."""
-        session = test_agent.create_session(name="Status Filter Test")
+        session = _make_session(client, test_agent, name="Status Filter Test")
 
-        active = test_agent.list_sessions(status="active")
-        assert all(s.status == "active" for s in active)
+        page = client.Session.search(agent=test_agent, status="active")
+        assert all(s.status == "active" for s in page.results)
 
         # Cleanup
         try:
@@ -121,7 +128,7 @@ class TestSessionCRUD:
 
     def test_update_session(self, client, test_agent):
         """Updating session name via save() should persist the change."""
-        session = test_agent.create_session(name="Before Update")
+        session = _make_session(client, test_agent, name="Before Update")
         session.name = "After Update"
         session.save()
 
@@ -134,13 +141,11 @@ class TestSessionCRUD:
         except Exception:
             pass
 
-    def test_create_session_with_history(self, client, test_agent):
-        """Creating a session with history should seed it with messages."""
-        history = [
-            {"role": "user", "content": "What is 2+2?"},
-            {"role": "assistant", "content": "4"},
-        ]
-        session = test_agent.create_session(name="History Test", history=history)
+    def test_seed_session_with_messages(self, client, test_agent):
+        """Seeding a session via add_message should persist the transcript."""
+        session = _make_session(client, test_agent, name="History Test")
+        session.add_message(role="user", content="What is 2+2?")
+        session.add_message(role="assistant", content="4")
 
         assert session.id is not None
         messages = session.messages()
@@ -157,7 +162,7 @@ class TestSessionCRUD:
 
     def test_delete_session(self, client, test_agent):
         """Deleting a session should succeed."""
-        session = test_agent.create_session(name="Delete Me")
+        session = _make_session(client, test_agent, name="Delete Me")
         session_id = session.id
         assert session_id is not None
 
@@ -176,7 +181,7 @@ class TestSessionMessages:
     @pytest.fixture()
     def session(self, client, test_agent):
         """Create a session for message tests and clean up after."""
-        s = test_agent.create_session(name=f"Msg Test {int(time.time())}")
+        s = _make_session(client, test_agent, name=f"Msg Test {int(time.time())}")
         yield s
         try:
             s.delete()
@@ -299,13 +304,13 @@ class TestSessionWithAgentRun:
     """Tests for how agent.run() interacts with sessions."""
 
     def test_run_with_session_adds_messages(self, client, test_agent):
-        """Running an agent with a session_id should add messages to the session."""
-        session = test_agent.create_session(name="Run Test")
+        """Running an agent with session=… should add messages to the session."""
+        session = _make_session(client, test_agent, name="Run Test")
         msgs_before = session.messages()
 
         result = test_agent.run(
             "What is the capital of France?",
-            session_id=session.id,
+            session=session,
         )
         assert result.status == "SUCCESS"
 
@@ -334,7 +339,7 @@ class TestSessionErrors:
 
     def test_react_to_user_message_raises_error(self, client, test_agent):
         """Reacting to a user message should raise an APIError."""
-        session = test_agent.create_session(name="React Error Test")
+        session = _make_session(client, test_agent, name="React Error Test")
         msg = session.add_message(role="user", content="Can't like this")
 
         with pytest.raises(APIError, match="assistant"):

--- a/tests/functional/v2/test_snake_case_e2e.py
+++ b/tests/functional/v2/test_snake_case_e2e.py
@@ -172,14 +172,15 @@ class TestAgentRunParamsKwargs:
     call agent.run() with the snake_case kwarg → backend accepts and responds.
     """
 
-    def test_session_id(self, client, test_agent):
-        """session_id (renamed from sessionId) is sent to the backend and reflected in the response."""
+    def test_session(self, client, test_agent):
+        """session=… routes the run through the session and reflects the id in the response."""
         agent = client.Agent.get(test_agent.id)
-        session = agent.create_session(name="snake_case_test")
+        session = client.Session(agent=agent, name="snake_case_test")
+        session.save()
         sid = session.id
 
         try:
-            response = agent.run("ping", session_id=sid)
+            response = agent.run("ping", session=session)
 
             assert response.status == "SUCCESS"
             assert response.data.session_id is not None
@@ -214,23 +215,17 @@ class TestAgentRunParamsKwargs:
 
         assert response.status == "SUCCESS"
 
-    def test_allow_history_and_session_id(self, client, test_agent):
-        """allow_history_and_session_id (renamed from allowHistoryAndSessionId) is accepted."""
+    def test_history_on_direct_run(self, client, test_agent):
+        """history (a legacy direct-run kwarg) is accepted on a sessionless run.
+
+        Conversation continuity now flows through session=… rather than
+        combining history with a session in one run.
+        """
         agent = client.Agent.get(test_agent.id)
-        session = agent.create_session(name="history_test")
-        sid = session.id
 
-        try:
-            response = agent.run(
-                "ping",
-                session_id=sid,
-                history=[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
-                allow_history_and_session_id=True,
-            )
+        response = agent.run(
+            "ping",
+            history=[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+        )
 
-            assert response.status == "SUCCESS"
-        finally:
-            try:
-                session.delete()
-            except Exception:
-                pass
+        assert response.status == "SUCCESS"

--- a/tests/unit/v2/test_agent_session_tool_parameters.py
+++ b/tests/unit/v2/test_agent_session_tool_parameters.py
@@ -1,7 +1,7 @@
 """Unit tests for tool-parameter overrides through the session run path (PROD-2481).
 
 Per-tool parameters are set by mutating the agent's tool objects (object API).
-``run(via_session=True)`` serializes the agent's *current* tool parameter state
+``run(query, session=…)`` serializes the agent's *current* tool parameter state
 into the per-message override, matching the single-shot run path. The
 session-level ``tools`` dict kwargs that PR #967 added were removed in favor of
 this object-based flow.
@@ -73,11 +73,11 @@ class TestExecutionConfigNoTools:
     def test_execution_config_has_no_tools_field(self):
         assert "tools" not in ExecutionConfig().__dict__
 
-    def test_create_session_rejects_tools_kwarg(self):
-        agent = _bound_agent(_make_mock_context())(id="agent_99", name="A")
-        agent._update_saved_state()
+    def test_session_rejects_tools_kwarg(self):
+        # Session carries no session-level tools override; per-tool params flow
+        # through the object API + the per-message tools override instead.
         with pytest.raises(TypeError):
-            agent.create_session(tools=[{"id": "tool-1"}])
+            Session(agent_id="agent_99", tools=[{"id": "tool-1"}])
 
 
 # ---------------------------------------------------------------------------
@@ -116,11 +116,11 @@ class TestAddMessageTools:
 
 
 # ---------------------------------------------------------------------------
-# via_session=True forwards the agent's current tool params as the override.
+# run(query, session=…) forwards the agent's current tool params as the override.
 # ---------------------------------------------------------------------------
 
 
-class TestRunViaSessionTools:
+class TestRunWithSessionTools:
     def _wire_poll_success(self, ctx, request_id):
         ctx.client.get.return_value = {
             "status": "SUCCESS",
@@ -136,40 +136,41 @@ class TestRunViaSessionTools:
         class BoundSession(Session):
             context = ctx
 
-        BoundSession.save = lambda self, *a, **kw: setattr(self, "id", "sess_new") or self
-
         def fake_add_message(self, role, content, **kw):
             add_calls.append(kw)
             return _user_message(request_id="req_xyz")
 
         BoundSession.add_message = fake_add_message
         ctx.Session = BoundSession
+        session = BoundSession(agent_id="agent_99", name="A")
+        session.id = "sess_new"
+        return session
 
-    def test_via_session_routes_agent_tool_params(self):
+    def test_session_run_routes_agent_tool_params(self):
         ctx = _make_mock_context()
         add_calls: List[dict] = []
-        self._bound_session(ctx, add_calls)
+        session = self._bound_session(ctx, add_calls)
         self._wire_poll_success(ctx, "req_xyz")
 
         agent = _bound_agent(ctx)(id="agent_99", name="A", tools=[_model_tool(temperature=0.7)])
         agent._update_saved_state()
 
-        agent.run("hi", via_session=True)
+        agent.run("hi", session=session)
 
         assert len(add_calls) == 1
         tool = _tool_by_id(add_calls[0]["tools"], "m2")
         assert _params_as_dict(tool["parameters"]) == {"temperature": 0.7}
 
-    def test_via_session_without_tool_params_passes_none(self):
+    def test_session_run_without_tool_params_passes_none(self):
         ctx = _make_mock_context()
         add_calls: List[dict] = []
-        self._bound_session(ctx, add_calls)
+        session = self._bound_session(ctx, add_calls)
         self._wire_poll_success(ctx, "req_xyz")
 
         agent = _bound_agent(ctx)(id="agent_99", name="A")
         agent._update_saved_state()
 
-        agent.run("hi", via_session=True)
+        agent.run("hi", session=session)
         assert add_calls[0].get("tools") is None
 
 

--- a/tests/unit/v2/test_agent_via_session.py
+++ b/tests/unit/v2/test_agent_via_session.py
@@ -1,10 +1,12 @@
-"""Unit tests for the opt-in `via_session=True` path on Agent.run().
+"""Unit tests for the `session=` run path on Agent.run().
 
-The opt-in path: post a user message to a Session (carrying the agent's
-`executionConfig`) and then poll the legacy `/sdk/agents/{request_id}/result`
-endpoint using the request_id the backend stamps on the user message.
-That preserves the full `AgentRunResult` shape (steps, execution_stats,
-used_credits, run_time) while migrating the trigger surface to sessions.
+Passing `session=` (a Session object or id string) posts a user message to that
+Session (carrying its `executionConfig`) and then polls the
+`/sdk/agents/{request_id}/result` endpoint using the request_id the backend
+stamps on the user message. That preserves the full `AgentRunResult` shape
+(steps, execution_stats, used_credits, run_time) while routing the trigger
+through sessions. There is no `via_session` flag and no id-only `session_id=`;
+threads are managed through `aix.Session` and passed here.
 """
 
 from unittest.mock import Mock, patch
@@ -49,139 +51,138 @@ def _user_message(request_id="req_abc", id_="msg_user"):
     )
 
 
+def _success_result(session_id="sess_abc", request_id="req_abc"):
+    return {
+        "status": "SUCCESS",
+        "completed": True,
+        "data": {"output": "hi back!", "session_id": session_id, "steps": [{"agent": "agent_99", "thought": "ok"}]},
+        "sessionId": session_id,
+        "requestId": request_id,
+        "usedCredits": 0.42,
+        "runTime": 1.7,
+    }
+
+
 # ---------------------------------------------------------------------------
-# 1. Creates session when no session_id is provided, then polls legacy result
+# 1. session= a Session object → post to it, then poll the run result
 # ---------------------------------------------------------------------------
 
 
-class TestRunViaSessionCreatesSession:
-    def test_creates_session_then_polls_legacy_result(self):
+class TestRunWithSessionObject:
+    def test_session_object_posts_and_polls(self):
         ctx = _make_mock_context()
 
-        # Build a real Session subclass bound to ctx with save() + add_message()
-        # mocked so we can assert how _run_via_session wires them.
         class BoundSession(Session):
             context = ctx
 
-        save_calls = []
         add_calls = []
-
-        def fake_save(self, *a, **kw):
-            self.id = "sess_new"
-            save_calls.append(
-                {
-                    "agent_id": self.agent_id,
-                    "name": self.name,
-                    "execution_config": self.execution_config,
-                }
-            )
-            return self
 
         def fake_add_message(self, role, content, **kw):
             add_calls.append({"role": role, "content": content, "kwargs": kw})
             return _user_message(request_id="req_xyz")
 
-        BoundSession.save = fake_save
         BoundSession.add_message = fake_add_message
         ctx.Session = BoundSession
-
-        # The legacy poll endpoint returns a fully populated result.
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {
-                "output": "hi back!",
-                "session_id": "sess_new",
-                "steps": [{"agent": "agent_99", "thought": "ok"}],
-            },
-            "sessionId": "sess_new",
-            "requestId": "req_xyz",
-            "usedCredits": 0.42,
-            "runTime": 1.7,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_obj", request_id="req_xyz")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
-        result = agent.run(
-            "hi",
-            via_session=True,
-            execution_params={"max_tokens": 64},
-            criteria="be brief",
-        )
+        session = BoundSession(agent=agent, name="thread")
+        session.id = "sess_obj"
 
-        # Session was created with the executionConfig our shortcut kwargs implied.
-        assert len(save_calls) == 1
-        cfg = save_calls[0]["execution_config"]
-        assert isinstance(cfg, ExecutionConfig)
-        assert cfg.execution_params == {"max_tokens": 64}
-        assert cfg.criteria == "be brief"
+        result = agent.run("hi", session=session)
 
-        # User message was POSTed.
+        # The user message was POSTed to the passed-in session.
         assert len(add_calls) == 1
         assert add_calls[0]["role"] == "user"
         assert add_calls[0]["content"] == "hi"
 
-        # Legacy result endpoint was hit with the request_id from the user message.
+        # The run-result endpoint was hit with the user message's request_id.
         get_call = ctx.client.get.call_args_list[0]
         assert "/sdk/agents/req_xyz/result" in get_call[0][0]
 
-        # Result preserves the full legacy shape.
+        # Result preserves the full result shape.
         assert isinstance(result, AgentRunResult)
         assert result.status == "SUCCESS"
         assert result.completed is True
-        assert result.session_id == "sess_new"
+        assert result.session_id == "sess_obj"
         assert result.request_id == "req_xyz"
         assert result.data.output == "hi back!"
         assert result.data.steps == [{"agent": "agent_99", "thought": "ok"}]
         assert result.used_credits == 0.42
         assert result.run_time == 1.7
 
+    def test_session_object_without_context_is_bound(self):
+        """A Session with no context is bound to the agent's context on run."""
+        ctx = _make_mock_context()
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        session = Session(agent_id="agent_99", name="unbound")
+        session.id = "sess_unbound"
+        session.add_message = Mock(return_value=_user_message(request_id="req_bound"))
+        assert getattr(session, "context", None) is None
+
+        ctx.client.get.return_value = _success_result(session_id="sess_unbound", request_id="req_bound")
+        agent.run("hi", session=session)
+
+        assert session.context is ctx
+        session.add_message.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
-# 2. Reuses an existing session_id without creating a new one
+# 2. session= an id string → fetched via Session.get
 # ---------------------------------------------------------------------------
 
 
-class TestRunViaSessionReuse:
-    def test_reuses_existing_session_id(self):
+class TestRunWithSessionId:
+    def test_session_id_fetches_via_get(self):
         ctx = _make_mock_context()
 
         existing = Mock(spec=Session)
         existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = None
         existing.add_message = Mock(return_value=_user_message(request_id="req_reuse"))
 
         ctx.Session = Mock()
         ctx.Session.get = Mock(return_value=existing)
-
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {"output": "again", "session_id": "sess_abc", "steps": []},
-            "sessionId": "sess_abc",
-            "requestId": "req_reuse",
-            "usedCredits": 0.0,
-            "runTime": 0.5,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_reuse")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
-        result = agent.run("hi again", via_session=True, session_id="sess_abc")
+        result = agent.run("hi again", session="sess_abc")
 
         ctx.Session.get.assert_called_once_with("sess_abc")
-        # No new session was instantiated via ctx.Session(...).
-        ctx.Session.assert_not_called()
         existing.add_message.assert_called_once()
-        # And the legacy poll endpoint used the user message's request_id.
         get_call = ctx.client.get.call_args_list[0]
         assert "/sdk/agents/req_reuse/result" in get_call[0][0]
         assert result.session_id == "sess_abc"
 
-    def test_reused_session_applies_per_run_overrides_and_warns(self):
-        """Per-run execution kwargs on a reused session_id must take effect.
+    def test_bad_session_type_raises(self):
+        ctx = _make_mock_context()
+        ctx.Session = Mock()
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        with pytest.raises(TypeError, match="session must be a Session instance or a session id"):
+            agent.run("hi", session=123)
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-run execution overrides merge onto the session's config
+# ---------------------------------------------------------------------------
+
+
+class TestRunWithSessionOverrides:
+    def test_applies_per_run_overrides_and_warns(self):
+        """Per-run execution kwargs on a session must take effect.
 
         They are merged onto the session's stored executionConfig and the
         session is re-saved, with a warning that the config is mutated for
@@ -191,121 +192,92 @@ class TestRunViaSessionReuse:
 
         existing = Mock(spec=Session)
         existing.id = "sess_abc"
+        existing.context = ctx
         existing.execution_config = ExecutionConfig(execution_params={"max_tokens": 64})
         existing.save = Mock()
         existing.add_message = Mock(return_value=_user_message(request_id="req_override"))
 
         ctx.Session = Mock()
         ctx.Session.get = Mock(return_value=existing)
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {"output": "ok", "session_id": "sess_abc", "steps": []},
-            "sessionId": "sess_abc",
-            "requestId": "req_override",
-            "usedCredits": 0.0,
-            "runTime": 0.5,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_override")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
-        with pytest.warns(UserWarning, match="existing session_id"):
-            agent.run(
-                "hi again",
-                via_session=True,
-                session_id="sess_abc",
-                criteria="be brief",
-            )
+        with pytest.warns(UserWarning, match="session 'sess_abc'"):
+            agent.run("hi again", session="sess_abc", criteria="be brief")
 
-        # The session's stored config was updated: existing field preserved,
-        # the override merged in, and the session re-saved before the message.
         existing.save.assert_called_once()
         assert existing.execution_config.execution_params == {"max_tokens": 64}
         assert existing.execution_config.criteria == "be brief"
         existing.add_message.assert_called_once()
 
-    def test_reused_session_without_overrides_does_not_resave(self):
+    def test_without_overrides_does_not_resave(self):
         ctx = _make_mock_context()
 
         existing = Mock(spec=Session)
         existing.id = "sess_abc"
+        existing.context = ctx
         existing.execution_config = ExecutionConfig(criteria="be brief")
         existing.save = Mock()
         existing.add_message = Mock(return_value=_user_message(request_id="req_noop"))
 
         ctx.Session = Mock()
         ctx.Session.get = Mock(return_value=existing)
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {"output": "ok", "session_id": "sess_abc", "steps": []},
-            "sessionId": "sess_abc",
-            "requestId": "req_noop",
-            "usedCredits": 0.0,
-            "runTime": 0.5,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_noop")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
-        # No override kwargs → session config is left untouched, no re-save.
-        agent.run("hi again", via_session=True, session_id="sess_abc")
+        agent.run("hi again", session="sess_abc")
         existing.save.assert_not_called()
 
-    def test_reused_session_matching_overrides_does_not_resave(self):
+    def test_matching_overrides_does_not_resave(self):
         ctx = _make_mock_context()
 
         existing = Mock(spec=Session)
         existing.id = "sess_abc"
+        existing.context = ctx
         existing.execution_config = ExecutionConfig(criteria="be brief")
         existing.save = Mock()
         existing.add_message = Mock(return_value=_user_message(request_id="req_same"))
 
         ctx.Session = Mock()
         ctx.Session.get = Mock(return_value=existing)
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {"output": "ok", "session_id": "sess_abc", "steps": []},
-            "sessionId": "sess_abc",
-            "requestId": "req_same",
-            "usedCredits": 0.0,
-            "runTime": 0.5,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_same")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
-        # Override equals stored config → no mutation, no re-save, no warning.
         import warnings as _warnings
 
         with _warnings.catch_warnings():
             _warnings.simplefilter("error")
-            agent.run("hi again", via_session=True, session_id="sess_abc", criteria="be brief")
+            agent.run("hi again", session="sess_abc", criteria="be brief")
         existing.save.assert_not_called()
 
+
+# ---------------------------------------------------------------------------
+# 4. Attachments / files / audio-as-prompt
+# ---------------------------------------------------------------------------
+
+
+class TestRunWithSessionAttachments:
     def test_forwards_attachments_and_files_to_user_message(self):
         ctx = _make_mock_context()
 
         existing = Mock(spec=Session)
         existing.id = "sess_att"
+        existing.context = ctx
+        existing.execution_config = None
         existing.add_message = Mock(return_value=_user_message(request_id="req_att"))
 
         ctx.Session = Mock()
         ctx.Session.get = Mock(return_value=existing)
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {"output": "ok", "session_id": "sess_att", "steps": []},
-            "sessionId": "sess_att",
-            "requestId": "req_att",
-            "usedCredits": 0.0,
-            "runTime": 0.5,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_att", request_id="req_att")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
@@ -313,13 +285,7 @@ class TestRunViaSessionReuse:
 
         attachments = [{"url": "https://s3/a.png", "type": "image"}]
         files = ["/tmp/report.pdf"]
-        agent.run(
-            "describe these",
-            via_session=True,
-            session_id="sess_att",
-            attachments=attachments,
-            files=files,
-        )
+        agent.run("describe these", session="sess_att", attachments=attachments, files=files)
 
         _, kwargs = existing.add_message.call_args
         assert kwargs["attachments"] == attachments
@@ -331,26 +297,20 @@ class TestRunViaSessionReuse:
 
         existing = Mock(spec=Session)
         existing.id = "sess_aud"
+        existing.context = ctx
+        existing.execution_config = None
         existing.add_message = Mock(return_value=_user_message(request_id="req_aud"))
 
         ctx.Session = Mock()
         ctx.Session.get = Mock(return_value=existing)
-        ctx.client.get.return_value = {
-            "status": "SUCCESS",
-            "completed": True,
-            "data": {"output": "ok", "session_id": "sess_aud", "steps": []},
-            "sessionId": "sess_aud",
-            "requestId": "req_aud",
-            "usedCredits": 0.0,
-            "runTime": 0.5,
-        }
+        ctx.client.get.return_value = _success_result(session_id="sess_aud", request_id="req_aud")
 
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
         attachments = [{"url": "https://s3/a.wav", "type": "audio"}]
-        agent.run(via_session=True, session_id="sess_aud", attachments=attachments)
+        agent.run(session="sess_aud", attachments=attachments)
 
         _, kwargs = existing.add_message.call_args
         assert kwargs["content"] == ""  # empty query coerced to empty content
@@ -358,28 +318,32 @@ class TestRunViaSessionReuse:
 
     def test_raises_when_no_query_and_no_attachments(self):
         ctx = _make_mock_context()
+        existing = Mock(spec=Session)
+        existing.id = "sess_x"
+        existing.context = ctx
+        existing.execution_config = None
         ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
         with pytest.raises(ValueError, match="requires a query or attachments"):
-            agent.run(via_session=True, session_id="sess_x")
+            agent.run(session="sess_x")
 
 
 # ---------------------------------------------------------------------------
-# 3. Missing requestId on the user message → ValueError (defensive)
+# 5. Missing requestId on the user message → ValueError (defensive)
 # ---------------------------------------------------------------------------
 
 
-class TestRunViaSessionMissingRequestId:
+class TestRunWithSessionMissingRequestId:
     def test_raises_when_user_message_has_no_request_id(self):
         ctx = _make_mock_context()
 
         class BoundSession(Session):
             context = ctx
 
-        BoundSession.save = lambda self, *a, **kw: setattr(self, "id", "sess_new") or self
         BoundSession.add_message = lambda self, role, content, **kw: _user_message(request_id=None)
         ctx.Session = BoundSession
 
@@ -387,57 +351,65 @@ class TestRunViaSessionMissingRequestId:
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
+        session = BoundSession(agent_id="agent_99")
+        session.id = "sess_new"
+
         with pytest.raises(ValueError, match="requestId"):
-            agent.run("hi", via_session=True)
+            agent.run("hi", session=session)
 
 
 # ---------------------------------------------------------------------------
-# 4. Rejects legacy-only kwargs under via_session=True
+# 6. Rejects legacy-only kwargs when running with a session
 # ---------------------------------------------------------------------------
 
 
-class TestRunViaSessionRejectsLegacyKwargs:
+class TestRunWithSessionRejectsLegacyKwargs:
     @pytest.mark.parametrize(
         "legacy_kwarg",
-        ["tasks", "prompt", "inspectors", "history", "variables", "allow_history_and_session_id"],
+        ["tasks", "prompt", "inspectors", "history", "variables"],
     )
     def test_rejects_legacy_kwargs(self, legacy_kwarg):
         ctx = _make_mock_context()
+        existing = Mock(spec=Session)
+        existing.id = "sess_x"
+        existing.context = ctx
+        existing.execution_config = None
         ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
         with pytest.raises(ValueError, match=legacy_kwarg):
-            agent.run("hi", via_session=True, **{legacy_kwarg: ["something"]})
+            agent.run("hi", session="sess_x", **{legacy_kwarg: ["something"]})
 
 
 # ---------------------------------------------------------------------------
-# 5. run_async with via_session=True is not implemented
+# 7. run_async with session= is not implemented
 # ---------------------------------------------------------------------------
 
 
-class TestRunAsyncViaSessionNotImplemented:
-    def test_run_async_via_session_not_implemented(self):
+class TestRunAsyncWithSessionNotImplemented:
+    def test_run_async_with_session_not_implemented(self):
         ctx = _make_mock_context()
         ctx.Session = Mock()
         BoundAgent = _bound_agent(ctx)
         agent = BoundAgent(id="agent_99", name="A")
         agent._update_saved_state()
 
-        with pytest.raises(NotImplementedError, match="via_session"):
-            agent.run_async("hi", via_session=True)
+        with pytest.raises(NotImplementedError, match="session"):
+            agent.run_async("hi", session="sess_x")
 
 
 # ---------------------------------------------------------------------------
-# 6. Default path (no via_session) still hits legacy /v2/agents/{id}/run
+# 8. Default path (no session) still hits /v2/agents/{id}/run
 # ---------------------------------------------------------------------------
 
 
 class TestDefaultPathUnchanged:
-    def test_run_default_path_hits_legacy_endpoint(self):
+    def test_run_default_path_hits_direct_endpoint(self):
         ctx = _make_mock_context()
-        # Legacy run: POST returns a polling URL, then GET resolves to a SUCCESS.
+        # Direct run: POST returns a polling URL, then GET resolves to a SUCCESS.
         ctx.client.request.return_value = {
             "status": "IN_PROGRESS",
             "data": "https://platform-api.aixplain.com/sdk/agents/exec_42/result",
@@ -445,9 +417,9 @@ class TestDefaultPathUnchanged:
         ctx.client.get.return_value = {
             "status": "SUCCESS",
             "completed": True,
-            "data": {"output": "legacy reply", "session_id": None, "steps": []},
+            "data": {"output": "direct reply", "session_id": None, "steps": []},
             "sessionId": None,
-            "requestId": "req_legacy",
+            "requestId": "req_direct",
             "usedCredits": 0.5,
             "runTime": 1.2,
         }
@@ -459,62 +431,15 @@ class TestDefaultPathUnchanged:
         with patch("time.sleep"):
             result = agent.run("hi")
 
-        # Legacy POST went to v2/agents/{id}/run.
+        # Direct POST went to v2/agents/{id}/run.
         post_call = ctx.client.request.call_args_list[0]
         assert post_call[0][0] == "post"
         assert "v2/agents/agent_99/run" in post_call[0][1]
 
-        # Legacy poll URL was used.
+        # Direct poll URL was used.
         get_call = ctx.client.get.call_args_list[0]
         assert "/sdk/agents/exec_42/result" in get_call[0][0]
 
-        # And we did NOT touch ctx.Session at all.
-        assert not hasattr(ctx.Session, "save") or not ctx.Session.save.called  # type: ignore[attr-defined]
-
         assert result.status == "SUCCESS"
-        assert result.data.output == "legacy reply"
+        assert result.data.output == "direct reply"
         assert result.used_credits == 0.5
-
-
-# ---------------------------------------------------------------------------
-# 7. generate_session_id() is a deprecated shim over create_session()
-# ---------------------------------------------------------------------------
-
-
-class TestGenerateSessionIdDeprecationShim:
-    def test_warns_and_delegates_to_create_session(self):
-        ctx = _make_mock_context()
-        BoundAgent = _bound_agent(ctx)
-        agent = BoundAgent(id="agent_99", name="A")
-        agent._update_saved_state()
-
-        created = Mock(spec=Session)
-        created.id = "sess_shim"
-
-        with patch.object(BoundAgent, "create_session", return_value=created) as create_mock:
-            with pytest.warns(DeprecationWarning, match="create_session"):
-                session_id = agent.generate_session_id()
-
-        assert session_id == "sess_shim"
-        create_mock.assert_called_once()
-
-    def test_auto_saves_unsaved_agent_before_creating_session(self):
-        """Preserves the legacy behavior of persisting an unsaved agent."""
-        ctx = _make_mock_context()
-        BoundAgent = _bound_agent(ctx)
-        agent = BoundAgent(name="A")  # no id → unsaved
-
-        created = Mock(spec=Session)
-        created.id = "sess_shim"
-
-        def fake_save(self, *a, **kw):
-            self.id = "agent_saved"
-            return self
-
-        with patch.object(BoundAgent, "save", fake_save):
-            with patch.object(BoundAgent, "create_session", return_value=created):
-                with pytest.warns(DeprecationWarning):
-                    session_id = agent.generate_session_id()
-
-        assert agent.id == "agent_saved"
-        assert session_id == "sess_shim"

--- a/tests/unit/v2/test_session.py
+++ b/tests/unit/v2/test_session.py
@@ -419,10 +419,10 @@ class TestSessionDelete:
         assert result.completed is True
 
 
-class TestSessionList:
-    """Tests for Session.list() classmethod."""
+class TestSessionSearch:
+    """Tests for Session.search() classmethod (returns a Page)."""
 
-    def test_list_returns_sessions(self):
+    def test_search_returns_page_of_sessions(self):
         ctx = _make_mock_context()
         ctx.client.request.return_value = [
             SAMPLE_SESSION_DICT,
@@ -430,64 +430,117 @@ class TestSessionList:
         ]
         BoundSession = _bound_session_class(ctx)
 
-        sessions = BoundSession.list()
+        page = BoundSession.search()
 
         ctx.client.request.assert_called_once()
         args, kwargs = ctx.client.request.call_args
         assert args[0] == "get"
         assert "v1/sessions" in args[1]
-        assert len(sessions) == 2
-        assert sessions[0].id == "sess_001"
-        assert sessions[1].id == "sess_002"
+        assert page.total == 2
+        assert page.page_total == 1
+        assert page.page_number == 0
+        assert len(page.results) == 2
+        assert page.results[0].id == "sess_001"
+        assert page.results[1].id == "sess_002"
+        # Page is iterable over its results.
+        assert [s.id for s in page] == ["sess_001", "sess_002"]
 
-    def test_list_with_agent_id_filter(self):
+    def test_search_with_agent_object_filter(self):
         ctx = _make_mock_context()
         ctx.client.request.return_value = [SAMPLE_SESSION_DICT]
         BoundSession = _bound_session_class(ctx)
 
-        BoundSession.list(agent_id="agent_99")
+        class _Agent:
+            id = "agent_99"
+
+        BoundSession.search(agent=_Agent())
 
         _, kwargs = ctx.client.request.call_args
         assert kwargs["params"]["agentId"] == "agent_99"
 
-    def test_list_with_status_filter(self):
+    def test_search_with_agent_id_string_filter(self):
+        ctx = _make_mock_context()
+        ctx.client.request.return_value = [SAMPLE_SESSION_DICT]
+        BoundSession = _bound_session_class(ctx)
+
+        BoundSession.search(agent="agent_99")
+
+        _, kwargs = ctx.client.request.call_args
+        assert kwargs["params"]["agentId"] == "agent_99"
+
+    def test_search_with_status_filter(self):
         ctx = _make_mock_context()
         ctx.client.request.return_value = []
         BoundSession = _bound_session_class(ctx)
 
-        BoundSession.list(status="completed")
+        BoundSession.search(status="completed")
 
         _, kwargs = ctx.client.request.call_args
         assert kwargs["params"]["status"] == "completed"
 
-    def test_list_with_user_id_filter(self):
+    def test_search_with_user_id_filter(self):
         ctx = _make_mock_context()
         ctx.client.request.return_value = []
         BoundSession = _bound_session_class(ctx)
 
-        BoundSession.list(user_id="user_42")
+        BoundSession.search(user_id="user_42")
 
         _, kwargs = ctx.client.request.call_args
         assert kwargs["params"]["userId"] == "user_42"
 
-    def test_list_with_all_filters(self):
+    def test_search_with_date_and_memory_filters(self):
+        from datetime import datetime
+
         ctx = _make_mock_context()
         ctx.client.request.return_value = []
         BoundSession = _bound_session_class(ctx)
 
-        BoundSession.list(agent_id="a1", status="active", user_id="u1")
+        BoundSession.search(
+            created_after=datetime(2026, 1, 1),
+            created_before="2026-06-01T00:00:00",
+            memory_enabled=True,
+        )
 
         _, kwargs = ctx.client.request.call_args
         params = kwargs["params"]
-        assert params == {"agentId": "a1", "status": "active", "userId": "u1"}
+        assert params["createdAfter"] == "2026-01-01T00:00:00"
+        assert params["createdBefore"] == "2026-06-01T00:00:00"
+        assert params["memoryEnabled"] is True
 
-    def test_list_empty_result(self):
+    def test_search_forwards_pagination(self):
         ctx = _make_mock_context()
         ctx.client.request.return_value = []
         BoundSession = _bound_session_class(ctx)
 
-        sessions = BoundSession.list()
-        assert sessions == []
+        BoundSession.search(page_number=2, page_size=5)
+
+        _, kwargs = ctx.client.request.call_args
+        assert kwargs["params"]["pageNumber"] == 2
+        assert kwargs["params"]["pageSize"] == 5
+
+    def test_search_empty_result(self):
+        ctx = _make_mock_context()
+        ctx.client.request.return_value = []
+        BoundSession = _bound_session_class(ctx)
+
+        page = BoundSession.search()
+        assert page.results == []
+        assert page.total == 0
+
+    def test_search_paginated_dict_envelope(self):
+        """Tolerate a future paginated dict envelope (total/pageTotal)."""
+        ctx = _make_mock_context()
+        ctx.client.request.return_value = {
+            "results": [SAMPLE_SESSION_DICT],
+            "total": 17,
+            "pageTotal": 4,
+        }
+        BoundSession = _bound_session_class(ctx)
+
+        page = BoundSession.search(page_number=1)
+        assert page.total == 17
+        assert page.page_total == 4
+        assert len(page.results) == 1
 
 
 # =========================================================================
@@ -819,31 +872,33 @@ class TestSessionErrorHandling:
         session._update_saved_state()
         return session
 
-    # --- list() errors ---
+    # --- search() errors ---
 
-    def test_list_api_error_propagates(self):
+    def test_search_api_error_propagates(self):
         ctx = _make_mock_context()
         ctx.client.request.side_effect = APIError("Unauthorized", status_code=401)
         BoundSession = _bound_session_class(ctx)
 
         with pytest.raises(APIError, match="Unauthorized"):
-            BoundSession.list()
+            BoundSession.search()
 
-    def test_list_non_list_response_raises_resource_error(self):
+    def test_search_dict_without_results_yields_empty_page(self):
+        # A dict response is treated as a (future) paginated envelope; one that
+        # carries no results/items key yields an empty page rather than raising.
         ctx = _make_mock_context()
         ctx.client.request.return_value = {"error": "something went wrong"}
         BoundSession = _bound_session_class(ctx)
 
-        with pytest.raises(ResourceError, match="Expected a list of sessions"):
-            BoundSession.list()
+        page = BoundSession.search()
+        assert page.results == []
 
-    def test_list_malformed_item_raises_resource_error(self):
+    def test_search_malformed_item_raises_resource_error(self):
         ctx = _make_mock_context()
         ctx.client.request.return_value = ["not_a_dict"]
         BoundSession = _bound_session_class(ctx)
 
         with pytest.raises(ResourceError, match="Failed to parse session"):
-            BoundSession.list()
+            BoundSession.search()
 
     # --- messages() errors ---
 
@@ -932,150 +987,33 @@ class TestSessionErrorHandling:
 
 
 # =========================================================================
-# Agent — session convenience methods
+# Agent — session convenience: create/list live on aix.Session now
 # =========================================================================
 
 
-class TestAgentCreateSession:
-    """Tests for Agent.create_session()."""
+class TestAgentSessionMethodsRemoved:
+    """The three collapsed create/list/id paths are gone from Agent.
 
-    def test_create_session_calls_save(self):
+    Sessions are managed through ``aix.Session`` alone: create with
+    ``aix.Session(agent=…)``, find with ``aix.Session.search(agent=…)``.
+    """
+
+    @pytest.mark.parametrize("method_name", ["create_session", "list_sessions", "generate_session_id"])
+    def test_removed_agent_methods(self, method_name):
         ctx = _make_mock_context()
-        # Mock Session class bound to context
-        mock_session_instance = Mock()
-        mock_session_instance.save.return_value = mock_session_instance
-        mock_session_instance.id = "new_sess"
+        BoundAgent = _bound_agent_class(ctx)
+        agent = BoundAgent(id="agent_99", name="Test Agent")
+        assert not hasattr(agent, method_name)
 
-        MockSession = Mock(return_value=mock_session_instance)
-        ctx.Session = MockSession
-
+    def test_session_constructor_accepts_agent(self):
+        ctx = _make_mock_context()
+        BoundSession = _bound_session_class(ctx)
         BoundAgent = _bound_agent_class(ctx)
         agent = BoundAgent(id="agent_99", name="Test Agent")
 
-        session = agent.create_session(name="Chat 1")
-
-        MockSession.assert_called_once_with(agent_id="agent_99", name="Chat 1", execution_config=None)
-        mock_session_instance.save.assert_called_once()
-        assert session is mock_session_instance
-
-    def test_create_session_without_name(self):
-        ctx = _make_mock_context()
-        mock_session_instance = Mock()
-        mock_session_instance.save.return_value = mock_session_instance
-        MockSession = Mock(return_value=mock_session_instance)
-        ctx.Session = MockSession
-
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-
-        agent.create_session()
-
-        MockSession.assert_called_once_with(agent_id="agent_99", name=None, execution_config=None)
-
-    def test_create_session_with_history(self):
-        ctx = _make_mock_context()
-        mock_session_instance = Mock()
-        mock_session_instance.save.return_value = mock_session_instance
-        mock_session_instance.id = "new_sess"
-        MockSession = Mock(return_value=mock_session_instance)
-        ctx.Session = MockSession
-
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-
-        history = [
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi there!"},
-            {"role": "user", "content": "How are you?"},
-        ]
-        session = agent.create_session(name="With History", history=history)
-
-        mock_session_instance.save.assert_called_once()
-        assert mock_session_instance.add_message.call_count == 3
-        calls = mock_session_instance.add_message.call_args_list
-        assert calls[0] == call(role="user", content="Hello", attachments=None, files=None)
-        assert calls[1] == call(role="assistant", content="Hi there!", attachments=None, files=None)
-        assert calls[2] == call(role="user", content="How are you?", attachments=None, files=None)
-
-    def test_create_session_with_history_attachments_and_files(self):
-        ctx = _make_mock_context()
-        mock_session_instance = Mock()
-        mock_session_instance.save.return_value = mock_session_instance
-        mock_session_instance.id = "new_sess"
-        MockSession = Mock(return_value=mock_session_instance)
-        ctx.Session = MockSession
-
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-
-        att = [{"url": "https://example.com/img.png", "name": "img.png", "type": "image"}]
-        history = [
-            {"role": "user", "content": "See image", "attachments": att},
-            {"role": "user", "content": "And file", "files": ["/tmp/data.csv"]},
-            {"role": "assistant", "content": "Got it"},
-        ]
-        agent.create_session(name="Rich History", history=history)
-
-        calls = mock_session_instance.add_message.call_args_list
-        assert calls[0] == call(role="user", content="See image", attachments=att, files=None)
-        assert calls[1] == call(role="user", content="And file", attachments=None, files=["/tmp/data.csv"])
-        assert calls[2] == call(role="assistant", content="Got it", attachments=None, files=None)
-
-    def test_create_session_with_invalid_history(self):
-        ctx = _make_mock_context()
-        ctx.Session = Mock()
-
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-
-        with pytest.raises(ValueError):
-            agent.create_session(history=[{"bad": "format"}])
-
-    def test_create_session_requires_saved_agent(self):
-        ctx = _make_mock_context()
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(name="Unsaved Agent")
-
-        with pytest.raises(ValueError, match="must be saved"):
-            agent.create_session()
-
-
-class TestAgentListSessions:
-    """Tests for Agent.list_sessions()."""
-
-    def test_list_sessions_delegates_to_session_list(self):
-        ctx = _make_mock_context()
-        mock_sessions = [Mock(), Mock()]
-        ctx.Session = Mock()
-        ctx.Session.list.return_value = mock_sessions
-
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-
-        result = agent.list_sessions()
-
-        ctx.Session.list.assert_called_once_with(agent_id="agent_99", status=None)
-        assert result == mock_sessions
-
-    def test_list_sessions_with_status_filter(self):
-        ctx = _make_mock_context()
-        ctx.Session = Mock()
-        ctx.Session.list.return_value = []
-
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-
-        agent.list_sessions(status="completed")
-
-        ctx.Session.list.assert_called_once_with(agent_id="agent_99", status="completed")
-
-    def test_list_sessions_requires_saved_agent(self):
-        ctx = _make_mock_context()
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(name="Unsaved Agent")
-
-        with pytest.raises(ValueError, match="must be saved"):
-            agent.list_sessions()
+        session = BoundSession(agent=agent, name="Chat 1")
+        assert session.agent_id == "agent_99"
+        assert session.name == "Chat 1"
 
 
 # =========================================================================
@@ -1381,85 +1319,50 @@ class TestSessionExecutionConfigPayload:
         }
 
 
-class TestAgentCreateSessionExecutionConfig:
-    """Tests for execution config plumbing in Agent.create_session()."""
+class TestSessionExecutionConfigConstruction:
+    """ExecutionConfig is attached to a Session at construction time.
 
-    def _setup(self):
+    (The old ``agent.create_session(execution_params=…, criteria=…)`` shortcut
+    plumbing was removed; callers build an ``ExecutionConfig`` and pass it to
+    ``Session(execution_config=…)``, or pass per-run overrides to
+    ``agent.run(query, session=…)``.)
+    """
+
+    def test_shortcut_style_execution_config(self):
         ctx = _make_mock_context()
-        mock_session_instance = Mock()
-        mock_session_instance.save.return_value = mock_session_instance
-        mock_session_instance.id = "new_sess"
-        MockSession = Mock(return_value=mock_session_instance)
-        ctx.Session = MockSession
-        BoundAgent = _bound_agent_class(ctx)
-        agent = BoundAgent(id="agent_99", name="Test Agent")
-        return agent, MockSession, mock_session_instance
+        BoundSession = _bound_session_class(ctx)
 
-    def test_shortcut_kwargs_build_execution_config(self):
-        agent, MockSession, _ = self._setup()
-
-        agent.create_session(
-            name="With Config",
+        cfg = ExecutionConfig(
             execution_params={"output_format": "text", "max_tokens": 1024},
             criteria="Be helpful",
             evolve='{"toEvolve": true}',
             identifier="user-abc",
             run_response_generation=True,
         )
+        session = BoundSession(agent_id="agent_99", name="With Config", execution_config=cfg)
 
-        _, kwargs = MockSession.call_args
-        assert kwargs["agent_id"] == "agent_99"
-        assert kwargs["name"] == "With Config"
-        cfg = kwargs["execution_config"]
-        assert isinstance(cfg, ExecutionConfig)
+        assert session.execution_config is cfg
         assert cfg.execution_params == {"output_format": "text", "max_tokens": 1024}
         assert cfg.criteria == "Be helpful"
         assert cfg.evolve == '{"toEvolve": true}'
         assert cfg.identifier == "user-abc"
         assert cfg.run_response_generation is True
 
-    def test_explicit_execution_config_object(self):
-        agent, MockSession, _ = self._setup()
-        explicit = ExecutionConfig(criteria="explicit")
+    def test_dict_execution_config_is_coerced(self):
+        ctx = _make_mock_context()
+        BoundSession = _bound_session_class(ctx)
 
-        agent.create_session(execution_config=explicit)
+        session = BoundSession(agent_id="agent_99", execution_config={"criteria": "x"})
+        assert isinstance(session.execution_config, ExecutionConfig)
+        assert session.execution_config.criteria == "x"
 
-        cfg = MockSession.call_args.kwargs["execution_config"]
-        # The explicit object passes through unchanged.
-        assert cfg is explicit
+    def test_no_execution_config_by_default(self):
+        ctx = _make_mock_context()
+        BoundSession = _bound_session_class(ctx)
 
-    def test_explicit_execution_config_dict_is_coerced(self):
-        agent, MockSession, _ = self._setup()
+        session = BoundSession(agent_id="agent_99", name="plain")
+        assert session.execution_config is None
 
-        agent.create_session(execution_config={"criteria": "x"})
-
-        cfg = MockSession.call_args.kwargs["execution_config"]
-        assert isinstance(cfg, ExecutionConfig)
-        assert cfg.criteria == "x"
-
-    def test_no_execution_config_when_kwargs_omitted(self):
-        agent, MockSession, _ = self._setup()
-
-        agent.create_session(name="plain")
-
-        assert MockSession.call_args.kwargs["execution_config"] is None
-
-    def test_explicit_and_shortcut_kwargs_conflict(self):
-        agent, _, _ = self._setup()
-
-        with pytest.raises(ValueError, match="not both"):
-            agent.create_session(
-                execution_config={"criteria": "x"},
-                criteria="y",
-            )
-
-    def test_run_response_generation_false_still_builds_config(self):
-        # False is a meaningful explicit choice (default behavior is False),
-        # so passing it must still flow through to the session.
-        agent, MockSession, _ = self._setup()
-
-        agent.create_session(run_response_generation=False)
-
-        cfg = MockSession.call_args.kwargs["execution_config"]
-        assert isinstance(cfg, ExecutionConfig)
+    def test_run_response_generation_false_is_kept(self):
+        cfg = ExecutionConfig(run_response_generation=False)
         assert cfg.run_response_generation is False

--- a/tests/unit/v2/test_snake_case_conventions.py
+++ b/tests/unit/v2/test_snake_case_conventions.py
@@ -131,8 +131,11 @@ class TestAgentRunParamsKeys:
 
     def test_snake_case_keys_exist(self):
         hints = AgentRunParams.__annotations__
-        assert "session_id" in hints
-        assert "allow_history_and_session_id" in hints
+        # ``session`` (polymorphic Session/id) replaced the removed id-only
+        # ``session_id`` and the ``allow_history_and_session_id`` flag.
+        assert "session" in hints
+        assert "session_id" not in hints
+        assert "allow_history_and_session_id" not in hints
         assert "execution_params" in hints
         assert "run_response_generation" in hints
 
@@ -180,23 +183,14 @@ class TestBuildRunPayload:
         agent.expected_output = ""
         return agent
 
-    def test_session_id_becomes_camelcase(self):
+    def test_run_response_generation_becomes_camelcase(self):
         agent = self._make_agent()
         payload = agent.build_run_payload(
             query="hello",
-            session_id="sess-1",
+            run_response_generation=True,
         )
-        assert payload["sessionId"] == "sess-1"
-        assert "session_id" not in payload
-
-    def test_allow_history_becomes_camelcase(self):
-        agent = self._make_agent()
-        payload = agent.build_run_payload(
-            query="hello",
-            allow_history_and_session_id=True,
-        )
-        assert payload["allowHistoryAndSessionId"] is True
-        assert "allow_history_and_session_id" not in payload
+        assert payload["runResponseGeneration"] is True
+        assert "run_response_generation" not in payload
 
     def test_execution_params_snake_case_converted(self):
         agent = self._make_agent()


### PR DESCRIPTION
1. Manage sessions through aix.Session alone — removed agent.create_session(), agent.list_sessions(), agent.generate_session_id(), and the internal _resolve_execution_config() helper. Added an agent= init arg to [Session](vscode-webview://0v0m0cuimos6sv6di2jcmtv8mfn5vlksl9rbir21dbi0ueb2327d/aixplain/v2/session.py) (accepts an Agent or an id string), so aix.Session(agent=agent, name=…) is the single create path.

2. Session.search(agent=…) -> Page — replaced the bespoke Session.list(). Session now inherits SearchResourceMixin and overrides [search()](vscode-webview://0v0m0cuimos6sv6di2jcmtv8mfn5vlksl9rbir21dbi0ueb2327d/aixplain/v2/session.py) to hit the real GET /v1/sessions endpoint and wrap results in a Page (tolerates a future paginated-dict envelope too).

3. Date-range + memory filters — search(created_after=…, created_before=…, memory_enabled=…) are wired into the query params. (SDK-side only; backend filter delivery is a follow-up per the story, noted in the docstring.)

4. agent.run(query, session=…) — polymorphic (Session object or id string) via the new _resolve_session/_run_with_session. Dropped via_session and the id-only session_id= from AgentRunParams and the snake→camel map; run_async rejects session= as before.

6. Removed agent.generate_session_id() — gone.

---
IMPORTANT:
- Item 5 (one run endpoint): session= runs go through POST /v1/sessions/{id}/messages; sessionless runs still use the direct /v2/agents/{id}/run. Retiring the direct endpoint needs Ibrahim / backend consolidation.
- Item 7 (ownership): built agent-bound now (matches the backend that welds a session to one agent_id). Agent-agnostic threads / handoff are deferred until the backend can drop the binding — the agent= arg gives us a clean seam to relax later.