### PR TITLE
feat(agent): surface run artifacts on the agent response (v2 + v1)

### DIFF
--- a/aixplain/v1/modules/agent/__init__.py
+++ b/aixplain/v1/modules/agent/__init__.py
@@ -40,7 +40,7 @@ from aixplain.modules.agent.agent_task import WorkflowTask, AgentTask
 from aixplain.modules.agent.output_format import OutputFormat
 from aixplain.modules.agent.tool import Tool, DeployableTool
 from aixplain.modules.agent.agent_response import AgentResponse
-from aixplain.modules.agent.agent_response_data import AgentResponseData
+from aixplain.modules.agent.agent_response_data import AgentResponseData, Artifact  # noqa: F401
 from aixplain.modules.agent.utils import process_variables, validate_history
 from pydantic import BaseModel
 from typing import Dict, List, Text, Optional, Union, Any
@@ -707,6 +707,7 @@ class Agent(Model, DeployableMixin[Union[Tool, DeployableTool]]):
                         intermediate_steps=result_data.get("intermediate_steps"),
                         steps=result_data.get("steps"),
                         execution_stats=result_data.get("executionStats"),
+                        artifacts=result_data.get("artifacts"),
                     ),
                     used_credits=result_data.get("usedCredits", 0.0),
                     run_time=result_data.get("runTime", end - start),
@@ -723,6 +724,7 @@ class Agent(Model, DeployableMixin[Union[Tool, DeployableTool]]):
                     intermediate_steps=result_data.get("intermediate_steps"),
                     steps=result_data.get("steps"),
                     execution_stats=result_data.get("executionStats"),
+                    artifacts=result_data.get("artifacts"),
                 ),
                 used_credits=result_data.get("usedCredits", 0.0),
                 run_time=result_data.get("runTime", end - start),

--- a/aixplain/v1/modules/agent/agent_response.py
+++ b/aixplain/v1/modules/agent/agent_response.py
@@ -1,6 +1,6 @@
 from aixplain.enums import ResponseStatus
 from typing import Any, Dict, Optional, Text, Union, List, TYPE_CHECKING
-from aixplain.modules.agent.agent_response_data import AgentResponseData
+from aixplain.modules.agent.agent_response_data import AgentResponseData, Artifact
 from aixplain.modules.model.response import ModelResponse
 
 if TYPE_CHECKING:
@@ -27,6 +27,8 @@ class AgentResponse(ModelResponse):
         diagnostic_error_codes (List[str]): Aggregated, deduplicated diagnostic error codes
             observed during execution (e.g. MAX_TOKENS_REACHED, TOOL_FAILED).
             Does not affect run status.
+        artifacts (List[Artifact]): Deliverables produced during the run, a
+            passthrough of ``data.artifacts``. Always a list.
     """
 
     def __init__(
@@ -83,6 +85,22 @@ class AgentResponse(ModelResponse):
         self.data = data or AgentResponseData()
         self.diagnostic_error_codes = diagnostic_error_codes if diagnostic_error_codes is not None else []
 
+    @property
+    def artifacts(self) -> List[Artifact]:
+        """Deliverables produced during the run (see :class:`Artifact`).
+
+        Always a list — empty when the run produced nothing, when artifact
+        capture is disabled, or when the backend predates artifact support.
+        """
+        data = self.data
+        if isinstance(data, dict):
+            # ``data`` is a bare dict on some paths (e.g. ``Agent.evolve``)
+            # rather than an AgentResponseData. Matches the v2 property.
+            return Artifact.from_list(data.get("artifacts"))
+        # Anything else (AgentResponseData, EvolverResponseData, ...) is read by
+        # attribute, defaulting to [] when it has no artifacts.
+        return getattr(data, "artifacts", None) or []
+
     def __getitem__(self, key: Text) -> Any:
         """Get a response attribute using dictionary-style access.
 
@@ -98,6 +116,12 @@ class AgentResponse(ModelResponse):
         """
         if key == "data":
             return self.data.to_dict()
+        if key == "artifacts":
+            # A property, so it is absent from ``__dict__`` and the parent
+            # lookup would raise. Route it here so ``response["artifacts"]``
+            # and ``response.get("artifacts")`` honour the always-a-list
+            # guarantee instead of raising / returning None.
+            return self.artifacts
         return super().__getitem__(key)
 
     def __setitem__(self, key: Text, value: Any) -> None:

--- a/aixplain/v1/modules/agent/agent_response_data.py
+++ b/aixplain/v1/modules/agent/agent_response_data.py
@@ -5,7 +5,160 @@ input, output, and execution details of an agent's response, including intermedi
 steps and execution statistics.
 """
 
+import dataclasses
+from dataclasses import dataclass
 from typing import List, Dict, Any, Optional, Text
