### PR TITLE
feat(run): propagate the calling agent as an x-agent header (ENG-3488)

### DIFF
--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -500,9 +500,12 @@ class ModelRunParams(BaseRunParams):
             ``identifier`` (→ ``x-user-id``). Omit it (or pass ``None``) to send
             no header.
         agent_name: Name of the agent making this call, emitted as the ``x-agent``
-            header so downstream services can attribute it to the calling agent
-            (for a team run, the specific sub-agent — not the team). Header-only,
-            on the same terms as ``session_id``.
+            header so downstream services can attribute it to the calling agent.
+            In a team run this is whichever agent actually issued the call: the
+            sub-agent for a delegated call, but the orchestrator's own name for a
+            tool it calls directly — so consumers should not assume the value is
+            always a sub-agent, nor always the team root. Header-only, on the same
+            terms as ``session_id``, and must be ASCII (see ``_headers_for_run``).
     """
 
     stream: NotRequired[bool]

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -499,10 +499,15 @@ class ModelRunParams(BaseRunParams):
             model/action input payload and the run URL, exactly like
             ``identifier`` (→ ``x-user-id``). Omit it (or pass ``None``) to send
             no header.
+        agent_name: Name of the agent making this call, emitted as the ``x-agent``
+            header so downstream services can attribute it to the calling agent
+            (for a team run, the specific sub-agent — not the team). Header-only,
+            on the same terms as ``session_id``.
     """
 
     stream: NotRequired[bool]
     session_id: NotRequired[Optional[str]]
+    agent_name: NotRequired[Optional[str]]
 
 
 @dataclass_json
