### PR TITLE
fix(run): propagate caller identifier as x-user-id header without leaking it into model/tool payloads [ENG-3254]

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -620,7 +620,16 @@ class Model(
         else:
             super().__setattr__(name, value)
 
-    _SDK_ONLY_PARAMS = frozenset({"timeout", "wait_time", "show_progress", "stream", "run_retries", "run_retry_wait"})
+    _SDK_ONLY_PARAMS = frozenset(
+        {"timeout", "wait_time", "show_progress", "stream", "run_retries", "run_retry_wait", "identifier"}
+    )
+
+    # ``identifier`` is a per-run caller identity emitted as the ``x-user-id``
+    # header (RunnableResourceMixin._headers_for_run), never a model/action
+    # input. Exclude it from the v2 payload builder here (and from the v1/URL
+    # builders via _SDK_ONLY_PARAMS above) so it cannot leak into model inputs
+    # or supplier-facing logs. Agent keeps it in the body by NOT overriding this.
+    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier"}
 
     def build_run_payload(self, **kwargs: Unpack[ModelRunParams]) -> dict:
         """Build the JSON payload for a model execution request.

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -1219,6 +1219,10 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     RESPONSE_CLASS: type = Result  # Default response class
 
     # SDK-only keys: never forwarded to build_run_payload / build_run_url.
+    # NOTE: ``identifier`` is intentionally NOT excluded here — for Agent runs it
+    # is a legitimate execution-config body field (see Agent). Model/Tool, where
+    # it is header-only, add it to their own override so it never leaks into the
+    # model/action input payload.
     _RUN_CONTROL_KEYS: frozenset[str] = frozenset(
         {
             "run_retries",

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -522,15 +522,23 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
                     result[key] = value
             return result
         elif isinstance(kwargs["data"], list):
-            return {
+            result = {
                 "action": action_name,
                 "data": kwargs["data"],
             }
+            for key, value in kwargs.items():
+                if key not in ["data", "action"]:
+                    result[key] = value
+            return result
         else:
-            return {
+            result = {
                 "action": action_name,
                 "data": {
                     **merged,
                     **kwargs["data"],
                 },
             }
+            for key, value in kwargs.items():
+                if key not in ["data", "action"]:
+                    result[key] = value
+            return result

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -352,6 +352,38 @@ class TestModelRunRouting:
 # =============================================================================
 
 
+class TestModelIdentifierHeader:
+    """identifier must ride as the x-user-id header, never as a model input."""
+
+    def _create_model(self):
+        model = Model.__new__(Model)
+        model.id = "test-model-id"
+        model.name = "Test Model"
+        model.connection_type = ["synchronous"]
+        model.params = None
+        model.__post_init__()
+        model.context = Mock()
+        return model
+
+    def test_identifier_excluded_from_payload(self):
+        """A caller identity passed to run() must not leak into the model input
+        payload (PII / unknown-input); it is header-only for Model/Tool."""
+        model = self._create_model()
+        payload_kwargs = model._payload_kwargs_for_run({"text": "hi", "identifier": "alice"})
+        assert "identifier" not in payload_kwargs
+        assert payload_kwargs["text"] == "hi"
+
+    def test_identifier_still_emitted_as_header(self):
+        model = self._create_model()
+        assert model._headers_for_run({"text": "hi", "identifier": "alice"}) == {"x-user-id": "alice"}
+
+    def test_identifier_excluded_from_build_run_payload(self):
+        """Also excluded from the v1/URL payload builder path (_SDK_ONLY_PARAMS)."""
+        model = self._create_model()
+        payload = model.build_run_payload(text="hi", identifier="alice")
+        assert "identifier" not in payload
+
+
 class TestModelV1Fallback:
     """Tests for _run_async_v1() V1 endpoint integration."""
 

--- a/tests/unit/v2/test_resource.py
+++ b/tests/unit/v2/test_resource.py
@@ -973,6 +973,22 @@ class TestRunnableResourceMixin:
         resource.context.client.request.assert_called_once()
         mock_sleep.assert_not_called()
 
+    def test_identifier_emitted_as_header(self):
+        """identifier is emitted as the x-user-id header for any runnable resource."""
+        resource = self._create_runnable_resource()
+
+        headers = resource._headers_for_run({"text": "hi", "identifier": "alice"})
+        assert headers == {"x-user-id": "alice"}
+
+    def test_base_keeps_identifier_in_payload(self):
+        """The base mixin keeps identifier in the payload — for Agent runs it is a
+        legitimate execution-config body field. Model/Tool exclude it via override."""
+        resource = self._create_runnable_resource()
+
+        payload_kwargs = resource._payload_kwargs_for_run({"text": "hi", "identifier": "alice"})
+        assert payload_kwargs["identifier"] == "alice"
+        assert payload_kwargs["text"] == "hi"
+
 
 # =============================================================================
 # Result Class Tests

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -632,3 +632,39 @@ class TestSingleActionInference:
         errors = tool._validate_params(action="delete", data={})
 
         assert errors == ["Action 'delete' is not allowed for this tool. Allowed actions: ['search']"]
+
+
+class TestMergeWithDynamicAttrs:
+    """Tests that _merge_with_dynamic_attrs preserves extra top-level kwargs."""
+
+    def _make_tool(self):
+        query_spec = _make_action_input_spec()
+        return _make_minimal_tool_with_actions({"search": [query_spec]}, allowed_actions=["search"])
+
+    def test_str_data_preserves_extra_kwargs(self):
+        """str data: extra top-level kwargs should be preserved (existing behavior)."""
+        tool = self._make_tool()
+
+        result = tool._merge_with_dynamic_attrs(action="search", data="hi", identifier="alice")
+
+        assert result["action"] == "search"
+        assert result["data"] == "hi"
+        assert result["identifier"] == "alice"
+
+    def test_dict_data_preserves_extra_kwargs(self):
+        """dict data: extra top-level kwargs should be preserved alongside merged data."""
+        tool = self._make_tool()
+
+        result = tool._merge_with_dynamic_attrs(action="search", data={"q": "hi"}, identifier="alice")
+
+        assert result["identifier"] == "alice"
+        assert result["data"]["q"] == "hi"
+
+    def test_list_data_preserves_extra_kwargs(self):
+        """list data: extra top-level kwargs should be preserved and data stays a list."""
+        tool = self._make_tool()
+
+        result = tool._merge_with_dynamic_attrs(action="search", data=["x"], identifier="alice")
+
+        assert result["identifier"] == "alice"
+        assert result["data"] == ["x"]


### PR DESCRIPTION
## Summary

Per-run `identifier` (the caller identity that becomes the `x-user-id` header) had two problems: it never reached the header for connection/action tools, and it leaked into request bodies for models/tools. This fixes both so `identifier` is a header-only signal for Model/Tool runs, while Agent runs keep it in the body as an execution-config field.

Needed by aixplain-agents ENG-3254 (`x-user-id` propagation to remote tool requests), which calls `run(..., identifier=...)` on model and connection handles.

## Changes

- **`Tool._merge_with_dynamic_attrs` (`tool.py`)** — the dict- and list-data branches dropped every kwarg except `action`/`data`, so `identifier` was discarded before `_headers_for_run` ran and **no `x-user-id` header was ever sent for connection/action tools**. Now preserves extra top-level kwargs symmetrically with the str-data branch (which already did).
- **`Model` payload exclusion (`model.py`)** — `identifier` was forwarded into the model input payload (PII in supplier-facing inputs/logs; risk of "unknown input" validation errors). Added `identifier` to `Model._RUN_CONTROL_KEYS` (v2 path) and `Model._SDK_ONLY_PARAMS` (v1/URL builders) so it is excluded from all model/tool payload builders. `Tool` inherits this via `Tool(Model, ...)`.
- **`resource.py`** — base `RunnableResourceMixin._RUN_CONTROL_KEYS` intentionally does **not** exclude `identifier`: for `Agent` runs it is a legitimate `ExecutionConfig` body field (see #969). Only Model/Tool, where it is header-only, override to exclude it.

## Behavior after this change

| Run type | `x-user-id` header | `identifier` in body |
|----------|--------------------|----------------------|
| Model    | ✅ emitted          | ❌ excluded (leak fixed) |
| Tool / connection | ✅ emitted (was missing) | ❌ excluded |
| Agent    | ✅ emitted          | ✅ kept (intended) |

## Tests

TDD throughout. Added unit coverage: header emission, payload exclusion on both the v2 (`_RUN_CONTROL_KEYS`) and v1/URL (`_SDK_ONLY_PARAMS`) builders, the tool merge preserving identity for dict/list data, and confirmation the base mixin keeps `identifier` in the body (Agent contract). Full v2 unit suite: **1004 passed, 4 skipped**.
