### PR TITLE
fix(v2): make Utility.run an instance method so super().run() binds self (BUG-1088)

### DIFF
--- a/aixplain/v2/utility.py
+++ b/aixplain/v2/utility.py
@@ -107,8 +107,7 @@ class Utility(
         """
         return super().get(id, resource_path="sdk/models", **kwargs)
 
-    @classmethod
-    def run(cls: type["Utility"], **kwargs: Unpack[UtilityRunParams]) -> Result:
+    def run(self, **kwargs: Unpack[UtilityRunParams]) -> Result:
         """Run the utility with provided parameters.
 
         Args:

--- a/tests/unit/v2/test_utility_run.py
+++ b/tests/unit/v2/test_utility_run.py
@@ -1,0 +1,38 @@
+"""Regression tests for Utility.run.
+
+`Utility.run` was declared as a ``@classmethod`` overriding the instance method
+``RunnableResourceMixin.run``. Inside a classmethod ``super()`` binds to the class, so the
+descriptor yields the *unbound* function and ``self`` is never supplied — every call raised
+``TypeError: run() missing 1 required positional argument: 'self'``.
+
+The bug was invisible because no test exercised ``Utility.run``.
+"""
+
+from unittest.mock import patch
+
+from aixplain.v2.resource import RunnableResourceMixin
+from aixplain.v2.utility import Utility
+
+
+def test_run_is_an_instance_method_not_a_classmethod():
+    """A classmethod here breaks `super().run()`; guard the shape directly."""
+    assert not isinstance(Utility.__dict__["run"], classmethod), (
+        "Utility.run must be an instance method so super().run() binds self"
+    )
+
+
+def test_run_delegates_to_the_mixin_with_self():
+    """The regression: calling run() on an instance must reach the mixin bound."""
+    utility = Utility(id="6789")
+
+    # autospec=True keeps the descriptor protocol, so the mock receives `self` exactly as
+    # the real method would. A plain Mock would not bind and could never tell the two
+    # states apart.
+    with patch.object(RunnableResourceMixin, "run", autospec=True, return_value="ran") as mocked_run:
+        result = utility.run(data="hello")
+
+    assert result == "ran"
+    mocked_run.assert_called_once()
+    # `self` must be the instance we called it on — this is what the classmethod broke.
+    assert mocked_run.call_args.args[0] is utility
+    assert mocked_run.call_args.kwargs == {"data": "hello"}


### PR DESCRIPTION
## Problem

`Utility.run` was declared as a `@classmethod` overriding the instance method
`RunnableResourceMixin.run`:

```python
@classmethod
def run(cls: type["Utility"], **kwargs: Unpack[UtilityRunParams]) -> Result:
    return super().run(**kwargs)
```

Inside a `classmethod`, `super()` binds to the **class**, so the descriptor yields the *unbound*
function and `self` is never supplied. Every call raised:

```
TypeError: RunnableResourceMixin.run() missing 1 required positional argument: 'self'
```

The API is public and documented (`docs/api-reference/python/aixplain/v2/utility.md`), so utilities
could not be executed through v2 at all.

## Root cause

`Utility.get` and `Utility.search` are legitimately classmethods — they override classmethod bases.
`run` overrides an *instance* method, so the decorator was copied one method too far. The sibling run
methods are instance methods and work correctly: `Tool.run` (`tool.py:473`), `Model.run`
(`model.py:751`).

## Change

Two lines: drop `@classmethod`, take `self`. No behaviour change beyond making the call work.

## Why it shipped

No test exercised `Utility.run` — `grep '\.run(' tests/unit/utility_test.py` returns nothing, while
the same query against `tests/unit/v2/test_model.py` returns 20+ hits. This PR adds
`tests/unit/v2/test_utility_run.py` with two tests: one asserts the method is not a classmethod, one
asserts the mixin receives the instance as `self`.

The second test uses `autospec=True` deliberately — a plain `Mock` replaces the method with a
non-descriptor, so it would never receive `self` and could not distinguish the fixed from the broken
state.

## Verification

| | |
|---|---|
| New tests, before the fix | **2 failed** (`TypeError` from the descriptor binding) |
| New tests, after the fix | **2 passed** |
| Full `tests/unit`, before | 1384 passed, 38 errors |
| Full `tests/unit`, after | **1386 passed** (+2, the new tests), **38 errors — unchanged** |
| `ruff check` / `ruff format --check` | clean on both files |

The 38 collection errors are pre-existing and environmental (missing optional dev dependencies in
the runner); they are identical with and without this change.

## Ticket

BUG-1088 — https://aixplain.atlassian.net/browse/BUG-1088

Found by an SDK-wide correctness audit; three independent reviewers reached this finding separately.
