### PR TITLE
fix(tool): point DEFAULT_INTEGRATION_ID at Python Sandbox, not Slack

### DIFF
--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -39,7 +39,7 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
 
     RESOURCE_PATH = "v2/tools"
     RESPONSE_CLASS = ToolResult
-    DEFAULT_INTEGRATION_ID = "686432941223092cb4294d3f"  # Script integration
+    DEFAULT_INTEGRATION_ID = "688779d8bfb8e46c273982ca"  # Python Sandbox (script) integration
 
     # Tool-specific fields
     asset_id: Optional[str] = field(default=None, metadata=dj_config(field_name="assetId"))

--- a/tests/functional/v2/test_integration.py
+++ b/tests/functional/v2/test_integration.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.fixture(scope="module")
 def slack_integration_id():
     """Return a Slack integration model ID for testing."""
-    return "686432941223092cb4294d3f"  # Use Script integration from test_aa.py (Slack integration)
+    return "686432941223092cb4294d3f"  # Slack integration
 
 
 def validate_integration_structure(integration):

--- a/tests/functional/v2/test_model.py
+++ b/tests/functional/v2/test_model.py
@@ -17,7 +17,7 @@ def stream_tool_call_model_id():
 @pytest.fixture(scope="module")
 def slack_integration_id():
     """Return a Slack integration model ID for testing."""
-    return "686432941223092cb4294d3f"  # Use Script integration (Slack integration)
+    return "686432941223092cb4294d3f"  # Slack integration
 
 
 def validate_model_structure(model):

--- a/tests/functional/v2/test_snake_case_e2e.py
+++ b/tests/functional/v2/test_snake_case_e2e.py
@@ -95,11 +95,11 @@ class TestToolDictFieldsRoundTrip:
 class TestInputActionFieldsRoundTrip:
     """Input / Action fields are read from the backend; verify snake_case ↔ camelCase mapping."""
 
-    SCRIPT_INTEGRATION_ID = "686432941223092cb4294d3f"
+    SLACK_INTEGRATION_ID = "686432941223092cb4294d3f"
 
     def test_input_fields_survive_serialization_round_trip(self, client):
         """Fetch real Input from API, read snake_case attrs, to_dict → from_dict, values match."""
-        integration = client.Integration.get(self.SCRIPT_INTEGRATION_ID)
+        integration = client.Integration.get(self.SLACK_INTEGRATION_ID)
         if not integration.actions_available:
             pytest.skip("Integration has no actions available")
 
@@ -133,7 +133,7 @@ class TestInputActionFieldsRoundTrip:
 
     def test_action_display_name_survives_round_trip(self, client):
         """Fetch real Action from API, read display_name, to_dict → from_dict, value matches."""
-        integration = client.Integration.get(self.SCRIPT_INTEGRATION_ID)
+        integration = client.Integration.get(self.SLACK_INTEGRATION_ID)
         if not integration.actions_available:
             pytest.skip("Integration has no actions available")
 

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -430,6 +430,23 @@ class TestToolCreate:
         assert tool.id == mock_connection.id
 
 
+class TestScriptToolDefaultIntegration:
+    """Tests that Tool(code=...) targets the Python Sandbox integration."""
+
+    PYTHON_SANDBOX_ID = "688779d8bfb8e46c273982ca"
+
+    def test_default_integration_id_is_python_sandbox(self):
+        """DEFAULT_INTEGRATION_ID must be the Python Sandbox integration,
+        not Slack (686432941223092cb4294d3f) — a script tool wired to Slack
+        serializes with the full SLACK_* action catalog and never runs its code."""
+        assert Tool.DEFAULT_INTEGRATION_ID == self.PYTHON_SANDBOX_ID
+
+    def test_code_only_tool_uses_python_sandbox_integration(self):
+        tool = Tool(name="Script Tool", description="desc", code="def main(): pass")
+        assert tool.integration == self.PYTHON_SANDBOX_ID
+        assert tool.config == {"code": "def main(): pass"}
+
+
 # =============================================================================
 # save() integration (update path)
 # =============================================================================


### PR DESCRIPTION
## Problem
`Tool.DEFAULT_INTEGRATION_ID` was `686432941223092cb4294d3f`, which is the **Slack** integration on both dev and prod (verified via `/sdk/models/<id>`), despite being commented "Script integration". Any script tool created with `aix.Tool(code=...)` (or `integration=aix.Tool.DEFAULT_INTEGRATION_ID`) was silently connected to Slack:

- the saved agent's payload carried the **full SLACK_* action catalog** and empty `parameters`
- the user's Python code never executed

## Fix
- Use `688779d8bfb8e46c273982ca` (Python Sandbox, `pythonscript`) — verified on dev and prod, and the same ID v1's `ModelFactory.PYTHON_SANDBOX_ID` already uses.
- Add a unit test locking `DEFAULT_INTEGRATION_ID` and the `Tool(code=...)` path to the sandbox integration.
- Fix test comments/names that mislabeled the Slack ID as the Script integration (`SCRIPT_INTEGRATION_ID` → `SLACK_INTEGRATION_ID`); those tests genuinely target Slack and keep the old ID.

## Testing
- `tests/unit`: 1442 passed, 4 skipped.
- New test fails before the fix, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Zr94ozn8WzV5qv1B17EL