### PR TITLE
fix(client): surface supplierError detail in APIError messages (test)

### DIFF
--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -176,8 +176,18 @@ class AixplainClient:
                 logger.error(f"Error parsing error response: {e}")
 
             if error_obj:
+                # supplierError carries the actionable detail (e.g. "Name already
+                # exists"); the "error" field is often just a code like
+                # "err.supplier_error".
+                message = (
+                    error_obj.get("supplierError")
+                    or error_obj.get("supplier_error")
+                    or error_obj.get("message")
+                    or error_obj.get("error")
+                    or response.text
+                )
                 raise APIError(
-                    error_obj.get("message", error_obj.get("error", response.text)),
+                    message,
                     status_code=error_obj.get("statusCode", response.status_code),
                     response_data=error_obj,
                     error=error_obj.get("error", response.text),

--- a/tests/unit/v2/test_client.py
+++ b/tests/unit/v2/test_client.py
@@ -402,6 +402,30 @@ class TestAixplainClientErrorHandling:
             assert exc_info.value.status_code == 404
             assert exc_info.value.error == "NOT_FOUND"
 
+    def test_error_prefers_supplier_error_detail(self):
+        """supplierError carries the actionable detail (e.g. 'Name already exists')
+        and must win over the generic 'error' code (e.g. 'err.supplier_error')."""
+        client = AixplainClient(
+            base_url="https://api.example.com",
+            team_api_key="key",
+        )
+
+        mock_response = Mock()
+        mock_response.ok = False
+        mock_response.status_code = 422
+        mock_response.json.return_value = {
+            "completed": True,
+            "error": "err.supplier_error",
+            "supplierError": "Name already exists",
+        }
+
+        with patch.object(client.session, "request", return_value=mock_response):
+            with pytest.raises(APIError) as exc_info:
+                client.request_raw("GET", "resource")
+
+            assert exc_info.value.message == "Name already exists"
+            assert exc_info.value.error == "err.supplier_error"
+
     def test_error_falls_back_to_error_field(self):
         """When 'message' is absent, should use 'error' field."""
         client = AixplainClient(


### PR DESCRIPTION
Cherry-pick of the client error-message fix onto `test` — it was pushed to the #1031 branch after that PR was squash-merged, so `test` never received it (already on `development` as `854f723e`).

A duplicate-name connect failed with the opaque `Polling failed: err.supplier_error`; the actionable detail (`Name already exists`) was in the `supplierError` field but dropped. APIError messages now prefer `supplierError` > `message` > `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Zr94ozn8WzV5qv1B17EL