+
+
+@dataclass
+class Artifact:
+    """A user-facing deliverable produced during an agent run.
+
+    v1 mirror of :class:`aixplain.v2.agent.Artifact` — same field names, same
+    semantics. Artifacts come from two sources:
+
+    - ``source="tool_output"`` — media a tool generated (image/audio/video/page).
+      Carries a ``url``, usually a **presigned** URL.
+    - ``source="workspace"`` — a file the agent wrote into its workspace.
+      Carries inline UTF-8 text in ``content`` (binary workspace files are
+      skipped by the engine; there is no uploader yet).
+
+    Exactly one of ``url`` / ``content`` is populated.
+
+    Warning:
+        ``url_expires_at`` is when the **presigned URL** dies, not the artifact.
+        Observed in the wild: a 24h window on a generated image URL. If you
+        persist artifact URLs (database, cache, sent email), re-host the bytes
+        before ``url_expires_at`` or the links will rot.
+
+    ``category`` and ``source`` are plain strings, not enums: the engine may add
+    new media categories before this SDK knows about them, and an unknown value
+    must pass through rather than raise.
+
+    Attributes:
+        id (str): Unique identifier of the artifact.
+        name (str): URL basename, or workspace-relative path (``outputs/report.csv``).
+        title (Optional[str]): Human-friendly title, when the engine set one.
+        mime_type (Optional[str]): MIME type of the artifact content.
+        category (str): ``image`` / ``audio`` / ``video`` / ``page`` / ``document``
+            / ``code`` / ``data`` / ``archive`` / ``other``, or any newer value
+            the engine introduces.
+        source (str): ``tool_output`` or ``workspace``.
+        tool_name (Optional[str]): Tool that produced it (``tool_output`` only).
+        url (Optional[str]): Presigned URL (``tool_output`` only).
+        url_expires_at (Optional[str]): ISO-8601 expiry of ``url``.
+        content (Optional[str]): Inline UTF-8 text (``workspace`` only).
+        sha256 (Optional[str]): Content digest (``workspace`` only).
+        byte_size (Optional[int]): Content size in bytes (``workspace`` only).
+        mentioned_in_answer (bool): Whether the final answer cited the artifact.
+        created_at (str): ISO-8601 creation timestamp.
+    """
+
+    id: str = ""
+    name: str = ""
+    title: Optional[str] = None
+    mime_type: Optional[str] = None
+    category: str = "other"
+    source: str = ""
+    tool_name: Optional[str] = None
+    url: Optional[str] = None
+    url_expires_at: Optional[str] = None
+    content: Optional[str] = None
+    sha256: Optional[str] = None
+    byte_size: Optional[int] = None
+    mentioned_in_answer: bool = False
+    created_at: str = ""
+
+    # Webhook payloads are camelCased by the engine; poll payloads are snake_case
+    # (which already matches the attribute names and binds directly).
+    _ALIASES = {
+        "mimeType": "mime_type",
+        "toolName": "tool_name",
+        "urlExpiresAt": "url_expires_at",
+        "byteSize": "byte_size",
+        "mentionedInAnswer": "mentioned_in_answer",
+        "createdAt": "created_at",
+    }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Artifact":
+        """Create an Artifact from a snake_case or camelCase payload.
+
+        Unknown keys are ignored, and missing keys fall back to the field
+        defaults. If a payload carries both spellings of a field, the one
+        appearing last wins (matching the v2 decoder).
+
+        Args:
+            data (Dict[str, Any]): The artifact payload.
+
+        Returns:
+            Artifact: A new instance populated with the payload data.
+        """
+        names = {f.name for f in dataclasses.fields(cls)}
+        kwargs = {}
+        for key, value in (data or {}).items():
+            attr = cls._ALIASES.get(key, key)
+            if attr in names:
+                kwargs[attr] = value
+        return cls(**kwargs)
+
+    @classmethod
+    def from_list(cls, value: Any) -> List["Artifact"]:
+        """Decode an ``artifacts`` payload without ever raising.
+
+        Args:
+            value (Any): The raw ``artifacts`` value. Anything that is not a
+                list (including ``None``) yields an empty list.
+
+        Returns:
+            List[Artifact]: The decodable entries; junk entries are dropped.
+        """
+        if not isinstance(value, list):
+            return []
+        artifacts: List["Artifact"] = []
+        for item in value:
+            if isinstance(item, cls):
+                artifacts.append(item)
+            elif isinstance(item, dict):
+                try:
+                    artifacts.append(cls.from_dict(item))
+                except Exception:  # pragma: no cover - defensive; engine shape drift
+                    continue
+        return artifacts
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the artifact to its camelCase wire representation.
+
+        Returns:
+            Dict[str, Any]: The artifact as a dictionary, matching the keys the
+                v2 SDK emits.
+        """
+        reverse = {attr: key for key, attr in self._ALIASES.items()}
+        return {reverse.get(f.name, f.name): getattr(self, f.name) for f in dataclasses.fields(self)}
+
+    def get(self, key: str, default: Optional[Any] = None) -> Any:
+        """Get an attribute value, dict-style, with a default.
+
+        Args:
+            key (str): The name of the attribute to get.
+            default (Optional[Any], optional): The value to return if the
+                attribute is not found. Defaults to None.
+
+        Returns:
+            Any: The value of the attribute, or the default value if not found.
+        """
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        """Get an attribute value using dictionary-style access.
+
+        Args:
+            key (str): The name of the attribute to get.
+
+        Returns:
+            Any: The value of the attribute, or None if not found.
+        """
+        return getattr(self, key, None)
 
 
 class AgentResponseData:
@@ -22,6 +175,9 @@ class AgentResponseData:
         steps (List[Any]): Reformatted list of steps with detailed execution info.
         execution_stats (Optional[Dict[str, Any]]): Statistics about the execution.
         critiques (str): Any critiques or feedback about the execution.
+        artifacts (List[Artifact]): Deliverables produced during the run. Always a
+            list, empty when the run produced none or the backend predates
+            artifact support.
     """
 
     def __init__(
@@ -33,6 +189,7 @@ class AgentResponseData:
         steps: Optional[List[Any]] = None,
         execution_stats: Optional[Dict[str, Any]] = None,
         critiques: Optional[str] = None,
+        artifacts: Optional[List[Any]] = None,
     ):
         """Initialize a new AgentResponseData instance.
 
@@ -51,6 +208,10 @@ class AgentResponseData:
                 the execution. Defaults to None.
             critiques (Optional[str], optional): Any critiques or feedback about
                 the execution. Defaults to None.
+            artifacts (Optional[List[Any]], optional): Deliverables produced during
+                the run, as raw payload dictionaries or :class:`Artifact`
+                instances. Anything undecodable is dropped. Defaults to None,
+                which yields an empty list.
         """
         self.input = input
         self.output = output
@@ -59,6 +220,7 @@ class AgentResponseData:
         self.steps = steps or []
         self.execution_stats = execution_stats
         self.critiques = critiques or ""
+        self.artifacts = Artifact.from_list(artifacts)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "AgentResponseData":
@@ -73,6 +235,7 @@ class AgentResponseData:
                 - steps: Reformatted list of steps with detailed execution info
                 - executionStats: Statistics about the execution
                 - critiques: Any critiques or feedback
+                - artifacts: Deliverables produced during the run
 
         Returns:
             AgentResponseData: A new instance populated with the dictionary data.
@@ -85,6 +248,7 @@ class AgentResponseData:
             steps=data.get("steps", []),
             execution_stats=data.get("executionStats"),
             critiques=data.get("critiques", ""),
