### PR TITLE
feat(v2): media-generation members on Function enum

### DIFF
--- a/aixplain/v2/enums.py
+++ b/aixplain/v2/enums.py
@@ -45,6 +45,17 @@ class Function(str, Enum):
     UTILITIES = "utilities"  # Add the missing utilities function
     GUARDRAILS = "guardrails"  # Guardrail / inspector guard models
 
+    # Media-generation functions (backend kebab-case ids, like UTILITIES/GUARDRAILS above)
+    TEXT_TO_IMAGE_GENERATION = "text-to-image-generation"
+    IMAGE_GENERATION = "image-generation"
+    VIDEO_GENERATION = "video-generation"
+    TEXT_TO_VIDEO_GENERATION = "text-to-video-generation"
+    IMAGE_TO_VIDEO_GENERATION = "image-to-video-generation"
+    SPEECH_SYNTHESIS = "speech-synthesis"
+    TEXT_TO_SPEECH = "text-to-speech"
+    TEXT_TO_AUDIO = "text-to-audio"
+    VOICE_CLONING = "voice-cloning"
+
 
 class Language(str, Enum):
     """Languages supported by the platform."""

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -52,6 +52,15 @@ class TestFindFunctionById:
             kebab = member.value.lower().replace("_", "-")
             assert find_function_by_id(kebab) == member, f"{kebab} did not resolve to {member}"
 
+    def test_media_function_ids_decode(self):
+        """Backend media-generation function IDs should resolve to real enum members."""
+        assert find_function_by_id("text-to-image-generation") is Function.TEXT_TO_IMAGE_GENERATION
+        assert find_function_by_id("speech-synthesis") is Function.SPEECH_SYNTHESIS
+        assert find_function_by_id("video-generation") is Function.VIDEO_GENERATION
+        # existing behavior preserved
+        assert find_function_by_id("text-generation") is Function.TEXT_GENERATION
+        assert find_function_by_id("no-such-function") is None
+
 
 # =============================================================================
 # Connection Type Property Tests


### PR DESCRIPTION
## Summary
The aixplain-agents framework needs to decode an asset's capability (e.g. `text-to-image-generation`) from the backend's `function.id` at runtime, but the v2 SDK's `Function` enum is missing the media-generation members, so `find_function_by_id` currently decodes them to `None`.

This adds nine kebab-case members (image/video/speech/audio generation, following the existing `UTILITIES`/`GUARDRAILS` precedent) so these ids resolve directly without any decoder changes.

## Test plan
- [x] Added `test_media_function_ids_decode` to `tests/unit/v2/test_model.py::TestFindFunctionById`
- [x] Verified RED before the enum change, GREEN after
- [x] Ran full `tests/unit/v2/test_model.py` (92 passed) to confirm no regressions