### PR TITLE
fix(model): normalize OpenRouter reasoning fields into reasoning_content

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -56,11 +56,15 @@ def _normalize_reasoning(
     if isinstance(reasoning, str) and reasoning:
         return reasoning
     if isinstance(reasoning_details, list):
-        joined = "".join(
-            d.get("text")
-            for d in reasoning_details
-            if isinstance(d, dict) and d.get("type") == "reasoning.text" and isinstance(d.get("text"), str)
-        )
+        parts = []
+        for d in reasoning_details:
+            if not isinstance(d, dict):
+                continue
+            if d.get("type") == "reasoning.text" and isinstance(d.get("text"), str):
+                parts.append(d["text"])
+            elif d.get("type") == "reasoning.summary" and isinstance(d.get("summary"), str):
+                parts.append(d["summary"])
+        joined = "".join(parts)
         return joined or None
     return None
 
@@ -73,15 +77,19 @@ class Message:
     role: str
     content: Optional[str] = None
     reasoning_content: Optional[str] = None
-    reasoning: Optional[str] = None
-    reasoning_details: Optional[List[Any]] = None
     tool_calls: Optional[List[dict[str, Any]]] = None
     refusal: Optional[str] = None
     annotations: List[Any] = field(default_factory=list)
+    # Raw supplier variants (OpenRouter); folded into ``reasoning_content`` and
+    # cleared in ``__post_init__``. Kept last to preserve positional construction.
+    reasoning: Optional[str] = None
+    reasoning_details: Optional[List[Any]] = None
 
     def __post_init__(self) -> None:
         """Canonicalize supplier-specific reasoning fields onto ``reasoning_content``."""
         self.reasoning_content = _normalize_reasoning(self.reasoning_content, self.reasoning, self.reasoning_details)
+        self.reasoning = None
+        self.reasoning_details = None
 
 
 @dataclass_json

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -40,6 +40,31 @@ _MODEL_POLL_URL_RE = re.compile(
 )
 
 
+def _normalize_reasoning(
+    reasoning_content: Optional[str],
+    reasoning: Optional[str],
+    reasoning_details: Optional[List[Any]],
+) -> Optional[str]:
+    """Canonicalize reasoning onto one field.
+
+    Suppliers disagree on the field name: xAI/vLLM use ``reasoning_content``,
+    OpenRouter uses ``reasoning`` plus structured ``reasoning_details``.
+    Precedence: reasoning_content -> reasoning -> joined reasoning.text blocks.
+    """
+    if isinstance(reasoning_content, str) and reasoning_content:
+        return reasoning_content
+    if isinstance(reasoning, str) and reasoning:
+        return reasoning
+    if isinstance(reasoning_details, list):
+        joined = "".join(
+            d.get("text")
+            for d in reasoning_details
+            if isinstance(d, dict) and d.get("type") == "reasoning.text" and isinstance(d.get("text"), str)
+        )
+        return joined or None
+    return None
+
+
 @dataclass_json
 @dataclass
 class Message:
@@ -48,9 +73,15 @@ class Message:
     role: str
     content: Optional[str] = None
     reasoning_content: Optional[str] = None
+    reasoning: Optional[str] = None
+    reasoning_details: Optional[List[Any]] = None
     tool_calls: Optional[List[dict[str, Any]]] = None
     refusal: Optional[str] = None
     annotations: List[Any] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Canonicalize supplier-specific reasoning fields onto ``reasoning_content``."""
+        self.reasoning_content = _normalize_reasoning(self.reasoning_content, self.reasoning, self.reasoning_details)
 
 
 @dataclass_json
@@ -302,8 +333,12 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                 content = delta.get("content")
                 content = content if isinstance(content, str) else ""
 
-                reasoning_content = delta.get("reasoning_content")
-                reasoning_content = reasoning_content if isinstance(reasoning_content, str) else None
+                raw_details = delta.get("reasoning_details")
+                reasoning_content = _normalize_reasoning(
+                    delta.get("reasoning_content") if isinstance(delta.get("reasoning_content"), str) else None,
+                    delta.get("reasoning") if isinstance(delta.get("reasoning"), str) else None,
+                    raw_details if isinstance(raw_details, list) else None,
+                )
 
                 tool_calls = delta.get("tool_calls")
                 if tool_calls is not None and not isinstance(tool_calls, list):

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -557,6 +557,38 @@ class TestReasoningNormalization:
         msg = Message.from_dict({"role": "assistant", "content": "391"})
         assert msg.reasoning_content is None
 
+    def test_message_reads_reasoning_summary_blocks(self):
+        msg = Message.from_dict(
+            {
+                "role": "assistant",
+                "content": "391",
+                "reasoning_details": [{"type": "reasoning.summary", "summary": "The user wants 17*23."}],
+            }
+        )
+        assert msg.reasoning_content == "The user wants 17*23."
+
+    def test_message_positional_construction_unchanged(self):
+        # New fields live at the end so pre-existing positional callers keep binding
+        # (role, content, reasoning_content, tool_calls, ...).
+        calls = [{"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+        msg = Message("assistant", "hi", None, calls)
+        assert msg.tool_calls == calls
+        assert msg.reasoning_content is None
+
+    def test_message_to_dict_emits_reasoning_once(self):
+        msg = Message.from_dict(
+            {
+                "role": "assistant",
+                "content": "391",
+                "reasoning": "chain of thought",
+                "reasoning_details": [{"type": "reasoning.text", "text": "chain of thought"}],
+            }
+        )
+        data = msg.to_dict()
+        assert data["reasoning_content"] == "chain of thought"
+        assert data.get("reasoning") is None
+        assert data.get("reasoning_details") is None
+
 
 class TestModelStreaming:
     """Tests for v2 streaming parser and streaming payload options."""

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -516,6 +516,48 @@ class TestModelV1Fallback:
 # =============================================================================
 
 
+class TestReasoningNormalization:
+    """OpenRouter returns reasoning on ``reasoning``/``reasoning_details``; the SDK
+    must normalize those into the canonical ``reasoning_content`` field."""
+
+    def test_message_normalizes_openrouter_reasoning_string(self):
+        msg = Message.from_dict(
+            {
+                "role": "assistant",
+                "content": "391",
+                "reasoning": "Okay, let's see. 17*23...",
+                "reasoning_details": [
+                    {"type": "reasoning.text", "text": "Okay, let's see. 17*23...", "format": "unknown", "index": 0}
+                ],
+            }
+        )
+        assert msg.reasoning_content == "Okay, let's see. 17*23..."
+
+    def test_message_prefers_existing_reasoning_content(self):
+        msg = Message.from_dict(
+            {"role": "assistant", "content": "391", "reasoning_content": "xai text", "reasoning": "other"}
+        )
+        assert msg.reasoning_content == "xai text"
+
+    def test_message_joins_reasoning_details_text_blocks(self):
+        msg = Message.from_dict(
+            {
+                "role": "assistant",
+                "content": "391",
+                "reasoning_details": [
+                    {"type": "reasoning.text", "text": "part one. "},
+                    {"type": "reasoning.encrypted", "data": "opaque"},
+                    {"type": "reasoning.text", "text": "part two."},
+                ],
+            }
+        )
+        assert msg.reasoning_content == "part one. part two."
+
+    def test_message_without_reasoning_stays_none(self):
+        msg = Message.from_dict({"role": "assistant", "content": "391"})
+        assert msg.reasoning_content is None
+
+
 class TestModelStreaming:
     """Tests for v2 streaming parser and streaming payload options."""
 
@@ -675,6 +717,33 @@ class TestModelStreaming:
         assert chunk.tool_calls is None
         assert chunk.usage is None
         assert chunk.finish_reason is None
+
+    def test_streamer_normalizes_openrouter_reasoning_deltas(self):
+        """OpenRouter deltas carry ``reasoning``/``reasoning_details`` instead of
+        ``reasoning_content``; the streamer must normalize onto the canonical field."""
+        streamer = self._create_streamer(
+            [
+                (
+                    'data: {"id":"gen-1","choices":[{"index":0,"delta":{"content":"","role":"assistant",'
+                    '"reasoning":"Okay","reasoning_details":[{"type":"reasoning.text","text":"Okay",'
+                    '"format":"unknown","index":0}]},"finish_reason":null}]}'
+                ),
+                'data: {"id":"gen-1","choices":[{"index":0,"delta":{"content":"391"},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ]
+        )
+
+        reasoning_only = next(streamer)
+        answer = next(streamer)
+
+        assert reasoning_only.data == ""
+        assert reasoning_only.reasoning_content == "Okay"
+
+        assert answer.data == "391"
+        assert answer.reasoning_content is None
+
+        with pytest.raises(StopIteration):
+            next(streamer)
 
     def test_streamer_normalizes_single_tool_call_object(self):
         """ModelResponseStreamer should normalize a single tool_call object to a list."""


### PR DESCRIPTION
## Summary
- `Message` and the v2 stream parser now normalize `reasoning` / `reasoning_details[].text` (OpenRouter wire shape) into the canonical `reasoning_content` field
- Precedence: `reasoning_content` → `reasoning` → joined `reasoning.text` blocks (non-text blocks like `reasoning.encrypted` are skipped)
- Fixes reasoning being silently dropped for OpenRouter-hosted reasoning models (Qwen Thinking, Kimi K2 Thinking, DeepSeek), non-streaming and streaming

## Companion PR
aixplain/aixplain-agents#292 — native-reasoning-only step thoughts