### PR TITLE
fix(v2): preserve reasoning_content in model run responses (#985)

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -47,6 +47,7 @@ class Message:
 
     role: str
     content: Optional[str] = None
+    reasoning_content: Optional[str] = None
     tool_calls: Optional[List[dict[str, Any]]] = None
     refusal: Optional[str] = None
     annotations: List[Any] = field(default_factory=list)
@@ -156,6 +157,7 @@ class StreamChunk:
     Attributes:
         status: The current status of the streaming operation (IN_PROGRESS or SUCCESS)
         data: The content/token of this chunk
+        reasoning_content: Reasoning-model chain-of-thought text delta, when provided
         tool_calls: Tool call deltas when stream uses OpenAI-style chunk format
         usage: Usage payload when provided in a stream chunk
         finish_reason: Completion reason for the current choice, when provided
@@ -163,6 +165,7 @@ class StreamChunk:
 
     status: ResponseStatus
     data: str
+    reasoning_content: Optional[str] = None
     tool_calls: Optional[List[dict[str, Any]]] = None
     usage: Optional[dict[str, Any]] = None
     finish_reason: Optional[str] = None
@@ -299,6 +302,9 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                 content = delta.get("content")
                 content = content if isinstance(content, str) else ""
 
+                reasoning_content = delta.get("reasoning_content")
+                reasoning_content = reasoning_content if isinstance(reasoning_content, str) else None
+
                 tool_calls = delta.get("tool_calls")
                 if tool_calls is not None and not isinstance(tool_calls, list):
                     tool_calls = [tool_calls]
@@ -312,6 +318,7 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                 return StreamChunk(
                     status=self.status,
                     data=content,
+                    reasoning_content=reasoning_content,
                     tool_calls=tool_calls,
                     usage=usage,
                     finish_reason=finish_reason,

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -595,6 +595,55 @@ class TestModelStreaming:
         with pytest.raises(StopIteration):
             next(streamer)
 
+    def test_streamer_parses_reasoning_content_deltas(self):
+        """ModelResponseStreamer should preserve delta.reasoning_content from OpenAI chunks.
+
+        Covers three cases: a reasoning-only chunk (empty ``content``) must still be
+        yielded with ``data == ""``, a mixed chunk must carry both, and a plain
+        content chunk must leave ``reasoning_content`` as None.
+        """
+        streamer = self._create_streamer(
+            [
+                'data: {"id":"chatcmpl-r","choices":[{"index":0,"delta":{"reasoning_content":"Let me think"},"finish_reason":null}],"usage":null}',
+                'data: {"id":"chatcmpl-r","choices":[{"index":0,"delta":{"content":"Answer","reasoning_content":" more"},"finish_reason":null}],"usage":null}',
+                'data: {"id":"chatcmpl-r","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}],"usage":null}',
+                "data: [DONE]",
+            ]
+        )
+
+        reasoning_only = next(streamer)
+        mixed = next(streamer)
+        content_only = next(streamer)
+
+        assert reasoning_only.data == ""
+        assert reasoning_only.reasoning_content == "Let me think"
+
+        assert mixed.data == "Answer"
+        assert mixed.reasoning_content == " more"
+
+        assert content_only.data == "!"
+        assert content_only.reasoning_content is None
+
+        with pytest.raises(StopIteration):
+            next(streamer)
+
+    def test_streamer_content_only_chunk_leaves_reasoning_content_none(self):
+        """A content-only OpenAI chunk should stream unchanged with reasoning_content None."""
+        streamer = self._create_streamer(
+            [
+                'data: {"id":"chatcmpl-c","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}],"usage":null}',
+                "data: [DONE]",
+            ]
+        )
+
+        chunk = next(streamer)
+
+        assert chunk.data == "Hello"
+        assert chunk.reasoning_content is None
+        assert chunk.tool_calls is None
+        assert chunk.usage is None
+        assert chunk.finish_reason is None
+
     def test_streamer_normalizes_single_tool_call_object(self):
         """ModelResponseStreamer should normalize a single tool_call object to a list."""
         streamer = self._create_streamer(
@@ -750,6 +799,61 @@ class TestModelIntegrationGaps:
         assert message.tool_calls is not None
         assert message.tool_calls[0]["function"]["name"] == "get_current_time"
         assert message.tool_calls[0]["function"]["arguments"] == '{"city":"Tokyo"}'
+
+    def test_message_deserializes_reasoning_content(self):
+        """ModelResult parsing should preserve reasoning_content from reasoning LLMs.
+
+        For some reasoning models (e.g. Qwen 3.6 35B A3B) the platform routes all
+        completion tokens into ``reasoning_content`` while ``content``/``data`` stay
+        empty; the field must survive deserialization instead of being dropped.
+        """
+        payload = {
+            "details": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "Here's a thinking sequence\n\n1. Deconstruct the prompt: ...",
+                        "name": None,
+                        "tool_calls": [],
+                    },
+                    "finish_reason": "length",
+                    "logprobs": None,
+                }
+            ],
+            "status": "SUCCESS",
+            "completed": True,
+            "data": "",
+            "usage": {"prompt_tokens": "26", "completion_tokens": "80", "total_tokens": 106},
+        }
+
+        result = ModelResult.from_dict(payload)
+
+        message = result.details[0].message
+        assert isinstance(message, Message)
+        assert message.content == ""
+        assert message.reasoning_content == "Here's a thinking sequence\n\n1. Deconstruct the prompt: ..."
+
+    def test_message_without_reasoning_content_defaults_to_none(self):
+        """A message without reasoning_content should deserialize with reasoning_content is None."""
+        payload = {
+            "status": "SUCCESS",
+            "completed": True,
+            "details": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello, world!"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        result = ModelResult.from_dict(payload)
+
+        message = result.details[0].message
+        assert message.content == "Hello, world!"
+        assert message.reasoning_content is None
 
     def test_guardrail_response_with_dict_details_deserializes(self):
         """ModelResult parsing should tolerate a non-list ``details`` payload.


### PR DESCRIPTION
## Summary

Fixes #985 — the v2 SDK dropped `reasoning_content` (reasoning-model chain-of-thought text) from model run responses.

- Add a `reasoning_content: Optional[str]` field to `Message` (non-streaming path).
- Add a `reasoning_content: Optional[str]` field to `StreamChunk` (streaming path).
- Carry `reasoning_content` through the OpenAI-style stream chunk parsing in `ModelResponseStreamer`, reading it from the delta and coercing non-string values to `None`.

## Testing

- Added unit tests covering `reasoning_content` in both the non-streaming `Message` and the streaming `StreamChunk` paths (written TDD-first).
- Full v2 model unit test suite passes; pre-commit hooks (ruff, ruff format, pytest) pass.

Closes #985