### PR TITLE
fix(v2): bound the remaining unbounded HTTP calls on the upload/file path (BUG-938)

### DIFF
--- a/aixplain/utils/file_utils.py
+++ b/aixplain/utils/file_utils.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
 import os
 import re
 import requests
@@ -23,10 +24,48 @@ from aixplain.enums.license import License
 from aixplain.utils.request_utils import _request_with_retry
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Optional, Text, Union, Dict, List
+from typing import Any, Optional, Text, Tuple, Union, Dict, List
 from uuid import uuid4
 from urllib.parse import urljoin, urlparse
 from pandas import DataFrame
+
+logger = logging.getLogger(__name__)
+
+# Default (connect, read) timeout for the streaming download below. Without one,
+# ``requests`` blocks forever on a socket read: a blackholed download pins the
+# calling thread mid-``iter_content`` with an open file handle. The read timeout
+# bounds the gap between chunks, not the total download, so large files are fine.
+DEFAULT_DOWNLOAD_CONNECT_TIMEOUT = 10.0
+DEFAULT_DOWNLOAD_READ_TIMEOUT = 300.0
+
+
+def _download_timeout() -> Tuple[float, float]:
+    """Resolve the (connect, read) download timeout, honouring env overrides.
+
+    Uses the same ``AIXPLAIN_HTTP_CONNECT_TIMEOUT`` / ``AIXPLAIN_HTTP_READ_TIMEOUT``
+    names as the v2 client so one pair of variables tunes the whole SDK. A
+    malformed or non-positive value must not silently remove the bound it exists
+    to configure, so it is logged and the default is kept.
+    """
+
+    def _resolve(name: str, default: float) -> float:
+        raw = os.getenv(name, "").strip()
+        if not raw:
+            return default
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(f"Ignoring non-numeric {name}={raw!r}; using {default}s")
+            return default
+        if value <= 0:
+            logger.warning(f"Ignoring non-positive {name}={raw!r}; using {default}s")
+            return default
+        return value
+
+    return (
+        _resolve("AIXPLAIN_HTTP_CONNECT_TIMEOUT", DEFAULT_DOWNLOAD_CONNECT_TIMEOUT),
+        _resolve("AIXPLAIN_HTTP_READ_TIMEOUT", DEFAULT_DOWNLOAD_READ_TIMEOUT),
+    )
 
 
 def save_file(download_url: Text, download_file_path: Optional[Union[str, Path]] = None) -> Union[str, Path]:
