### PR TITLE
fix(model): restore session_id in _SDK_ONLY_PARAMS dropped by merge

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -671,7 +671,16 @@ class Model(
             super().__setattr__(name, value)
 
     _SDK_ONLY_PARAMS = frozenset(
-        {"timeout", "wait_time", "show_progress", "stream", "run_retries", "run_retry_wait", "identifier"}
+        {
+            "timeout",
+            "wait_time",
+            "show_progress",
+            "stream",
+            "run_retries",
+            "run_retry_wait",
+            "identifier",
+            "session_id",
+        }
     )
 
     # ``identifier`` is a per-run caller identity emitted as the ``x-user-id``


### PR DESCRIPTION
## Summary
- Restores `"session_id"` in `Model._SDK_ONLY_PARAMS`, which was accidentally dropped by a merge-conflict resolution. `test` inherited the regression via #1015 / the `main` back-merge (`b1cc9412`), so `tests/unit/v2/test_model.py::TestModelSessionHeader::test_session_id_excluded_from_build_run_payload` fails on this branch too.

## Root cause
- #1013 (`9acccf46`, ENG-3473) added `session_id` to `Model._SDK_ONLY_PARAMS` so it is emitted only as the `x-session-id` header and never leaks into `build_run_payload` / `build_run_url` output.
- The merge of `test` into `development` (`dc8c4c2f`) resolved the frozenset conflict in favor of the older one-line `test`-branch version, silently dropping the `session_id` entry. A mechanical re-run of that merge confirms this was the only regressed hunk.

Same fix, same commit cherry-picked: `development` already has it (`9cba90d3`), `main` PR is #1020.

## Test plan
- The previously failing test passes; full `tests/unit/v2/test_model.py` green (77 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)