### PR TITLE
fix(tool): send required function_name when connecting script tools

### DIFF
--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -1,5 +1,6 @@
 """Tool resource module for managing tools and their integrations."""
 
+import ast
 import re
 import warnings
 from typing import Union, List, Optional, Any
@@ -67,17 +68,40 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
         """Initialize tool after dataclass creation."""
         if not self.id:
             if self.integration is None:
-                code = self.code or (self.config.pop("code", None) if self.config else None)
+                config = dict(self.config) if self.config else {}
+                code = self.code or config.pop("code", None)
                 assert code is not None, "Code is required to create a (script) Tool"
                 self.integration = self.DEFAULT_INTEGRATION_ID
-                self.config = {
-                    "code": code,
-                }
+                config["code"] = code
+                config["function_name"] = self._resolve_script_function_name(code, config.get("function_name"))
+                self.config = config
             else:
                 if isinstance(self.integration, str):
                     pass
                 elif not isinstance(self.integration, Integration):
                     raise ValueError("Integration must be an Integration object or a string")
+
+    @staticmethod
+    def _resolve_script_function_name(code: str, function_name: Optional[str] = None) -> str:
+        """Infer or validate the sandbox entrypoint — the integration requires ``function_name``."""
+        try:
+            tree = ast.parse(code)
+        except SyntaxError as e:
+            raise ValueError(f"code is not valid Python: {e}") from e
+
+        names = [node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        if function_name:
+            if function_name not in names:
+                raise ValueError(f"Function '{function_name}' not found in code. Available functions: {names}")
+            return function_name
+        if not names:
+            raise ValueError("No function found in code. Define at least one top-level function.")
+        if len(names) > 1:
+            raise ValueError(
+                f"Multiple functions found in code: {names}. "
+                "Specify the entrypoint via config={'function_name': '<name>'}."
+            )
+        return names[0]
 
     # ------------------------------------------------------------------
     # Override ``actions`` so ActionMixin's multi-action behaviour is used

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -444,7 +444,32 @@ class TestScriptToolDefaultIntegration:
     def test_code_only_tool_uses_python_sandbox_integration(self):
         tool = Tool(name="Script Tool", description="desc", code="def main(): pass")
         assert tool.integration == self.PYTHON_SANDBOX_ID
-        assert tool.config == {"code": "def main(): pass"}
+        assert tool.config == {"code": "def main(): pass", "function_name": "main"}
+
+    def test_function_name_inferred_from_non_main_function(self):
+        """The sandbox requires function_name; a single function of any name works."""
+        code = "def get_fact(city: str) -> str:\n    return city\n"
+        tool = Tool(name="Script Tool", description="desc", code=code)
+        assert tool.config == {"code": code, "function_name": "get_fact"}
+
+    def test_explicit_function_name_in_config_survives(self):
+        """Extra config keys must not be dropped on the code= route."""
+        code = "def helper(): pass\ndef entry(): pass\n"
+        tool = Tool(name="Script Tool", description="desc", code=code, config={"function_name": "entry"})
+        assert tool.config == {"code": code, "function_name": "entry"}
+
+    def test_multiple_functions_without_function_name_raises(self):
+        code = "def a(): pass\ndef b(): pass\n"
+        with pytest.raises(ValueError, match="Multiple functions"):
+            Tool(name="Script Tool", description="desc", code=code)
+
+    def test_function_name_not_in_code_raises(self):
+        with pytest.raises(ValueError, match="not found in code"):
+            Tool(name="Script Tool", description="desc", code="def main(): pass", config={"function_name": "nope"})
+
+    def test_code_without_any_function_raises(self):
+        with pytest.raises(ValueError, match="No function"):
+            Tool(name="Script Tool", description="desc", code="x = 1\n")
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #1025. With the integration ID fixed, script-tool connects still failed: the Python Sandbox integration requires **both** `code` and `function_name` inputs, but `Tool(code=...)` sent only `code`, so the backend rejected every connect with `err.supplier_error: Function not found in code`.

## Fix
- Infer `function_name` from the code via `ast` in `Tool.__post_init__`, mirroring v1's `create_script_connection_tool`: a single top-level function of **any name** works (no more implicit `main` requirement); multiple functions require an explicit `config={'function_name': ...}`; an unknown name fails fast client-side with the available function list.
- Extra `config` keys passed alongside `code=` are no longer silently dropped.

## Verified end-to-end on dev
```
tool saved in 2.8s
agent saved in 4.5s
run finished in 7.1s
output: Fun fact about Istanbul: it's the only city in the world located on two continents...
```
(Before this fix the same flow failed at `tool.save()`.)

Unit suite: 1447 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Zr94ozn8WzV5qv1B17EL