@@ -61,7 +100,11 @@ def save_file(download_url: Text, download_file_path: Optional[Union[str, Path]]
     return download_file_path
 
 
-def download_data(url_link: str, local_filename: Optional[str] = None) -> str:
+def download_data(
+    url_link: str,
+    local_filename: Optional[str] = None,
+    timeout: Optional[Union[float, Tuple[float, float]]] = None,
+) -> str:
     """Download a file from a URL with streaming support.
 
     This function downloads a file from the specified URL using streaming to
@@ -73,17 +116,27 @@ def download_data(url_link: str, local_filename: Optional[str] = None) -> str:
         local_filename (Optional[str], optional): Local path where the file
             should be saved. If None, uses the last part of the URL as the
             filename. Defaults to None.
+        timeout (Optional[Union[float, Tuple[float, float]]], optional): Timeout
+            in seconds, either a single value or a ``(connect, read)`` pair.
+            Defaults to None, which uses
+            (AIXPLAIN_HTTP_CONNECT_TIMEOUT or 10, AIXPLAIN_HTTP_READ_TIMEOUT or 300).
+            The read timeout bounds the gap between chunks, not the total
+            download, so it does not cap large transfers.
 
     Returns:
         str: Path to the downloaded file.
 
     Raises:
+        requests.exceptions.Timeout: If the connection or a chunk read exceeds
+            the timeout.
         requests.exceptions.RequestException: If the download fails or the
             server returns an error status.
     """
     if local_filename is None:
         local_filename = url_link.split("/")[-1]
-    with requests.get(url_link, stream=True) as r:
+    if timeout is None:
+        timeout = _download_timeout()
+    with requests.get(url_link, stream=True, timeout=timeout) as r:
         r.raise_for_status()
         with open(local_filename, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):

--- a/aixplain/v2/code_utils.py
+++ b/aixplain/v2/code_utils.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 import requests
 import validators
 
+from .client import default_timeout
 from .enums import DataType
 from .upload_utils import FileUploader
 
@@ -163,7 +164,7 @@ def parse_code(
         with open(code, "r") as f:
             str_code = f.read()
     elif validators.url(code):
-        str_code = requests.get(code).text
+        str_code = requests.get(code, timeout=default_timeout()).text
     else:
         str_code = code
 
@@ -273,7 +274,7 @@ def parse_code_decorated(
             with open(code, "r") as f:
                 str_code = f.read()
         elif validators.url(code):
-            str_code = requests.get(code).text
+            str_code = requests.get(code, timeout=default_timeout()).text
         else:
             str_code = code
 

--- a/aixplain/v2/upload_utils.py
+++ b/aixplain/v2/upload_utils.py
@@ -117,8 +117,20 @@ class RequestManager:
 
     @classmethod
     def request_with_retry(cls, method: str, url: str, **kwargs) -> requests.Response:
-        """Make HTTP request with retry logic."""
+        """Make HTTP request with retry logic.
+
+        A default ``(connect, read)`` timeout is applied when the caller doesn't
+        pass one: without it ``requests`` waits forever, so a peer that accepts
+        the connection and then goes silent pins the calling thread with no upper
+        bound. The read timeout bounds the gap between bytes, not the total
+        transfer, so large uploads are unaffected. Override per call with
+        ``timeout=`` or globally via ``AIXPLAIN_HTTP_CONNECT_TIMEOUT`` /
+        ``AIXPLAIN_HTTP_READ_TIMEOUT``.
+        """
+        from .client import default_timeout
+
         session = cls.create_session()
+        kwargs.setdefault("timeout", default_timeout())
         return session.request(method=method.upper(), url=url, **kwargs)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,25 @@
+import socket
+from contextlib import closing
+
+import pytest
+
+
+@pytest.fixture
+def blackhole_url():
+    """A listener that completes the handshake and never answers.
+
+    ``listen()`` without ``accept()`` still completes the TCP handshake from the
+    kernel backlog, so the connect succeeds and the read blocks — the production
+    failure mode an unbounded request turns into a permanent stall (LB draining,
+    NAT blackhole, half-open socket).
+
+    Sandboxed environments may forbid opening a listening socket at all; that is
+    an environment limit, not a regression, so it skips rather than errors.
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        try:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+        except OSError as e:
+            pytest.skip(f"cannot open a loopback listener in this environment: {e}")
+        yield f"http://127.0.0.1:{sock.getsockname()[1]}/blackhole"

--- a/tests/unit/utils/file_utils_test.py
+++ b/tests/unit/utils/file_utils_test.py
@@ -14,12 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from unittest.mock import Mock, patch
+import time
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import requests
 
 from aixplain.enums import License
-from aixplain.utils.file_utils import upload_data
+from aixplain.utils.file_utils import (
+    DEFAULT_DOWNLOAD_CONNECT_TIMEOUT,
+    DEFAULT_DOWNLOAD_READ_TIMEOUT,
+    download_data,
+    upload_data,
+)
 
 
 @pytest.mark.parametrize(
@@ -60,3 +67,67 @@ def test_upload_data_builds_s3_link_from_modern_presigned_url(tmp_path, presigne
         )
 
     assert s3_link == expected_link
+
+
+# ``blackhole_url`` comes from tests/unit/conftest.py.
+
+
+def _streaming_response():
+    """A ``requests.get(..., stream=True)`` stand-in usable as a context manager."""
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.iter_content.return_value = [b"chunk"]
+    return response
+
+
+class TestDownloadDataTimeout:
+    """The streaming download must be bounded: without a timeout the thread
+    hangs mid-``iter_content`` holding an open file handle (BUG-938)."""
+
+    def test_default_timeout_is_applied(self, tmp_path):
+        with patch("aixplain.utils.file_utils.requests.get", return_value=_streaming_response()) as mock_get:
+            download_data("https://example.com/f.bin", local_filename=str(tmp_path / "f.bin"))
+
+        assert mock_get.call_args.kwargs["timeout"] == (
+            DEFAULT_DOWNLOAD_CONNECT_TIMEOUT,
+            DEFAULT_DOWNLOAD_READ_TIMEOUT,
+        )
+
+    def test_explicit_timeout_wins(self, tmp_path):
+        with patch("aixplain.utils.file_utils.requests.get", return_value=_streaming_response()) as mock_get:
+            download_data("https://example.com/f.bin", local_filename=str(tmp_path / "f.bin"), timeout=2.5)
+
+        assert mock_get.call_args.kwargs["timeout"] == 2.5
+
+    def test_env_override_is_honoured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIXPLAIN_HTTP_CONNECT_TIMEOUT", "4")
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", "9.5")
+
+        with patch("aixplain.utils.file_utils.requests.get", return_value=_streaming_response()) as mock_get:
+            download_data("https://example.com/f.bin", local_filename=str(tmp_path / "f.bin"))
+
+        assert mock_get.call_args.kwargs["timeout"] == (4.0, 9.5)
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-5", ""])
+    def test_unusable_env_values_fall_back_to_defaults(self, bad, tmp_path, monkeypatch):
+        """A typo in the knob must not silently remove the bound it configures."""
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", bad)
+
+        with patch("aixplain.utils.file_utils.requests.get", return_value=_streaming_response()) as mock_get:
+            download_data("https://example.com/f.bin", local_filename=str(tmp_path / "f.bin"))
+
+        assert mock_get.call_args.kwargs["timeout"] == (
+            DEFAULT_DOWNLOAD_CONNECT_TIMEOUT,
+            DEFAULT_DOWNLOAD_READ_TIMEOUT,
+        )
+
+    def test_blackhole_fails_fast(self, blackhole_url, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIXPLAIN_HTTP_CONNECT_TIMEOUT", "1")
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", "1")
+
+        started = time.monotonic()
+        with pytest.raises(requests.exceptions.Timeout):
+            download_data(blackhole_url, local_filename=str(tmp_path / "f.bin"))
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 10, f"took {elapsed:.1f}s; the timeout is not bounding the read"

--- a/tests/unit/v2/test_no_unbounded_requests.py
+++ b/tests/unit/v2/test_no_unbounded_requests.py
@@ -1,0 +1,148 @@
+"""Guard test: no unbounded ``requests`` call on the v2 upload/file path.
+
+Without a ``timeout`` ``requests`` waits forever, so a peer that accepts the
+connection and then goes silent pins the calling thread with no upper bound
+(BUG-938).  Every HTTP dispatch in the files below must either pass ``timeout=``
+explicitly, or live in a function that ``setdefault``s one onto the kwargs it
+forwards.
+
+Modelled on ``test_no_v1_imports.py``: AST-based so comments and string
+literals (e.g. the generated worker code in ``rlm.py``) can't trip it, and
+scoped to a fixed file list so it has no false-positive surface.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The v2 upload/file transfer path. Extending this list is a one-line change.
+GUARDED_FILES = [
+    "aixplain/v2/client.py",
+    "aixplain/v2/upload_utils.py",
+    "aixplain/v2/code_utils.py",
+    "aixplain/utils/file_utils.py",
+]
+
+# ``requests``/``Session`` methods that actually put bytes on a socket.
+DISPATCH_ATTRS = frozenset({"get", "post", "put", "patch", "delete", "head", "options", "request", "send"})
+
+# A receiver whose dotted expression contains one of these is an HTTP dispatcher
+# rather than an ordinary object (``error_obj.get(...)``, ``payload.get(...)``).
+DISPATCH_RECEIVERS = ("requests", "session")
+
+
+def _receiver_repr(node: ast.AST) -> str:
+    """Best-effort dotted-name rendering of a call's receiver expression.
+
+    Handles the three shapes that appear on this path: ``requests.get``,
+    ``self.session.request`` and ``cls.create_session().request``.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_receiver_repr(node.value)}.{node.attr}"
+    if isinstance(node, ast.Call):
+        return _receiver_repr(node.func)
+    return ""
+
+
+def _is_http_dispatch(node: ast.Call) -> bool:
+    """True if ``node`` looks like an HTTP dispatch on requests/a Session."""
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in DISPATCH_ATTRS:
+        return False
+    receiver = _receiver_repr(node.func.value).lower()
+    return any(marker in receiver for marker in DISPATCH_RECEIVERS)
+
+
+def _forwards_kwargs(node: ast.Call) -> bool:
+    """True if the call splats a mapping (``**kwargs``) into the request."""
+    return any(keyword.arg is None for keyword in node.keywords)
+
+
+def _has_timeout_kwarg(node: ast.Call) -> bool:
+    return any(keyword.arg == "timeout" for keyword in node.keywords)
+
+
+def _sets_default_timeout(func_node: ast.AST) -> bool:
+    """True if the enclosing function ``setdefault``s a timeout onto its kwargs."""
+    for node in ast.walk(func_node):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "setdefault"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "timeout"
+        ):
+            return True
+    return False
+
+
+def find_unbounded_dispatches(source: str, filename: str = "<source>") -> list:
+    """Return ``"line N: <code>"`` for every dispatch with no bounded timeout."""
+    tree = ast.parse(source, filename=filename)
+
+    # Map each dispatch to its enclosing function so ``**kwargs`` forwarding can
+    # be credited to a ``setdefault`` earlier in that same function.
+    enclosing = {}
+    for func_node in ast.walk(tree):
+        if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for child in ast.walk(func_node):
+            if isinstance(child, ast.Call) and child not in enclosing:
+                enclosing[child] = func_node
+
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_http_dispatch(node):
+            continue
+        if _has_timeout_kwarg(node):
+            continue
+        func_node = enclosing.get(node)
+        if _forwards_kwargs(node) and func_node is not None and _sets_default_timeout(func_node):
+            continue
+        violations.append(f"  line {node.lineno}: {_receiver_repr(node.func)}(...) dispatches without a timeout")
+    return violations
+
+
+@pytest.mark.parametrize("rel_path", GUARDED_FILES)
+def test_no_unbounded_requests(rel_path):
+    """``rel_path`` must not dispatch HTTP without a bounded timeout."""
+    path = REPO_ROOT / rel_path
+    assert path.exists(), f"{rel_path} is guarded but missing — update GUARDED_FILES deliberately, not by accident"
+
+    violations = find_unbounded_dispatches(path.read_text(), filename=str(path))
+    assert not violations, f"unbounded requests call(s) in {rel_path} (BUG-938):\n" + "\n".join(violations)
+
+
+class TestDetectorIsNotVacuous:
+    """The guard is worthless if it can silently rot into always-passing."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "import requests\nrequests.get(url)\n",
+            "import requests\nrequests.post(url, data=payload)\n",
+            "def f(s):\n    return s.session.request('GET', url)\n",
+            "def f(cls):\n    return cls.create_session().request(method='GET', url=url)\n",
+            "def f(**kwargs):\n    return requests.get(url, **kwargs)\n",
+        ],
+    )
+    def test_flags_unbounded_dispatch(self, source):
+        assert find_unbounded_dispatches(source)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "import requests\nrequests.get(url, timeout=(10, 300))\n",
+            "def f(s):\n    return s.session.request('GET', url, timeout=5)\n",
+            "def f(session, **kwargs):\n    kwargs.setdefault('timeout', (10, 300))\n    return session.request(url, **kwargs)\n",
+            # Ordinary attribute access that merely shares a method name.
+            "error_obj.get('message')\npayload.get('key', None)\n",
+        ],
+    )
+    def test_accepts_bounded_or_unrelated_calls(self, source):
+        assert not find_unbounded_dispatches(source)