+            artifacts=data.get("artifacts"),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -100,6 +264,7 @@ class AgentResponseData:
                 - executionStats: Statistics about the execution
                 - execution_stats: Alias for executionStats
                 - critiques: Any critiques or feedback
+                - artifacts: Deliverables produced during the run
         """
         return {
             "input": self.input,
@@ -110,6 +275,7 @@ class AgentResponseData:
             "executionStats": self.execution_stats,
             "execution_stats": self.execution_stats,
             "critiques": self.critiques,
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
         }
 
     def get(self, key: str, default: Optional[Any] = None) -> Any:
@@ -165,7 +331,8 @@ class AgentResponseData:
             f"intermediate_steps={self.intermediate_steps}, "
             f"steps={self.steps}, "
             f"execution_stats={self.execution_stats}, "
-            f"critiques='{self.critiques}')"
+            f"critiques='{self.critiques}', "
+            f"artifacts={self.artifacts})"
         )
 
     def __contains__(self, key: Text) -> bool:

--- a/aixplain/v1/modules/team_agent/__init__.py
+++ b/aixplain/v1/modules/team_agent/__init__.py
@@ -709,6 +709,7 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                         steps=result_data.get("steps"),
                         execution_stats=result_data.get("executionStats"),
                         critiques=result_data.get("critiques", ""),
+                        artifacts=result_data.get("artifacts"),
                     ),
                     used_credits=result_data.get("usedCredits", 0.0),
                     run_time=result_data.get("runTime", end - start),
@@ -726,6 +727,7 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                     steps=result_data.get("steps"),
                     execution_stats=result_data.get("executionStats"),
                     critiques=result_data.get("critiques", ""),
+                    artifacts=result_data.get("artifacts"),
                 ),
                 used_credits=result_data.get("usedCredits", 0.0),
                 run_time=result_data.get("runTime", end - start),
@@ -942,6 +944,7 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                     intermediate_steps=resp_data.get("intermediate_steps"),
                     steps=resp_data.get("steps"),
                     execution_stats=resp_data.get("executionStats"),
+                    artifacts=resp_data.get("artifacts"),
                 )
         except Exception as e:
             import traceback

--- a/aixplain/v2/__init__.py
+++ b/aixplain/v2/__init__.py
@@ -3,7 +3,7 @@
 from .core import Aixplain
 from .rlm import RLM, RLMResult
 from .utility import Utility
-from .agent import Agent, Budget, ContextOverflowStrategy
+from .agent import Agent, Artifact, Budget, ContextOverflowStrategy
 from .tool import Tool
 from .skill import Skill
 from .actions import Input, Inputs, Action, Actions
@@ -95,6 +95,7 @@ __all__ = [
     "RLMResult",
     "Utility",
     "Agent",
+    "Artifact",
     "Budget",
     "ContextOverflowStrategy",
     "Tool",

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -316,6 +316,74 @@ class Budget:
 
 @dataclass_json
 @dataclass
+class Artifact:
+    """A user-facing deliverable produced during an agent run.
+
+    Artifacts are captured by the agent engine and come from two sources:
+
+    - ``source="tool_output"`` — media a tool generated (image/audio/video/page).
+      Carries a ``url``, usually a **presigned** URL.
+    - ``source="workspace"`` — a file the agent wrote into its workspace.
+      Carries inline UTF-8 text in ``content`` (binary workspace files are
+      skipped by the engine; there is no uploader yet).
+
+    Exactly one of ``url`` / ``content`` is populated.
+
+    .. warning::
+       ``url_expires_at`` is when the **presigned URL** dies, not the artifact.
+       Observed in the wild: a 24h window on a generated image URL. If you
+       persist artifact URLs (database, cache, sent email), re-host the bytes
+       before ``url_expires_at`` or the links will rot.
+
+    ``category`` and ``source`` are plain strings, not enums: the engine may add
+    new media categories before this SDK knows about them, and an unknown value
+    must pass through rather than raise.
+
+    Both wire casings deserialize: the poll/``checkRequest`` path emits
+    snake_case (``mime_type``) while the webhook body is camelCased
+    (``mimeType``). If a payload somehow carries both spellings of a field, the
+    one appearing last in the payload wins.
+    """
+
+    id: str = ""
+    name: str = ""
+    title: Optional[str] = None
+    mime_type: Optional[str] = field(default=None, metadata=config(field_name="mimeType"))
+    category: str = "other"
+    source: str = ""
+    tool_name: Optional[str] = field(default=None, metadata=config(field_name="toolName"))
+    url: Optional[str] = None
+    url_expires_at: Optional[str] = field(default=None, metadata=config(field_name="urlExpiresAt"))
+    content: Optional[str] = None
+    sha256: Optional[str] = None
+    byte_size: Optional[int] = field(default=None, metadata=config(field_name="byteSize"))
+    mentioned_in_answer: bool = field(default=False, metadata=config(field_name="mentionedInAnswer"))
+    created_at: str = field(default="", metadata=config(field_name="createdAt"))
+
+    @classmethod
+    def _coerce_list(cls, value: Any) -> List["Artifact"]:
+        """Decode an ``artifacts`` payload without ever raising.
+
+        Used as the ``decoder=`` for :attr:`AgentResponseData.artifacts`.
+        Non-list values yield ``[]``; individual entries that fail to decode are
+        dropped rather than failing the whole response.
+        """
+        if not isinstance(value, list):
+            return []
+        artifacts: List["Artifact"] = []
+        for item in value:
+            if isinstance(item, cls):
+                artifacts.append(item)
+            elif isinstance(item, dict):
+                try:
+                    artifacts.append(cls.from_dict(item))
+                except Exception:  # pragma: no cover - defensive; engine shape drift
+                    logger.debug("Skipping undecodable artifact entry: %r", item)
+        return artifacts
+
+
+@dataclass_json
+@dataclass
 class AgentResponseData:
     """Data structure for agent response."""
 
@@ -326,6 +394,14 @@ class AgentResponseData:
     execution_stats: Optional[Dict[str, Any]] = field(default=None, metadata=config(field_name="executionStats"))
     diagnostic_error_codes: List[str] = field(default_factory=list, metadata=config(field_name="diagnosticErrorCodes"))
     critiques: Optional[str] = ""
+    # Declared Optional only to keep dataclasses_json quiet: an explicit
+    # ``"artifacts": null`` on a non-Optional field makes it emit a
+    # "non-optional type ... detected when decoding" RuntimeWarning on every
+    # decode. The attribute itself is never None — ``__post_init__`` normalizes.
+    artifacts: Optional[List[Artifact]] = field(
+        default_factory=list,
+        metadata=config(decoder=Artifact._coerce_list),
+    )
     governance: Optional[Dict[str, Any]] = None
     _governance_status: Optional[str] = field(
         default=None, repr=False, metadata=config(field_name="governanceStatus", exclude=lambda x: True)
@@ -338,7 +414,13 @@ class AgentResponseData:
     )
 
     def __post_init__(self) -> None:
-        """Assemble the nested ``governance`` dict from the flat wire fields."""
+        """Normalize ``artifacts`` and assemble ``governance`` from flat wire fields."""
+        # Also runs for direct construction, which never touches the field
+        # decoder: ``AgentResponseData(artifacts=[{...}])`` must type its raw
+        # dicts the way v1 does, and an explicit ``artifacts=None`` must land on
+        # ``[]`` rather than ``None``. Re-coercing an already-decoded list is a
+        # cheap no-op, since ``Artifact`` instances pass straight through.
+        self.artifacts = Artifact._coerce_list(self.artifacts)
         if self.governance is None:
             self.governance = {
                 "status": self._governance_status,
@@ -396,6 +478,22 @@ class AgentRunResult(Result):
         metadata=config(exclude=lambda x: True),
         init=False,
     )
+
+    @property
+    def artifacts(self) -> List[Artifact]:
+        """Deliverables produced during the run (see :class:`Artifact`).
+
+        Always a list — empty when the run produced nothing, when artifact
+        capture is disabled, or when the backend predates artifact support.
+        """
+        data = self.data
+        if isinstance(data, AgentResponseData):
+            return data.artifacts or []
+        if isinstance(data, dict):
+            # ``data`` is a bare dict when the result was built by hand rather
+            # than decoded through ``from_dict``.
+            return Artifact._coerce_list(data.get("artifacts"))
+        return []
 
     @property
     def execution_id(self) -> Optional[str]:

--- a/tests/unit/agent/agent_artifacts_test.py
+++ b/tests/unit/agent/agent_artifacts_test.py
@@ -1,0 +1,272 @@
+"""Unit tests for the v1 ``artifacts`` field on the agent run response.
+
+v1 mirrors the v2 ``Artifact`` model field-for-field so user code that still
+imports ``aixplain.modules.agent`` gets the same typed deliverables. The same
+records arrive with two key casings (snake_case from the poll path, camelCase
+from the webhook body), so both must decode into the same object. These tests
+cover the dual-casing decode, the back-compat cases (absent / ``null`` / junk /
+non-list), unknown ``category`` passthrough, the ``AgentResponse.artifacts``
+passthrough property, and v1/v2 field parity.
+"""
+
+import dataclasses
+
+from aixplain.enums import ResponseStatus
+from aixplain.modules.agent.agent_response import AgentResponse
+from aixplain.modules.agent.agent_response_data import AgentResponseData, Artifact
+from aixplain.v2.agent import Artifact as V2Artifact
+
+# Captured from a live prod run: a Seedream image returned by a tool.
+SNAKE_IMAGE_ARTIFACT = {
+    "id": "6c968445-161c-48b3-acfc-6a1ddcaa6d25",
+    "name": "021786092513318a25d9fd8bbdfc574a90b55d3ae211a62db7f63_0.jpeg",
+    "title": None,
+    "mime_type": "image/jpeg",
+    "category": "image",
+    "source": "tool_output",
+    "tool_name": "actions_run",
+    "url": "https://ark-content-generation-v2-ap-southeast-1.tos-ap-southeast-1.volces.com/seedream-4-0/x.jpeg?X-Tos-Expires=86400",
+    "url_expires_at": "2026-08-08T08:48:42Z",
+    "content": None,
+    "sha256": None,
+    "byte_size": None,
+    "mentioned_in_answer": False,
+    "created_at": "2026-08-07T08:48:43.640756Z",
+}
+
+# Captured from a live prod run: a CSV the agent wrote into its workspace.
+SNAKE_WORKSPACE_ARTIFACT = {
+    "id": "4a955263-bcd1-4503-8eb4-778e8bc01111",
+    "name": "outputs/report.csv",
+    "mime_type": "text/csv",
+    "category": "data",
+    "source": "workspace",
+    "tool_name": None,
+    "url": None,
+    "url_expires_at": None,
+    "content": "quarter,revenue\nQ1,120000\nQ2,135000\nQ3,151000\nQ4,168000",
+    "sha256": "19b413378251d828b0c0347ebcfb50343f3aff8ebd54ee5d0fe439f974dfecb3",
+    "byte_size": 55,
+    "mentioned_in_answer": True,
+    "created_at": "2026-08-07T08:45:08.054556Z",
+}
+
+_CAMEL_KEYS = {
+    "mime_type": "mimeType",
+    "tool_name": "toolName",
+    "url_expires_at": "urlExpiresAt",
+    "byte_size": "byteSize",
+    "mentioned_in_answer": "mentionedInAnswer",
+    "created_at": "createdAt",
+}
+
+
+def _camelize(payload):
+    """Convert a snake_case artifact payload to the camelCase webhook shape."""
+    return {_CAMEL_KEYS.get(key, key): value for key, value in payload.items()}
+
+
+CAMEL_IMAGE_ARTIFACT = _camelize(SNAKE_IMAGE_ARTIFACT)
+CAMEL_WORKSPACE_ARTIFACT = _camelize(SNAKE_WORKSPACE_ARTIFACT)
+
+
+def _artifacts(payload):
+    """Decode an ``artifacts`` payload through ``AgentResponseData.from_dict``."""
+    return AgentResponseData.from_dict({"artifacts": payload}).artifacts
+
+
+def test_snake_case_payload_populates_every_field():
+    """The poll path (snake_case) lands on all 14 attributes."""
+    (artifact,) = _artifacts([SNAKE_IMAGE_ARTIFACT])
+
+    assert artifact.id == "6c968445-161c-48b3-acfc-6a1ddcaa6d25"
+    assert artifact.name == "021786092513318a25d9fd8bbdfc574a90b55d3ae211a62db7f63_0.jpeg"
+    assert artifact.title is None
+    assert artifact.mime_type == "image/jpeg"
+    assert artifact.category == "image"
+    assert artifact.source == "tool_output"
+    assert artifact.tool_name == "actions_run"
+    assert artifact.url == SNAKE_IMAGE_ARTIFACT["url"]
+    assert artifact.url_expires_at == "2026-08-08T08:48:42Z"
+    assert artifact.content is None
+    assert artifact.sha256 is None
+    assert artifact.byte_size is None
+    assert artifact.mentioned_in_answer is False
+    assert artifact.created_at == "2026-08-07T08:48:43.640756Z"
+
+
+def test_camel_case_payload_decodes_identically():
+    """The webhook path (camelCase) yields an object equal to the snake_case one."""
+    assert _artifacts([CAMEL_IMAGE_ARTIFACT]) == _artifacts([SNAKE_IMAGE_ARTIFACT])
+    assert _artifacts([CAMEL_WORKSPACE_ARTIFACT]) == _artifacts([SNAKE_WORKSPACE_ARTIFACT])
+
+
+def test_workspace_artifact_carries_inline_content():
+    """Workspace artifacts have inline text and a digest, and no URL."""
+    (artifact,) = _artifacts([SNAKE_WORKSPACE_ARTIFACT])
+
+    assert artifact.source == "workspace"
+    assert artifact.url is None
+    assert artifact.content.startswith("quarter,revenue")
+    assert artifact.sha256 == SNAKE_WORKSPACE_ARTIFACT["sha256"]
+    assert artifact.byte_size == 55
+    assert artifact.mentioned_in_answer is True
+
+
+def test_missing_key_yields_empty_list():
+    """Pre-#342 payloads have no ``artifacts`` key at all."""
+    assert AgentResponseData.from_dict({"output": "hi"}).artifacts == []
+    assert AgentResponseData().artifacts == []
+
+
+def test_null_artifacts_yields_empty_list():
+    """An explicit ``"artifacts": null`` decodes to ``[]`` rather than ``None``."""
+    assert _artifacts(None) == []
+
+
+def test_non_list_artifacts_yields_empty_list():
+    """A scalar where a list was expected must not raise."""
+    assert _artifacts("nope") == []
+    assert _artifacts({"id": "x"}) == []
+
+
+def test_junk_entries_are_dropped_and_valid_ones_kept():
+    """Undecodable list entries are skipped rather than failing the response."""
+    artifacts = _artifacts(["oops", 3, None, SNAKE_IMAGE_ARTIFACT])
+
+    assert [a.id for a in artifacts] == ["6c968445-161c-48b3-acfc-6a1ddcaa6d25"]
+
+
+def test_unknown_category_and_source_pass_through():
+    """The engine may add media categories before the SDK knows about them."""
+    (artifact,) = _artifacts([{"category": "hologram", "source": "teleporter"}])
+
+    assert artifact.category == "hologram"
+    assert artifact.source == "teleporter"
+
+
+def test_unknown_extra_key_is_ignored():
+    """Additive engine fields must not break deserialization."""
+    (artifact,) = _artifacts([dict(SNAKE_IMAGE_ARTIFACT, thumbnailUrl="https://thumb")])
+
+    assert artifact.id == SNAKE_IMAGE_ARTIFACT["id"]
+
+
+def test_partial_payload_falls_back_to_defaults():
+    """A truncated payload degrades to defaults instead of raising."""
+    (artifact,) = _artifacts([{"name": "out.txt"}])
+
+    assert artifact.name == "out.txt"
+    assert artifact.id == ""
+    assert artifact.category == "other"
+    assert artifact.mentioned_in_answer is False
+
+
+def test_constructor_accepts_artifact_instances():
+    """``AgentResponseData(artifacts=[Artifact(...)])`` keeps the typed entries."""
+    artifact = Artifact.from_dict(SNAKE_IMAGE_ARTIFACT)
+
+    assert AgentResponseData(artifacts=[artifact]).artifacts == [artifact]
+
+
+def test_artifact_supports_dict_style_access():
+    """v1 response objects are routinely read dict-style."""
+    (artifact,) = _artifacts([SNAKE_WORKSPACE_ARTIFACT])
+
+    assert artifact["category"] == "data"
+    assert artifact.get("mime_type") == "text/csv"
+    assert artifact.get("nonexistent", "fallback") == "fallback"
+
+
+def test_to_dict_emits_camel_case_and_round_trips():
+    """Serialization matches the camelCase wire shape and is lossless."""
+    (artifact,) = _artifacts([SNAKE_IMAGE_ARTIFACT])
+    payload = artifact.to_dict()
+
+    assert payload == CAMEL_IMAGE_ARTIFACT
+    assert Artifact.from_dict(payload) == artifact
+
+
+def test_response_data_to_dict_includes_artifacts():
+    """``AgentResponseData.to_dict()`` carries the serialized artifacts."""
+    data = AgentResponseData.from_dict({"artifacts": [SNAKE_WORKSPACE_ARTIFACT]})
+
+    # The live workspace payload omits ``title``; serialization fills the default.
+    assert data.to_dict()["artifacts"] == [dict(CAMEL_WORKSPACE_ARTIFACT, title=None)]
+    assert AgentResponseData().to_dict()["artifacts"] == []
+
+
+def test_agent_response_artifacts_passthrough():
+    """``response.artifacts`` mirrors ``response.data.artifacts``."""
+    response = AgentResponse(
+        status=ResponseStatus.SUCCESS,
+        data=AgentResponseData(artifacts=[SNAKE_IMAGE_ARTIFACT]),
+    )
+
+    assert response.artifacts is response.data.artifacts
+    assert response.artifacts[0].category == "image"
+
+
+def test_agent_response_artifacts_empty_without_artifact_bearing_data():
+    """Responses with no data — or non-agent data — still yield a list."""
+    assert AgentResponse(status=ResponseStatus.FAILED).artifacts == []
+
+    response = AgentResponse(status=ResponseStatus.SUCCESS)
+    response.data = object()  # e.g. an EvolverResponseData, which has no artifacts
+    assert response.artifacts == []
+
+
+def test_agent_response_dict_assignment_decodes_artifacts():
+    """``response["data"] = {...}`` routes through ``AgentResponseData.from_dict``."""
+    response = AgentResponse(status=ResponseStatus.SUCCESS)
+    response["data"] = {"output": "done", "artifacts": [CAMEL_IMAGE_ARTIFACT]}
+
+    assert response.artifacts[0].url == SNAKE_IMAGE_ARTIFACT["url"]
+
+
+def test_agent_response_artifacts_from_raw_dict_data():
+    """``data`` is a bare dict on some paths (``Agent.evolve``), not AgentResponseData."""
+    response = AgentResponse(status=ResponseStatus.SUCCESS, data={"artifacts": [CAMEL_IMAGE_ARTIFACT]})
+
+    assert [a.category for a in response.artifacts] == ["image"]
+
+
+def test_agent_response_artifacts_dict_style_access():
+    """v1 response objects are routinely read dict-style, including via ``get``."""
+    response = AgentResponse(
+        status=ResponseStatus.SUCCESS,
+        data=AgentResponseData(artifacts=[SNAKE_IMAGE_ARTIFACT]),
+    )
+
+    assert response["artifacts"] == response.artifacts
+    assert "artifacts" in response
+    # Never None — the same guarantee the attribute makes.
+    assert AgentResponse(status=ResponseStatus.FAILED).get("artifacts") == []
+
+
+def test_v1_and_v2_constructors_coerce_raw_dicts_alike():
+    """Hand-built response data types its artifacts the same way in v1 and v2."""
+    from aixplain.v2.agent import AgentResponseData as V2AgentResponseData
+
+    v1_artifacts = AgentResponseData(artifacts=[CAMEL_IMAGE_ARTIFACT]).artifacts
+    v2_artifacts = V2AgentResponseData(artifacts=[CAMEL_IMAGE_ARTIFACT]).artifacts
+
+    assert [dataclasses.asdict(a) for a in v1_artifacts] == [dataclasses.asdict(a) for a in v2_artifacts]
+
+
+def test_v1_and_v2_artifact_fields_are_identical():
+    """The duplicated v1/v2 definitions must not drift apart."""
+    v1_fields = {f.name for f in dataclasses.fields(Artifact)}
+    v2_fields = {f.name for f in dataclasses.fields(V2Artifact)}
+
+    assert v1_fields == v2_fields
+
+
+def test_v1_and_v2_decode_the_same_payload_the_same_way():
+    """Parity holds at the value level, for both casings."""
+    for payload in (SNAKE_IMAGE_ARTIFACT, CAMEL_IMAGE_ARTIFACT, SNAKE_WORKSPACE_ARTIFACT):
+        v1_artifact = Artifact.from_dict(payload)
+        v2_artifact = V2Artifact.from_dict(payload)
+
+        assert dataclasses.asdict(v1_artifact) == dataclasses.asdict(v2_artifact)
+        assert v1_artifact.to_dict() == v2_artifact.to_dict()