@@ -670,6 +675,11 @@ class Model(
         else:
             super().__setattr__(name, value)
 
+    # Orchestration params the SDK consumes itself, plus every per-run header
+    # kwarg. The header half is derived from RunnableResourceMixin._RUN_HEADER_KEYS
+    # rather than re-listed, so a new header can't be added to the wire while
+    # still leaking into the v1/URL payloads (a merge once silently dropped such a
+    # duplicated entry — see the _RUN_HEADER_KEYS note).
     _SDK_ONLY_PARAMS = frozenset(
         {
             "timeout",
@@ -678,10 +688,8 @@ class Model(
             "stream",
             "run_retries",
             "run_retry_wait",
-            "identifier",
-            "session_id",
         }
-    )
+    ) | {key for key, _ in RunnableResourceMixin._RUN_HEADER_KEYS}
 
     # ``identifier`` is a per-run caller identity emitted as the ``x-user-id``
     # header (RunnableResourceMixin._headers_for_run), never a model/action
@@ -689,10 +697,10 @@ class Model(
     # builders via _SDK_ONLY_PARAMS above) so it cannot leak into model inputs
     # or supplier-facing logs. Agent keeps it in the body by NOT overriding this.
     #
-    # ``session_id`` is the same kind of per-run metadata (emitted as
-    # ``x-session-id``) and is header-only for every runnable, so the base
-    # _RUN_CONTROL_KEYS already excludes it; it is repeated in
-    # _SDK_ONLY_PARAMS above to also cover the v1/URL builder paths.
+    # ``session_id`` (→ ``x-session-id``) and ``agent_name`` (→ ``x-agent``) are
+    # the same kind of per-run metadata but header-only for every runnable, so the
+    # base _RUN_CONTROL_KEYS already excludes them; _SDK_ONLY_PARAMS above covers
+    # them again for the v1/URL builder paths.
     _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier"}
 
     def build_run_payload(self, **kwargs: Unpack[ModelRunParams]) -> dict:
@@ -700,8 +708,8 @@ class Model(
 
         Strips SDK-only orchestration params (``timeout``, ``wait_time``,
         ``show_progress``, ``stream``, ``run_retries``, ``run_retry_wait``) and
-        the header-only run metadata (``identifier``, ``session_id``) so they are
-        never forwarded to the backend API.
+        the header-only run metadata (``identifier``, ``session_id``,
+        ``agent_name``) so they are never forwarded to the backend API.
         """
         filtered = {k: v for k, v in kwargs.items() if k not in self._SDK_ONLY_PARAMS}
         return super().build_run_payload(**filtered)

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -580,10 +580,11 @@ class BaseRunParams(BaseParams):
         run_retry_wait: Seconds to wait between retry attempts (default 1.0).
 
     Note:
-        ``session_id`` is a header-only run key handled by every runnable
-        (``_headers_for_run`` → ``x-session-id``, stripped from the body by
-        ``_RUN_CONTROL_KEYS``). It is declared on :class:`ModelRunParams` rather
-        than here: :class:`~aixplain.v2.agent.AgentRunParams` deliberately has no
+        ``session_id`` and ``agent_name`` are header-only run keys handled by every
+        runnable (``_headers_for_run`` → ``x-session-id`` / ``x-agent``, stripped
+        from the body by ``_RUN_CONTROL_KEYS``). They are declared on
+        :class:`ModelRunParams` rather than here:
+        :class:`~aixplain.v2.agent.AgentRunParams` deliberately has no
         ``session_id`` — agent runs join a conversation via ``session=``, and a
         look-alike key that only set a header would be a footgun.
     """
@@ -1226,17 +1227,29 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     RUN_ACTION_PATH: str = "run"
     RESPONSE_CLASS: type = Result  # Default response class
 
+    # Run kwargs emitted as per-run request headers, in wire order. Single source
+    # of truth: ``_headers_for_run`` builds from it, and Model derives its
+    # ``_SDK_ONLY_PARAMS`` from it, so adding a header here cannot be forgotten in
+    # one of the payload filters (a merge once dropped such a duplicated entry).
+    _RUN_HEADER_KEYS: tuple[tuple[str, str], ...] = (
+        ("identifier", "x-user-id"),
+        ("session_id", "x-session-id"),
+        ("agent_name", "x-agent"),
+    )
+
     # SDK-only keys: never forwarded to build_run_payload / build_run_url.
     # NOTE: ``identifier`` is intentionally NOT excluded here — for Agent runs it
     # is a legitimate execution-config body field (see Agent). Model/Tool, where
     # it is header-only, add it to their own override so it never leaks into the
     # model/action input payload.
     #
-    # ``session_id`` IS excluded here (unlike ``identifier``): it is header-only
-    # for every runnable. No run params type declares it as a body field — the
-    # Agent session path takes ``session=`` (a Session or id) and routes through
-    # ``POST /v1/sessions/{id}/messages``, so a top-level ``session_id`` kwarg is
-    # purely the per-run correlation channel emitted as ``x-session-id``.
+    # ``session_id`` and ``agent_name`` ARE excluded here (unlike ``identifier``):
+    # both are header-only for every runnable, since no run params type declares
+    # either as a body field. The Agent session path takes ``session=`` (a Session
+    # or id) and routes through ``POST /v1/sessions/{id}/messages``, so a
+    # top-level ``session_id`` kwarg is purely the per-run correlation channel
+    # emitted as ``x-session-id``; ``agent_name`` is likewise only the calling
+    # agent's name, emitted as ``x-agent``.
     _RUN_CONTROL_KEYS: frozenset[str] = frozenset(
         {
             "run_retries",
@@ -1245,6 +1258,7 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
             "wait_time",
             "show_progress",
             "session_id",
+            "agent_name",
         }
     )
 
@@ -1279,18 +1293,18 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     def _headers_for_run(self, kwargs: dict) -> Optional[dict]:
         """Build per-run headers from optional runtime metadata.
 
-        ``identifier`` → ``x-user-id`` (caller identity) and ``session_id`` →
-        ``x-session-id`` (conversation the run belongs to). Both are optional and
-        independent: a key that is absent or ``None`` simply omits its header, and
-        with neither present this returns ``None`` so no headers are attached.
+        Emits the ``_RUN_HEADER_KEYS`` mapping: ``identifier`` → ``x-user-id``
+        (caller identity), ``session_id`` → ``x-session-id`` (conversation the run
+        belongs to), and ``agent_name`` → ``x-agent`` (the agent making the call).
+        All are optional and independent: a key that is absent or ``None`` simply
+        omits its header, and with none present this returns ``None`` so no headers
+        are attached.
         """
         headers = {}
-        identifier = kwargs.get("identifier")
-        if identifier is not None:
-            headers["x-user-id"] = str(identifier)
-        session_id = kwargs.get("session_id")
-        if session_id is not None:
-            headers["x-session-id"] = str(session_id)
+        for key, header in self._RUN_HEADER_KEYS:
+            value = kwargs.get(key)
+            if value is not None:
+                headers[header] = str(value)
         return headers or None
 
     def _post_and_handle_run(self, **kwargs: Unpack[RunParamsT]) -> ResultT:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -1299,13 +1299,32 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         All are optional and independent: a key that is absent or ``None`` simply
         omits its header, and with none present this returns ``None`` so no headers
         are attached.
+
+        Raises:
+            ValueError: If a value is not ASCII. HTTP header values cannot carry
+                non-ASCII text, and the underlying stack would otherwise fail
+                deep inside ``send()`` with a bare ``UnicodeEncodeError`` that
+                names neither the run kwarg nor the header.
         """
         headers = {}
         for key, header in self._RUN_HEADER_KEYS:
             value = kwargs.get(key)
             if value is not None:
-                headers[header] = str(value)
+                headers[header] = self._validate_header_value(key, header, str(value))
         return headers or None
+
+    @staticmethod
+    def _validate_header_value(key: str, header: str, value: str) -> str:
+        """Return *value* unchanged, or raise if it cannot be sent as a header.
+
+        Never sanitizes: a caller who named an agent ``"Ürün Asistanı"`` gets told
+        the name cannot ride in ``x-agent``, rather than silently having it
+        transliterated or dropped and then wondering why downstream attribution
+        shows something else.
+        """
+        if not value.isascii():
+            raise ValueError(f"{key} {value!r} cannot be sent as the {header} header: header values must be ASCII")
+        return value
 
     def _post_and_handle_run(self, **kwargs: Unpack[RunParamsT]) -> ResultT:
         """Single POST + handle_run_response (no retries, no before_run)."""

--- a/tests/functional/v2/test_arabic_agent.py
+++ b/tests/functional/v2/test_arabic_agent.py
@@ -205,7 +205,7 @@ def _make_single_agent(client, llm_id: str, model_name: str, agent_def: dict):
         description=agent_def["description"],
         instructions=agent_def["instructions"],
         llm=llm_id,
-        max_tokens=900,
+        max_tokens=4096,
         max_iterations=4,
     )
     agent.save()
@@ -247,7 +247,7 @@ def _make_team_agent(client, llm_id: str, model_name: str, inspectors=None):
         llm=llm_id,
         agents=[researcher, drafter],
         inspectors=inspectors or [],
-        max_tokens=900,
+        max_tokens=4096,
         max_iterations=4,
     )
     team_agent.save()

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -498,6 +498,72 @@ class TestRunHeaderKeysAreSingleSourceOfTruth:
         assert {key for key, _ in Model._RUN_HEADER_KEYS} <= Model._SDK_ONLY_PARAMS
 
 
+class TestRunHeaderValuesMustBeAscii:
+    """A non-ASCII header value must fail with a descriptive error, not a codec
+    traceback from deep inside ``send()``.
+
+    ``agent_name`` is the first user-authored free text on this channel
+    (``identifier``/``session_id`` are platform-generated ids), so a Turkish,
+    Arabic or CJK agent name is a realistic input. requests/urllib3 prepares such
+    a header fine and only fails at send time with a bare ``UnicodeEncodeError``
+    naming neither the run kwarg nor the header.
+    """
+
+    def _create_model(self):
+        model = Model.__new__(Model)
+        model.id = "test-model-id"
+        model.name = "Test Model"
+        model.connection_type = ["synchronous"]
+        model.params = None
+        model.__post_init__()
+        model.context = Mock()
+        return model
+
+    @pytest.mark.parametrize("agent_name", ["Ürün Asistanı", "网站设计师", "مساعد"])
+    def test_non_ascii_agent_name_raises_descriptive_error(self, agent_name):
+        model = self._create_model()
+
+        with pytest.raises(ValueError) as excinfo:
+            model._headers_for_run({"text": "hi", "agent_name": agent_name})
+
+        message = str(excinfo.value)
+        assert "agent_name" in message
+        assert agent_name in message
+        assert "x-agent" in message
+        assert "ASCII" in message
+
+    def test_run_raises_before_issuing_the_request(self):
+        """Fail fast: no POST is attempted with an unsendable header."""
+        model = self._create_model()
+
+        with pytest.raises(ValueError, match="x-agent"):
+            model.run(text="hi", agent_name="Ürün Asistanı")
+
+        model.context.client.request.assert_not_called()
+
+    def test_ascii_agent_name_unaffected(self):
+        model = self._create_model()
+
+        assert model._headers_for_run({"agent_name": "Researcher"}) == {"x-agent": "Researcher"}
+
+    def test_value_is_never_sanitized(self):
+        """The name must not be transliterated or stripped — that would silently
+        mis-attribute the call downstream. It is all-or-nothing."""
+        model = self._create_model()
+
+        with pytest.raises(ValueError):
+            model._headers_for_run({"agent_name": "Ürün"})
+
+    @pytest.mark.parametrize("key", ["identifier", "session_id"])
+    def test_validation_applies_to_every_header_kwarg(self, key):
+        """Not agent_name-specific: any header value that can't be encoded gets the
+        same descriptive failure."""
+        model = self._create_model()
+
+        with pytest.raises(ValueError, match="ASCII"):
+            model._headers_for_run({key: "değer"})
+
+
 class TestModelV1Fallback:
     """Tests for _run_async_v1() V1 endpoint integration."""
 

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -425,6 +425,79 @@ class TestModelSessionHeader:
         assert "session_id" not in payload_kwargs
 
 
+class TestModelAgentHeader:
+    """agent_name must ride as the x-agent header, never as a model input."""
+
+    def _create_model(self):
+        model = Model.__new__(Model)
+        model.id = "test-model-id"
+        model.name = "Test Model"
+        model.connection_type = ["synchronous"]
+        model.params = None
+        model.__post_init__()
+        model.context = Mock()
+        return model
+
+    def test_agent_name_excluded_from_payload(self):
+        """The calling agent's name is per-run metadata, not a model input — it
+        must not reach the model (or supplier-facing logs) as an input field."""
+        model = self._create_model()
+        payload_kwargs = model._payload_kwargs_for_run({"text": "hi", "agent_name": "Researcher"})
+        assert "agent_name" not in payload_kwargs
+        assert payload_kwargs["text"] == "hi"
+
+    def test_agent_name_emitted_as_header(self):
+        model = self._create_model()
+        assert model._headers_for_run({"text": "hi", "agent_name": "Researcher"}) == {"x-agent": "Researcher"}
+
+    def test_agent_name_excluded_from_build_run_payload(self):
+        """Also excluded from the v1/URL payload builder path (_SDK_ONLY_PARAMS)."""
+        model = self._create_model()
+        payload = model.build_run_payload(text="hi", agent_name="Researcher")
+        assert "agent_name" not in payload
+
+    def test_all_run_metadata_headers_ride_together(self):
+        """All three headers on one run, and none of them in the payload."""
+        model = self._create_model()
+        kwargs = {"text": "hi", "identifier": "alice", "session_id": "sess-1", "agent_name": "Researcher"}
+        assert model._headers_for_run(kwargs) == {
+            "x-user-id": "alice",
+            "x-session-id": "sess-1",
+            "x-agent": "Researcher",
+        }
+        payload_kwargs = model._payload_kwargs_for_run(kwargs)
+        assert payload_kwargs == {"text": "hi"}
+
+
+class TestRunHeaderKeysAreSingleSourceOfTruth:
+    """Every ``_RUN_HEADER_KEYS`` kwarg must be filtered out of *both* payload
+    paths. Guards the failure mode that hit ``session_id`` once: a header was
+    added to the wire while a duplicated payload-filter literal lost its entry
+    in a merge, so the value silently rode in the body too.
+    """
+
+    def _create_model(self):
+        model = Model.__new__(Model)
+        model.id = "test-model-id"
+        model.name = "Test Model"
+        model.connection_type = ["synchronous"]
+        model.params = None
+        model.__post_init__()
+        model.context = Mock()
+        return model
+
+    def test_every_header_kwarg_stripped_from_both_payload_paths(self):
+        model = self._create_model()
+        for key, header in Model._RUN_HEADER_KEYS:
+            kwargs = {"text": "hi", key: "v"}
+            assert model._headers_for_run(kwargs) == {header: "v"}, f"{key} not emitted as {header}"
+            assert key not in model._payload_kwargs_for_run(kwargs), f"{key} leaked into the v2 payload"
+            assert key not in model.build_run_payload(**kwargs), f"{key} leaked into the v1/URL payload"
+
+    def test_header_kwargs_covered_by_sdk_only_params(self):
+        assert {key for key, _ in Model._RUN_HEADER_KEYS} <= Model._SDK_ONLY_PARAMS
+
+
 class TestModelV1Fallback:
     """Tests for _run_async_v1() V1 endpoint integration."""
 

--- a/tests/unit/v2/test_resource.py
+++ b/tests/unit/v2/test_resource.py
@@ -1011,13 +1011,35 @@ class TestRunnableResourceMixin:
         headers = resource._headers_for_run({"identifier": "alice", "session_id": "sess-1"})
         assert headers == {"x-user-id": "alice", "x-session-id": "sess-1"}
 
+    def test_agent_name_emitted_as_header(self):
+        """agent_name is emitted as the x-agent header for any runnable resource."""
+        resource = self._create_runnable_resource()
+
+        headers = resource._headers_for_run({"text": "hi", "agent_name": "Researcher"})
+        assert headers == {"x-agent": "Researcher"}
+
+    def test_base_excludes_agent_name_from_payload(self):
+        """Like session_id, agent_name is header-only for every runnable — no run
+        params type declares it as a body field, so the base mixin strips it."""
+        resource = self._create_runnable_resource()
+
+        payload_kwargs = resource._payload_kwargs_for_run({"text": "hi", "agent_name": "Researcher"})
+        assert "agent_name" not in payload_kwargs
+        assert payload_kwargs["text"] == "hi"
+
+    def test_all_run_metadata_headers_emitted_together(self):
+        resource = self._create_runnable_resource()
+
+        headers = resource._headers_for_run({"identifier": "alice", "session_id": "sess-1", "agent_name": "Researcher"})
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
     def test_no_headers_when_no_run_metadata(self):
-        """Neither key present → no headers dict at all, so _post_and_handle_run
+        """No header key present → no headers dict at all, so _post_and_handle_run
         attaches nothing (documented default, never a crash)."""
         resource = self._create_runnable_resource()
 
         assert resource._headers_for_run({"text": "hi"}) is None
-        assert resource._headers_for_run({"identifier": None, "session_id": None}) is None
+        assert resource._headers_for_run({key: None for key, _ in resource._RUN_HEADER_KEYS}) is None
 
 
 # =============================================================================

--- a/tests/unit/v2/test_resource.py
+++ b/tests/unit/v2/test_resource.py
@@ -1041,6 +1041,18 @@ class TestRunnableResourceMixin:
         assert resource._headers_for_run({"text": "hi"}) is None
         assert resource._headers_for_run({key: None for key, _ in resource._RUN_HEADER_KEYS}) is None
 
+    def test_non_ascii_header_value_raises_for_any_runnable(self):
+        """Header values must be ASCII. Raised here rather than left to fail at
+        ``send()`` with a bare UnicodeEncodeError naming neither kwarg nor header.
+        """
+        resource = self._create_runnable_resource()
+
+        with pytest.raises(ValueError) as excinfo:
+            resource._headers_for_run({"agent_name": "Ürün Asistanı"})
+
+        message = str(excinfo.value)
+        assert "agent_name" in message and "x-agent" in message and "ASCII" in message
+
 
 # =============================================================================
 # Result Class Tests

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -670,16 +670,24 @@ class TestMergeWithDynamicAttrs:
         assert result["data"] == ["x"]
 
     def test_run_metadata_survives_merge_and_stays_header_only(self):
-        """``identifier``/``session_id`` must survive the merge (so
-        ``_headers_for_run`` can see them) while staying out of the action payload."""
+        """Every ``_RUN_HEADER_KEYS`` kwarg must survive the merge (so
+        ``_headers_for_run`` can see it) while staying out of the action payload."""
         tool = self._make_tool()
 
         merged = tool._merge_with_dynamic_attrs(
-            action="search", data={"q": "hi"}, identifier="alice", session_id="sess-1"
+            action="search",
+            data={"q": "hi"},
+            identifier="alice",
+            session_id="sess-1",
+            agent_name="Researcher",
         )
 
-        assert tool._headers_for_run(merged) == {"x-user-id": "alice", "x-session-id": "sess-1"}
+        assert tool._headers_for_run(merged) == {
+            "x-user-id": "alice",
+            "x-session-id": "sess-1",
+            "x-agent": "Researcher",
+        }
         payload_kwargs = tool._payload_kwargs_for_run(merged)
-        assert "identifier" not in payload_kwargs
-        assert "session_id" not in payload_kwargs
+        for key, _ in tool._RUN_HEADER_KEYS:
+            assert key not in payload_kwargs
         assert payload_kwargs["data"] == {"q": "hi"}


### PR DESCRIPTION
Runnable resources already carry the caller identity as `x-user-id` and the
run's session as `x-session-id`; add the calling agent's name so downstream
services can attribute a call to the agent that made it.

- `agent_name` -> `x-agent`, header-only for every runnable like `session_id`
  (no run params type declares it as a body field), so the base
  _RUN_CONTROL_KEYS excludes it and Model/Tool also strip it from the v1/URL
  builder paths. Declared on ModelRunParams, not BaseRunParams, for the same
  reason as `session_id`: AgentRunParams must stay free of look-alike keys.
- Collapse the header list into one source of truth,
  RunnableResourceMixin._RUN_HEADER_KEYS. _headers_for_run now iterates it and
  Model._SDK_ONLY_PARAMS derives its header half from it, instead of both
  re-listing the same kwargs.

The refactor is motivated by 9cba90d: the merge of 'test' into development
(dc8c4c2) resolved the _SDK_ONLY_PARAMS hunk in favour of the older frozenset,
dropping `session_id` while keeping its tests and comments -- so the value rode
in the request body until someone noticed. With the keys derived rather than
duplicated, the payload filters can no longer drift from the wire.

Adds unit coverage for x-agent emission and payload exclusion (v2 + v1
builders), all three headers together, and
TestRunHeaderKeysAreSingleSourceOfTruth -- which asserts every _RUN_HEADER_KEYS
kwarg is stripped from both payload paths, and would have caught the regression
above.