### PR TITLE
fix(ci): pytest 'import file mismatch' collection errors on test branch

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+addopts = --import-mode=importlib
 testpaths =
     tests


### PR DESCRIPTION
CI on the `test` branch (and any branch running the full suite) aborts collection with 6 `import file mismatch` errors:

```
imported module 'test_model' has this __file__ attribute:
  .../tests/functional/v2/test_model.py
which is not the same as the test file we want to collect:
  .../tests/unit/v2/test_model.py
```

**Root cause:** duplicate test basenames (`test_model.py`, `test_tool.py`, `test_session.py`, `test_trigger.py`, `test_api_key.py`, `test_rlm.py`) across `tests/unit/v2`, `tests/functional/v2`, and `tests/functional/model`. Most test dirs have no `__init__.py`, so pytest's default *prepend* import mode assigns both files the same top-level module name and aborts.

**Fix:** `addopts = --import-mode=importlib` in `pytest.ini` — each test file gets a fully-qualified module name, so unique basenames are no longer required. This is pytest's recommended mode for new projects.

**Verification:**
- `pytest --collect-only`: 1808 tests collected, 0 errors (was 1458 + 6 errors, collection interrupted)
- `pytest tests/unit`: 1388 passed, 4 skipped
- No test module imports another test module by bare name (the one pattern importlib mode would break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dCb6BE5bqjCrmsiPDGLRr