--- a/tests/unit/v2/test_agent_artifacts.py
+++ b/tests/unit/v2/test_agent_artifacts.py
@@ -1,0 +1,247 @@
+"""Unit tests for the v2 ``artifacts`` field on the agent run response.
+
+The agent engine emits a session ``artifacts`` array describing the user-facing
+deliverables a run produced (generated media URLs, files written into the agent
+workspace). The same records reach the SDK with two different key casings — the
+poll / ``checkRequest`` path emits snake_case, the webhook body is camelCased by
+the engine — so both must deserialize into the same object. These tests cover:
+- snake_case and camelCase payloads decode to equal ``Artifact`` objects.
+- Absent, ``null``, non-list, and junk-element payloads yield ``[]`` without
+  raising and without emitting a ``RuntimeWarning``.
+- Unknown ``category`` / ``source`` values and unknown extra keys pass through.
+- ``to_dict()`` emits camelCase and round-trips losslessly.
+- ``AgentRunResult.artifacts`` mirrors ``result.data.artifacts``, and is ``[]``
+  when ``data`` is a plain string or missing entirely.
+"""
+
+import warnings
+
+from aixplain.v2.agent import AgentResponseData, AgentRunResult, Artifact
+
+# Captured from a live prod run: a Seedream image returned by a tool.
+SNAKE_IMAGE_ARTIFACT = {
+    "id": "6c968445-161c-48b3-acfc-6a1ddcaa6d25",
+    "name": "021786092513318a25d9fd8bbdfc574a90b55d3ae211a62db7f63_0.jpeg",
+    "title": None,
+    "mime_type": "image/jpeg",
+    "category": "image",
+    "source": "tool_output",
+    "tool_name": "actions_run",
+    "url": "https://ark-content-generation-v2-ap-southeast-1.tos-ap-southeast-1.volces.com/seedream-4-0/x.jpeg?X-Tos-Expires=86400",
+    "url_expires_at": "2026-08-08T08:48:42Z",
+    "content": None,
+    "sha256": None,
+    "byte_size": None,
+    "mentioned_in_answer": False,
+    "created_at": "2026-08-07T08:48:43.640756Z",
+}
+
+# Captured from a live prod run: a CSV the agent wrote into its workspace.
+SNAKE_WORKSPACE_ARTIFACT = {
+    "id": "4a955263-bcd1-4503-8eb4-778e8bc01111",
+    "name": "outputs/report.csv",
+    "mime_type": "text/csv",
+    "category": "data",
+    "source": "workspace",
+    "tool_name": None,
+    "url": None,
+    "url_expires_at": None,
+    "content": "quarter,revenue\nQ1,120000\nQ2,135000\nQ3,151000\nQ4,168000",
+    "sha256": "19b413378251d828b0c0347ebcfb50343f3aff8ebd54ee5d0fe439f974dfecb3",
+    "byte_size": 55,
+    "mentioned_in_answer": True,
+    "created_at": "2026-08-07T08:45:08.054556Z",
+}
+
+_CAMEL_KEYS = {
+    "mime_type": "mimeType",
+    "tool_name": "toolName",
+    "url_expires_at": "urlExpiresAt",
+    "byte_size": "byteSize",
+    "mentioned_in_answer": "mentionedInAnswer",
+    "created_at": "createdAt",
+}
+
+
+def _camelize(payload):
+    """Convert a snake_case artifact payload to the camelCase webhook shape."""
+    return {_CAMEL_KEYS.get(key, key): value for key, value in payload.items()}
+
+
+CAMEL_IMAGE_ARTIFACT = _camelize(SNAKE_IMAGE_ARTIFACT)
+CAMEL_WORKSPACE_ARTIFACT = _camelize(SNAKE_WORKSPACE_ARTIFACT)
+
+
+def _artifacts(payload):
+    """Decode an ``artifacts`` payload through ``AgentResponseData``."""
+    return AgentResponseData.from_dict({"artifacts": payload}).artifacts
+
+
+def test_snake_case_payload_populates_every_field():
+    """The poll path (snake_case) lands on all 14 attributes."""
+    (artifact,) = _artifacts([SNAKE_IMAGE_ARTIFACT])
+
+    assert artifact.id == "6c968445-161c-48b3-acfc-6a1ddcaa6d25"
+    assert artifact.name == "021786092513318a25d9fd8bbdfc574a90b55d3ae211a62db7f63_0.jpeg"
+    assert artifact.title is None
+    assert artifact.mime_type == "image/jpeg"
+    assert artifact.category == "image"
+    assert artifact.source == "tool_output"
+    assert artifact.tool_name == "actions_run"
+    assert artifact.url == SNAKE_IMAGE_ARTIFACT["url"]
+    assert artifact.url_expires_at == "2026-08-08T08:48:42Z"
+    assert artifact.content is None
+    assert artifact.sha256 is None
+    assert artifact.byte_size is None
+    assert artifact.mentioned_in_answer is False
+    assert artifact.created_at == "2026-08-07T08:48:43.640756Z"
+
+
+def test_camel_case_payload_decodes_identically():
+    """The webhook path (camelCase) yields an object equal to the snake_case one."""
+    assert _artifacts([CAMEL_IMAGE_ARTIFACT]) == _artifacts([SNAKE_IMAGE_ARTIFACT])
+    assert _artifacts([CAMEL_WORKSPACE_ARTIFACT]) == _artifacts([SNAKE_WORKSPACE_ARTIFACT])
+
+
+def test_workspace_artifact_carries_inline_content():
+    """Workspace artifacts have inline text and a digest, and no URL."""
+    (artifact,) = _artifacts([SNAKE_WORKSPACE_ARTIFACT])
+
+    assert artifact.source == "workspace"
+    assert artifact.url is None
+    assert artifact.content.startswith("quarter,revenue")
+    assert artifact.sha256 == SNAKE_WORKSPACE_ARTIFACT["sha256"]
+    assert artifact.byte_size == 55
+    assert artifact.mentioned_in_answer is True
+
+
+def test_missing_key_yields_empty_list():
+    """Pre-#342 payloads have no ``artifacts`` key at all."""
+    assert AgentResponseData.from_dict({"output": "hi"}).artifacts == []
+    assert AgentResponseData().artifacts == []
+
+
+def test_null_artifacts_yields_empty_list_without_warning():
+    """An explicit ``"artifacts": null`` decodes to ``[]`` and warns about nothing."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        data = AgentResponseData.from_dict({"artifacts": None})
+
+    assert data.artifacts == []
+    assert [str(w.message) for w in caught] == []
+
+
+def test_non_list_artifacts_yields_empty_list():
+    """A scalar where a list was expected must not raise."""
+    assert _artifacts("nope") == []
+    assert _artifacts({"id": "x"}) == []
+
+
+def test_junk_entries_are_dropped_and_valid_ones_kept():
+    """Undecodable list entries are skipped rather than failing the response."""
+    artifacts = _artifacts(["oops", 3, None, SNAKE_IMAGE_ARTIFACT])
+
+    assert [a.id for a in artifacts] == ["6c968445-161c-48b3-acfc-6a1ddcaa6d25"]
+
+
+def test_unknown_category_and_source_pass_through():
+    """The engine may add media categories before the SDK knows about them."""
+    (artifact,) = _artifacts([{"category": "hologram", "source": "teleporter"}])
+
+    assert artifact.category == "hologram"
+    assert artifact.source == "teleporter"
+
+
+def test_unknown_extra_key_is_ignored():
+    """Additive engine fields must not break deserialization."""
+    (artifact,) = _artifacts([dict(SNAKE_IMAGE_ARTIFACT, thumbnailUrl="https://thumb")])
+
+    assert artifact.id == SNAKE_IMAGE_ARTIFACT["id"]
+
+
+def test_partial_payload_falls_back_to_defaults():
+    """A truncated payload degrades to defaults instead of raising."""
+    (artifact,) = _artifacts([{"name": "out.txt"}])
+
+    assert artifact.name == "out.txt"
+    assert artifact.id == ""
+    assert artifact.category == "other"
+    assert artifact.mentioned_in_answer is False
+
+
+def test_artifacts_instances_pass_through_the_decoder():
+    """Already-typed entries survive a second decode pass unchanged."""
+    (artifact,) = _artifacts([SNAKE_IMAGE_ARTIFACT])
+
+    assert _artifacts([artifact]) == [artifact]
+
+
+def test_to_dict_emits_camel_case_and_round_trips():
+    """Serialization matches the camelCase wire shape and is lossless."""
+    (artifact,) = _artifacts([SNAKE_IMAGE_ARTIFACT])
+    payload = artifact.to_dict()
+
+    assert payload == CAMEL_IMAGE_ARTIFACT
+    assert Artifact.from_dict(payload) == artifact
+
+
+def test_response_data_to_dict_includes_artifacts():
+    """``AgentResponseData.to_dict()`` carries the serialized artifacts."""
+    data = AgentResponseData.from_dict({"artifacts": [SNAKE_WORKSPACE_ARTIFACT]})
+
+    # The live workspace payload omits ``title``; serialization fills the default.
+    assert data.to_dict()["artifacts"] == [dict(CAMEL_WORKSPACE_ARTIFACT, title=None)]
+
+
+def test_direct_construction_types_raw_dicts():
+    """``AgentResponseData(artifacts=[{...}])`` bypasses the field decoder.
+
+    Hand-built response data must still yield typed artifacts, matching v1.
+    """
+    data = AgentResponseData(artifacts=[SNAKE_IMAGE_ARTIFACT, CAMEL_WORKSPACE_ARTIFACT])
+
+    assert all(isinstance(a, Artifact) for a in data.artifacts)
+    assert [a.category for a in data.artifacts] == ["image", "data"]
+
+
+def test_direct_construction_normalizes_none_and_junk():
+    """The always-a-list guarantee holds for the constructor, not just decode."""
+    assert AgentResponseData(artifacts=None).artifacts == []
+    assert AgentResponseData(artifacts="nope").artifacts == []
+    assert AgentResponseData(artifacts=["oops", 3]).artifacts == []
+
+
+def test_run_result_decodes_nested_artifacts():
+    """``AgentRunResult.from_dict`` types artifacts nested under ``data``."""
+    result = AgentRunResult.from_dict(
+        {"status": "completed", "completed": True, "data": {"artifacts": [CAMEL_IMAGE_ARTIFACT]}}
+    )
+
+    assert isinstance(result.data, AgentResponseData)
+    assert isinstance(result.data.artifacts[0], Artifact)
+    assert result.data.artifacts[0].category == "image"
+
+
+def test_run_result_artifacts_property_mirrors_data():
+    """``result.artifacts`` is the same list as ``result.data.artifacts``."""
+    result = AgentRunResult.from_dict(
+        {"status": "completed", "completed": True, "data": {"artifacts": [SNAKE_IMAGE_ARTIFACT]}}
+    )
+
+    assert result.artifacts is result.data.artifacts
+
+
+def test_run_result_artifacts_property_decodes_raw_dict_data():
+    """``data`` is a bare dict on hand-built results, not just decoded ones."""
+    result = AgentRunResult(status="completed", completed=True, data={"artifacts": [CAMEL_IMAGE_ARTIFACT]})
+
+    assert [a.category for a in result.artifacts] == ["image"]
+
+
+def test_run_result_artifacts_property_is_empty_without_structured_data():
+    """``data`` is a bare string on some paths, and may be missing entirely."""
+    text_result = AgentRunResult.from_dict({"status": "completed", "completed": True, "data": "plain text"})
+    empty_result = AgentRunResult(status="completed", completed=True)
+
+    assert text_result.artifacts == []
+    assert empty_result.artifacts == []


### PR DESCRIPTION
Closes #1035

## Context

The agent engine ([aixplain-agents#342](https://github.com/aixplain/aixplain-agents/pull/342)) now captures user-facing deliverables produced during a run — generated image/audio/video URLs and files the agent wrote into its workspace — and emits them as an `artifacts` array on the run response. It is on by default on the platform path.

The SDK dropped the field on the floor: `AgentResponseData` had no `artifacts` member, so users had to reach into raw dicts to get at them.

## What changed

A typed `Artifact` in **both** SDK generations, with the 14 fields mirroring `aixplain_agents/artifacts/models.py::Artifact`.

**v2** (`aixplain/v2/agent.py`)
- `@dataclass_json` `Artifact`, following the existing `metadata=config(field_name=...)` idiom used by `execution_stats` / `diagnostic_error_codes`.
- `AgentResponseData.artifacts: List[Artifact]`, decoded through a non-raising `Artifact._coerce_list`.
- Passthrough `AgentRunResult.artifacts` property, so `result.artifacts` works without reaching through `data` — matching how users already reach `session_id`.
- `Artifact` exported from `aixplain.v2`.

**v1** (`aixplain/v1/modules/agent/agent_response_data.py`)
- Mirror `Artifact` dataclass — same field names, same semantics — with `from_dict` / `from_list` / `to_dict` and dict-style access.
- `AgentResponseData.artifacts`, wired through `Agent.run`, `TeamAgent.run` and `TeamAgent`'s poll path.
- `AgentResponse.artifacts` property, with `__getitem__` routing so `response["artifacts"]` and `response.get("artifacts")` honour the always-a-list guarantee rather than raising.

## Both wire casings parse

The same records reach users through two paths with different key casing:

- **poll / `checkRequest`** emits `model_dump(mode="json")` → snake_case (`mime_type`, `url_expires_at`, `byte_size`, `mentioned_in_answer`)
- **webhook** bodies are recursively camelCased by the engine → `mimeType`, `urlExpiresAt`, `byteSize`, `mentionedInAnswer`

Both decode. In v2 this falls out of `dataclasses_json` leaving keys that already match the Python attribute name alone, so declaring `mime_type` with `field_name="mimeType"` accepts both spellings for free; v1 uses an explicit alias table. Covered by tests on both sides.

## Back-compat

Total, by design — old engine builds and every pre-#342 stored result lack the key entirely:

- missing, `null`, or non-list `artifacts` ⇒ `[]`, never `None`, never a raise
- individual undecodable entries are dropped rather than failing the whole response
- `category` and `source` stay plain `str`, not enums, so engine-side additions pass through instead of raising

## Expiry caveat (documented in both docstrings)

`url_expires_at` is when the **presigned URL** dies, not the artifact — observed live as a 24h window on a generated image URL. Anything persisting these URLs must re-host the bytes before expiry or the links rot.

## Testing

41 new unit tests across `tests/unit/agent/agent_artifacts_test.py` and `tests/unit/v2/test_agent_artifacts.py` — both casings, missing/null/malformed payloads, unknown category/source, round-tripping, and the passthrough properties. All pass, along with the 1142 tests in the surrounding `tests/unit/agent` and `tests/unit/v2` suites.