### PR TITLE
fix(v2): default HTTP timeout on every client request

### DIFF
--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -1,7 +1,8 @@
 """Client module for making HTTP requests to the aiXplain API."""
 
-from typing import Any, Optional, Union, List
+from typing import Any, Optional, Tuple, Union, List
 import logging
+import os
 import requests
 from requests.adapters import HTTPAdapter, Retry
 from urllib.parse import urljoin
@@ -14,6 +15,50 @@ logger = logging.getLogger(__name__)
 DEFAULT_RETRY_TOTAL = 5
 DEFAULT_RETRY_BACKOFF_FACTOR = 0.1
 DEFAULT_RETRY_STATUS_FORCELIST = [500, 502, 503, 504]
+
+# Default (connect, read) timeout applied to every request that doesn't pass
+# its own ``timeout=``.  Without one, ``requests`` waits forever: a backend
+# that accepts the connection and then goes quiet blocks the calling thread
+# indefinitely (observed in production: a LIST_INPUTS POST to
+# /api/v2/execute hung for 938s after a RemoteDisconnected).  The read
+# timeout is generous because this session also carries synchronous model
+# executions; it bounds a hang, it does not schedule work.  For streaming
+# requests the read timeout applies per chunk, not to the whole stream.
+DEFAULT_TIMEOUT_CONNECT = 10.0
+DEFAULT_TIMEOUT_READ = 300.0
+TimeoutType = Union[float, Tuple[float, float]]
+
+
+def _timeout_from_env(name: str, default: float) -> float:
+    """Read a positive float timeout from ``name``, falling back to ``default``.
+
+    A malformed value must not silently remove the bound the variable exists
+    to configure, so it logs and keeps the default.
+    """
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(f"Ignoring non-numeric {name}={raw!r}; using {default}s")
+        return default
+    if value <= 0:
+        logger.warning(f"Ignoring non-positive {name}={raw!r}; using {default}s")
+        return default
+    return value
+
+
+def default_timeout() -> Tuple[float, float]:
+    """Resolve the default (connect, read) timeout, honouring env overrides.
+
+    ``AIXPLAIN_HTTP_CONNECT_TIMEOUT`` / ``AIXPLAIN_HTTP_READ_TIMEOUT`` (seconds)
+    override the built-in defaults per environment without a code change.
+    """
+    return (
+        _timeout_from_env("AIXPLAIN_HTTP_CONNECT_TIMEOUT", DEFAULT_TIMEOUT_CONNECT),
+        _timeout_from_env("AIXPLAIN_HTTP_READ_TIMEOUT", DEFAULT_TIMEOUT_READ),
+    )
 
 
 def create_retry_session(
@@ -61,6 +106,7 @@ class AixplainClient:
         retry_total: int = DEFAULT_RETRY_TOTAL,
         retry_backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR,
         retry_status_forcelist: List[int] = DEFAULT_RETRY_STATUS_FORCELIST,
+        timeout: Optional[TimeoutType] = None,
     ) -> None:
         """Initialize AixplainClient with authentication and retry configuration.
 
@@ -71,8 +117,13 @@ class AixplainClient:
             retry_total (int): Total number of retries allowed. Defaults to 5.
             retry_backoff_factor (float): Backoff factor between retry attempts. Defaults to 0.1.
             retry_status_forcelist (list): HTTP status codes that trigger a retry. Defaults to [500, 502, 503, 504].
+            timeout (float or (float, float) tuple, optional): Default timeout for every
+                request that doesn't pass its own ``timeout=``. Defaults to
+                (AIXPLAIN_HTTP_CONNECT_TIMEOUT or 10, AIXPLAIN_HTTP_READ_TIMEOUT or 300)
+                seconds. Individual calls can still override it per request.
         """
         self.base_url = base_url
+        self.timeout: TimeoutType = timeout if timeout is not None else default_timeout()
         self.team_api_key = team_api_key
         self.aixplain_api_key = aixplain_api_key
 
@@ -113,6 +164,7 @@ class AixplainClient:
         else:
             url = urljoin(self.base_url, path)
 
+        kwargs.setdefault("timeout", self.timeout)
         logger.debug(f"Requesting {method} {url} with kwargs: {kwargs}")
         response = self.session.request(method=method, url=url, **kwargs)
         logger.debug(f"Response: {response.text}")
@@ -200,6 +252,10 @@ class AixplainClient:
 
         # Enable streaming mode
         kwargs["stream"] = True
+        # In streaming mode the read timeout applies per chunk read, not to the
+        # stream's total lifetime, so long-lived SSE streams stay safe as long
+        # as the server keeps sending (events or keep-alives).
+        kwargs.setdefault("timeout", self.timeout)
 
         response = self.session.request(method=method, url=url, **kwargs)
 