--- a/tests/unit/v2/test_upload_timeouts.py
+++ b/tests/unit/v2/test_upload_timeouts.py
@@ -1,0 +1,125 @@
+"""Timeout coverage for the v2 upload path (BUG-938).
+
+``RequestManager.request_with_retry`` is the single dispatch point for both
+upload legs (the presigned-URL POST to the backend and the S3 PUT of the file
+body).  Without a ``timeout`` ``requests`` waits forever, so a peer that
+accepts the connection and then goes silent pins the calling thread with no
+upper bound.
+"""
+
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from aixplain.v2.client import DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ
+from aixplain.v2.exceptions import FileUploadError
+from aixplain.v2.upload_utils import FileUploader, RequestManager
+
+# ``blackhole_url`` comes from tests/unit/conftest.py.
+
+
+def _ok_response():
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"key": "uploads/x.csv", "uploadUrl": "https://s3.example.com/x"}
+    return response
+
+
+class TestRequestWithRetryTimeout:
+    def test_default_timeout_is_applied(self):
+        with patch("requests.Session.request", return_value=_ok_response()) as mock_request:
+            RequestManager.request_with_retry("post", "https://api.example.com/x")
+
+        assert mock_request.call_args.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)
+
+    def test_explicit_timeout_wins(self):
+        """A caller that knows its own bound keeps it."""
+        with patch("requests.Session.request", return_value=_ok_response()) as mock_request:
+            RequestManager.request_with_retry("post", "https://api.example.com/x", timeout=1.5)
+
+        assert mock_request.call_args.kwargs["timeout"] == 1.5
+
+    def test_env_override_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("AIXPLAIN_HTTP_CONNECT_TIMEOUT", "3")
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", "7")
+
+        with patch("requests.Session.request", return_value=_ok_response()) as mock_request:
+            RequestManager.request_with_retry("get", "https://api.example.com/x")
+
+        assert mock_request.call_args.kwargs["timeout"] == (3.0, 7.0)
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-5", ""])
+    def test_unusable_env_values_fall_back_to_defaults(self, bad, monkeypatch):
+        """A typo in the knob must not silently remove the bound it configures."""
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", bad)
+
+        with patch("requests.Session.request", return_value=_ok_response()) as mock_request:
+            RequestManager.request_with_retry("get", "https://api.example.com/x")
+
+        assert mock_request.call_args.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)
+
+
+class TestUploadLegsUseTheDispatcher:
+    """Neither upload leg may bypass ``request_with_retry`` and its default."""
+
+    def test_both_legs_go_through_request_with_retry(self, tmp_path):
+        file_path = tmp_path / "sample.csv"
+        file_path.write_text("a,b\n1,2\n")
+
+        uploader = FileUploader(backend_url="https://api.example.com", api_key="key")
+
+        with patch.object(RequestManager, "request_with_retry", return_value=_ok_response()) as mock_dispatch:
+            uploader.upload(str(file_path))
+
+        methods = [call.args[0] for call in mock_dispatch.call_args_list]
+        assert methods == ["post", "put"]
+
+    def test_dispatched_calls_carry_a_timeout(self, tmp_path):
+        file_path = tmp_path / "sample.csv"
+        file_path.write_text("a,b\n1,2\n")
+
+        uploader = FileUploader(backend_url="https://api.example.com", api_key="key")
+
+        with patch("requests.Session.request", return_value=_ok_response()) as mock_request:
+            uploader.upload(str(file_path))
+
+        assert mock_request.call_count == 2
+        for call in mock_request.call_args_list:
+            assert call.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)
+
+
+class TestBlackholeFailsFast:
+    """The acceptance criterion: bounded failure instead of an infinite hang."""
+
+    def test_put_leg_raises_timeout(self, blackhole_url, monkeypatch):
+        monkeypatch.setenv("AIXPLAIN_HTTP_CONNECT_TIMEOUT", "1")
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", "1")
+
+        started = time.monotonic()
+        # PUT is outside the retry session's allowed_methods, so the read
+        # timeout surfaces directly rather than as an exhausted-retry error.
+        with pytest.raises(requests.exceptions.Timeout):
+            RequestManager.request_with_retry("put", blackhole_url, data=b"payload")
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 10, f"took {elapsed:.1f}s; the timeout is not bounding the read"
+
+    def test_upload_wraps_the_timeout_in_file_upload_error(self, blackhole_url, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIXPLAIN_HTTP_CONNECT_TIMEOUT", "1")
+        monkeypatch.setenv("AIXPLAIN_HTTP_READ_TIMEOUT", "1")
+        file_path = tmp_path / "sample.csv"
+        file_path.write_text("a,b\n1,2\n")
+
+        uploader = FileUploader(backend_url=blackhole_url, api_key="key")
+
+        started = time.monotonic()
+        # The presigned POST *is* retried, so this leg fails after a bounded
+        # number of attempts (a urllib3 MaxRetryError surfacing as
+        # ConnectionError) rather than on the first read timeout.
+        with pytest.raises(FileUploadError):
+            uploader.upload(str(file_path))
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 60, f"took {elapsed:.1f}s; the retry budget is not bounded"


### PR DESCRIPTION
## Problem

`requests` has **no default timeout**. A call without an explicit `timeout=` waits forever, so a peer that completes the TCP handshake and then goes silent (LB draining, NAT blackhole, half-open socket) pins the calling thread with no upper bound — in `download_data`'s case, mid-`iter_content` with an open file handle.

`aixplain/v2/client.py` already grew a `default_timeout()` helper. This PR covers the callers on the upload/file path that it missed.

## Changes

| Location | Change |
|---|---|
| `v2/upload_utils.py` | `RequestManager.request_with_retry` `setdefault`s `default_timeout()` onto the forwarded kwargs. This is the single dispatch point for **both** upload legs (presigned-URL `POST` to the backend, S3 `PUT` of the file body), so one line bounds both. Callers keep their own bound if they pass `timeout=`. |
| `v2/code_utils.py` | `parse_code` and `parse_code_decorated` pass `default_timeout()` when fetching code from a URL. |
| `utils/file_utils.py` | `download_data` takes an optional `timeout` and defaults to `(10s connect, 300s read)`. |

### Configuration

Defaults are tunable through the **same** env vars as the v2 client, so one pair of knobs covers the whole SDK:

- `AIXPLAIN_HTTP_CONNECT_TIMEOUT` (default `10`)
- `AIXPLAIN_HTTP_READ_TIMEOUT` (default `300`)

A malformed or non-positive value is logged and ignored rather than silently removing the very bound it exists to configure.

### Why large transfers are safe

The read timeout bounds the **gap between chunks**, not the total transfer. A multi-GB download that keeps delivering bytes never trips it; only a stalled socket does.

## Tests

- **`tests/unit/v2/test_upload_timeouts.py`** — defaults applied, per-call override wins, env override honoured, unusable env values fall back; both upload legs verified to go through `request_with_retry` (so neither can bypass the default).
- **`tests/unit/utils/file_utils_test.py`** — the same matrix for `download_data`.
- **Blackhole tests** — a real loopback listener that completes the handshake and never answers, asserting bounded failure (`requests.exceptions.Timeout` / `FileUploadError`) instead of a hang. The shared `blackhole_url` fixture lives in the new `tests/unit/conftest.py` and skips where a sandbox forbids listening sockets.
- **`tests/unit/v2/test_no_unbounded_requests.py`** — an AST guard (modelled on the existing `test_no_v1_imports.py`) that fails if any HTTP dispatch in the guarded files regresses to an unbounded call. It credits `**kwargs` forwarding only when the enclosing function `setdefault`s a timeout, and includes anti-vacuity tests so the guard can't silently rot into always-passing.

### Verification

- `1272 passed` across `tests/unit`. The 32 collection errors are all a pre-existing missing `requests_mock` dependency in this environment, unrelated to this change.
- Blackhole tests confirmed passing against real sockets (11.5s wall clock, i.e. actually timing out rather than skipping).
- All pre-commit hooks pass, including `ruff`, `ruff format`, and `pytest-check`.

Written test-first: tests were red before the implementation landed.