--- a/tests/unit/v2/test_client.py
+++ b/tests/unit/v2/test_client.py
@@ -13,6 +13,8 @@ from aixplain.v2.client import (
     AixplainClient,
     create_retry_session,
     DEFAULT_RETRY_TOTAL,
+    DEFAULT_TIMEOUT_CONNECT,
+    DEFAULT_TIMEOUT_READ,
     DEFAULT_RETRY_BACKOFF_FACTOR,
     DEFAULT_RETRY_STATUS_FORCELIST,
 )
@@ -568,3 +570,69 @@ class TestAixplainClientGet:
             result = client.get("resource")
 
             assert result == expected_data
+
+
+class TestDefaultTimeout:
+    """Every request must carry a timeout: without one, a backend that accepts
+    the connection and then goes quiet blocks the calling thread forever
+    (observed in production: a LIST_INPUTS POST hung for 938s)."""
+
+    def _client(self, **kwargs):
+        return AixplainClient(base_url="https://api.example.com", team_api_key="key", **kwargs)
+
+    def _ok_response(self):
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {}
+        return mock_response
+
+    def test_default_timeout_applied_to_request_raw(self):
+        client = self._client()
+
+        with patch.object(client.session, "request", return_value=self._ok_response()) as mock_request:
+            client.request_raw("GET", "v2/models")
+
+        assert mock_request.call_args.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)
+
+    def test_default_timeout_applied_to_request_stream(self):
+        client = self._client()
+
+        with patch.object(client.session, "request", return_value=self._ok_response()) as mock_request:
+            client.request_stream("GET", "v2/models")
+
+        assert mock_request.call_args.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)
+        assert mock_request.call_args.kwargs["stream"] is True
+
+    def test_per_call_timeout_wins(self):
+        """A caller that knows its own bound keeps it."""
+        client = self._client()
+
+        with patch.object(client.session, "request", return_value=self._ok_response()) as mock_request:
+            client.request_raw("GET", "v2/models", timeout=1.5)
+
+        assert mock_request.call_args.kwargs["timeout"] == 1.5
+
+    def test_constructor_timeout_overrides_default(self):
+        client = self._client(timeout=(5.0, 60.0))
+
+        with patch.object(client.session, "request", return_value=self._ok_response()) as mock_request:
+            client.request_raw("GET", "v2/models")
+
+        assert mock_request.call_args.kwargs["timeout"] == (5.0, 60.0)
+
+    def test_env_overrides_are_honoured(self, monkeypatch):
+        monkeypatch.setenv("AIXPLAIN_HTTP_CONNECT_TIMEOUT", "3")
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", "45.5")
+
+        client = self._client()
+
+        assert client.timeout == (3.0, 45.5)
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-5", ""])
+    def test_unusable_env_values_fall_back_to_defaults(self, bad, monkeypatch):
+        """A typo in the knob must not silently remove the bound it configures."""
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", bad)
+
+        client = self._client()
+
+        assert client.timeout == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)


### PR DESCRIPTION
## Why

The v2 client's `requests.Session` is built with a Retry adapter but `session.request(...)` is never given a `timeout=`, so any SDK call can block its thread **forever**. Observed in production (agents service, request `9bc03c9e`): a `LIST_INPUTS` POST to `/api/v2/execute` hung for **938s** after a `RemoteDisconnected`, stalling tool discovery until the run timed out — and the un-cancellable blocked threads held a worker slot for 15 minutes after the run had already failed. Every consumer of this SDK has the same exposure.

## What

Both `session.request` call sites (`request_raw`, `request_stream`) now default to a `(connect=10s, read=300s)` timeout. Resolution order:

1. per-call `timeout=` (unchanged — `setdefault`, so explicit callers win)
2. `AixplainClient(timeout=...)` constructor arg
3. `AIXPLAIN_HTTP_CONNECT_TIMEOUT` / `AIXPLAIN_HTTP_READ_TIMEOUT` env vars (per-environment tuning without a code change)
4. built-in defaults

Malformed env values log a warning and keep the default rather than silently removing the bound.

## Notes

- The read default is deliberately generous: the same session carries synchronous model executions, so this bounds a hang rather than scheduling work.
- In streaming mode (`request_stream`) the read timeout applies **per chunk read**, not to the stream's lifetime — long-lived SSE streams are unaffected while the server keeps sending events or keep-alives.
- Out of scope: the bare `requests.get` calls in `v2/code_utils.py` (fetching user code from URLs) are still unbounded.

## Tests

7 new tests in `tests/unit/v2/test_client.py`: defaults on both call sites, per-call override, constructor override, env overrides, malformed-env fallback. Full `tests/unit/v2` suite: **1021 passed, 4 skipped**.