### PR TITLE
fix(v2/rlm): stop baking TEAM_API_KEY into RLM sandbox source (BUG-936, SEV1)

### DIFF
--- a/aixplain/v2/rlm.py
+++ b/aixplain/v2/rlm.py
@@ -2,12 +2,18 @@
 
 Orchestrates long-context analysis via an iterative REPL sandbox. The
 orchestrator model plans and writes Python code to chunk and explore a large
-context; a worker model handles per-chunk analysis via ``llm_query()`` calls
-injected into the sandbox session.
+context; a worker model handles per-chunk analysis via ``llm_query()``.
+
+``llm_query`` is credential-free inside the sandbox: the injected helper submits
+prompts on stdout and the SDK answers them in-process, so no API key is ever
+materialised in sandbox-executed source (BUG-936). SDK-generated setup code and
+model-emitted code run in separate sandbox sessions, and both are torn down when
+the run ends.
 """
 
 __author__ = "aiXplain"
 
+import hashlib
 import json
 import logging
 import os
@@ -20,7 +26,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json, config as dj_config
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 from .resource import BaseResource, Result
 from .mixins import ToolableMixin, ToolDict
@@ -42,13 +48,154 @@ _SANDBOX_TOOL_ID = "microsoft/code-execution/microsoft"
 _REPL_OUTPUT_MAX_CHARS = 100_000
 
 
+# Sandbox Sessions
+#
+# The sandbox is a third-party execution service with outbound network access
+# and a stdout return channel, and the code the orchestrator emits into it is
+# steered by (potentially untrusted) analysed context. Two sessions keep the
+# trust boundary structural rather than textual:
+#
+# - ``_SETUP_SESSION`` runs SDK-generated code only. Orchestrator-emitted code
+#   can never reach it, so it is the enforced home for any future bootstrap
+#   step that has to handle a credential.
+# - ``_REPL_SESSION`` holds the analysed context, the credential-free
+#   ``llm_query`` prelude, and every model-emitted block.
+_SETUP_SESSION = "setup"
+_REPL_SESSION = "repl"
+
+# Cheap reachability probe for the setup session. Also keeps that session live
+# on every run so the two-session split is exercised, not merely declared.
+_PREFLIGHT_CODE = "import sys\nimport requests as __requests\nprint(sys.version.split()[0])\n"
+
+# Candidate action names for closing a sandbox session. ``Tool.run`` validates
+# ``action`` against the tool's advertised actions, so the real name is
+# discovered at runtime and teardown falls back to wiping session state.
+_TEARDOWN_ACTION_CANDIDATES = ("close_session", "closeSession", "delete_session", "close")
+
+# Fallback teardown: drop everything the session holds (uploaded context,
+# cached answers, download URL) when no close action is exposed.
+_SESSION_WIPE_CODE = """for _aix_n in [_aix_x for _aix_x in list(globals()) if not _aix_x.startswith("__")]:
+    try:
+        del globals()[_aix_n]
+    except Exception:
+        pass
+import gc as _aix_gc
+_aix_gc.collect()
+"""
+
+# Sentinel used for "not yet resolved" on the cached teardown action name, so
+# a legitimately absent action (``None``) is not re-discovered on every close.
+_UNRESOLVED = object()
+
+
+# llm_query Protocol (BUG-936)
+#
+# ``llm_query`` used to be an in-sandbox ``requests.post`` to the worker model,
+# authenticated with the caller's account-level TEAM_API_KEY interpolated into
+# the generated source. Any prompt injection in the analysed context could read
+# it back out (``llm_query.__code__.co_consts``) and exfiltrate it.
+#
+# The credential now never enters the sandbox. Instead the prelude submits
+# prompts on stdout, the SDK answers them in-process with the key it already
+# holds, and the answers are pushed back as a plain JSON data literal.
+
+# Marker prefixing a submitted-prompt batch on sandbox stdout. Stripped by the
+# SDK before the output is shown to the orchestrator.
+_LLM_REQUEST_MARKER = "<<AIX_LLM_QUERY_REQUEST>>"
+
+# Returned by ``llm_query`` when the answer is not cached yet. Never allowed to
+# reach ``RLMResult.data``.
+_LLM_PENDING_SENTINEL = "[[AIX_PENDING: answer not available yet — re-run this block next turn]]"
+
+# Maximum prompts resolved per REPL turn.
+_LLM_MAX_PROMPTS_PER_BATCH = 256
+
+# Maximum characters of a single prompt forwarded to the worker model.
+_LLM_MAX_PROMPT_CHARS = 400_000
+
+# Output budget for a worker call made on behalf of ``llm_query``. Matches what
+# the old in-sandbox implementation requested, so answer length is unchanged.
+_LLM_QUERY_MAX_TOKENS = 8192
+
+# Maximum request markers parsed out of one block's stdout, so pathological
+# emitted output cannot wedge the resolve loop.
+_LLM_MAX_MARKERS_PER_BLOCK = 512
+
+# Replacement written over any secret value found in sandbox output.
+_REDACTION_PLACEHOLDER = "***REDACTED***"
+
+# Shortest string treated as a credential by the secret tripwire. Guards
+# against a short/degenerate environment value matching everything.
+_MIN_SECRET_LEN = 8
+
+_LLM_QUERY_PRELUDE = f'''import json as __json
+import hashlib as __hashlib
+
+# sha256(prompt) -> answer. Filled in by the aiXplain SDK between REPL turns.
+_llm_answers = {{}}
+# Prompts submitted this turn and still unanswered.
+_llm_query_pending = []
+
+
+def _aix_prompt_key(prompt):
+    return __hashlib.sha256(str(prompt).encode("utf-8")).hexdigest()
+
+
+def _aix_submit(prompts):
+    _new = []
+    for _p in prompts:
+        _p = str(_p)
+        if _aix_prompt_key(_p) in _llm_answers:
+            continue
+        if _p in _llm_query_pending or _p in _new:
+            continue
+        _new.append(_p)
+    _new = _new[:{_LLM_MAX_PROMPTS_PER_BATCH}]
+    if _new:
+        _llm_query_pending.extend(_new)
+        print({_LLM_REQUEST_MARKER!r} + __json.dumps(_new))
+    return len(_new)
+
+
+def llm_query_request(prompts):
+    """Submit one or more prompts to the worker LLM.
+
+    Answers are fetched by the platform between REPL turns, so they become
+    available on your NEXT turn. Returns the number of prompts submitted.
+    """
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    return _aix_submit(list(prompts))
+
+
+def llm_query(prompt):
+    """Answer `prompt` with the worker LLM.
+
+    Returns the real answer when it is already cached (submitted on an earlier
+    turn). Otherwise submits the prompt and returns a PENDING placeholder —
+    re-run the SAME block on your next turn to get real answers for the whole
+    batch at once.
+    """
+    _k = _aix_prompt_key(prompt)
+    if _k in _llm_answers:
+        return _llm_answers[_k]
+    _aix_submit([prompt])
+    return {_LLM_PENDING_SENTINEL!r}
+'''
+
+
 # Prompt Templates
 
 _SYSTEM_PROMPT = """You are tasked with answering a query with associated context. You can access, transform, and analyze this context interactively in a REPL environment that can recursively query sub-LLMs, which you are strongly encouraged to use as much as possible. You will be queried iteratively until you provide a final answer.
 
 The REPL environment is initialized with:
 1. A `context` variable that contains extremely important information about your query. You should check the content of the `context` variable to understand what you are working with. Make sure you look through it sufficiently as you answer your query.
-2. A `llm_query` function that allows you to query an LLM with a context window of {worker_context_window} inside your REPL environment. You must take this context window into consideration when deciding how much text to pass in each call.
+2. A `llm_query(prompt)` function backed by an LLM with a context window of {worker_context_window}. You must take this context window into consideration when deciding how much text to pass in each call.
+
+   Answers are fetched by the platform BETWEEN your REPL turns, so `llm_query` works in two steps:
+     Turn A — build all of your prompts and call `llm_query` on each one (or call `llm_query_request([...])` once with the whole list). Calls with no answer yet return the placeholder "__PENDING__" and the prompts are submitted for you.
+     Turn B — re-run the SAME block. Every submitted prompt now returns its real answer, and the whole batch was answered in parallel.
+   Never treat a "[[AIX_PENDING" value as an answer, never analyze one, and never put one in your final answer. If you see one, re-run the block that produced it.
 3. The ability to use `print()` statements to view the output of your REPL code and continue your reasoning.
 
 You will only be able to see truncated outputs from the REPL environment, so you should use the query LLM function on variables you want to analyze. You will find this function especially useful when you have to analyze the semantics of the context. Use these variables as buffers to build up your final answer.
@@ -59,10 +206,11 @@ You can use the REPL environment to help you understand your context, especially
 When you want to execute Python code in the REPL environment, wrap it in triple backticks with the 'repl' language identifier:
 ```repl
 # your Python code here
-chunk = context[:10000]
-answer = llm_query(f"What is the key finding in this text?\\n{{chunk}}")
-print(answer)
+chunks = [context[i:i + 10000] for i in range(0, len(context), 10000)]
+answers = [llm_query(f"What is the key finding in this text?\\n{{c}}") for c in chunks]
+print(answers[0][:500])
 ```
+Run that block once to submit every prompt, then run the exact same block again on your next turn — the second run returns the real answers for the whole batch.
 
 IMPORTANT: When you are done with the iterative process, you MUST provide a final answer using one of these two forms (NOT inside a code block):
 1. FINAL(your final answer here) — to provide the answer as literal text. Use `FINAL(...)` only when you are completely finished: you will make no further REPL calls, need no further inspection of REPL output, and are not including any REPL code in the same response.
@@ -71,7 +219,7 @@ IMPORTANT: When you are done with the iterative process, you MUST provide a fina
 Do not use `FINAL(...)` or `FINAL_VAR(...)` for intermediate status updates, plans, requests to inspect REPL output, statements such as needing more information, or any response that also includes REPL code to be executed first; those must be written as normal assistant text instead.
 
 Think step by step carefully, plan, and execute this plan immediately — do not just say what you will do.
-"""
+""".replace("__PENDING__", _LLM_PENDING_SENTINEL)
 
 _USER_PROMPT = (
     "Think step-by-step on what to do using the REPL environment (which contains the context) "
@@ -89,7 +237,14 @@ _CONTINUING_PREFIX = "The history above is your previous interactions with the R
 
 _FORCE_FINAL_PROMPT = (
     "Based on all the information gathered so far, provide a final answer to the user's query. "
-    "Use FINAL(your answer) or FINAL_VAR(variable_name)."
+    "Use FINAL(your answer) or FINAL_VAR(variable_name). "
+    "Do not include any '[[AIX_PENDING' placeholder in your answer — those are not answers."
+)
+
+_PENDING_REJECTED_PROMPT = (
+    "Your final answer contained a '[[AIX_PENDING' placeholder, which means at least one "
+    "llm_query prompt had not been answered yet. It was rejected. Re-run the REPL block that "
+    "produced those placeholders — the answers are cached now — then provide the final answer."
 )
 
 _DEFAULT_QUERY = (
@@ -250,6 +405,69 @@ def _truncate(text: str, max_chars: int = _REPL_OUTPUT_MAX_CHARS) -> str:
     if len(text) > max_chars:
         return text[:max_chars] + f"\n... [truncated — {len(text) - max_chars} chars omitted]"
     return text
+
+
+# llm_query Protocol Helpers
+
+
+def _prompt_key(prompt: str) -> str:
+    """Hash a prompt the same way the sandbox prelude does.
+
+    The sandbox keys ``_llm_answers`` by ``sha256`` of the full prompt, so the
+    SDK must hash the *untruncated* prompt it received for the answer to land
+    on the right key.
+    """
+    return hashlib.sha256(str(prompt).encode("utf-8")).hexdigest()
+
+
+def _extract_llm_requests(stdout: str) -> Tuple[str, List[str]]:
+    """Split submitted ``llm_query`` prompts out of sandbox stdout.
+
+    The prelude emits each batch as ``<marker><json array>`` on its own line.
+    Those segments are removed so the orchestrator never sees the protocol
+    chatter (or its own prompts echoed back).
+
+    Args:
+        stdout: Raw stdout captured from the REPL session.
+
+    Returns:
+        ``(clean_stdout, prompts)``. Malformed payloads are ignored rather than
+        raising, and both the marker count and the prompt count are bounded.
+    """
+    if _LLM_REQUEST_MARKER not in stdout:
+        return stdout, []
+
+    kept: List[str] = []
+    prompts: List[str] = []
+    markers = 0
+    for line in stdout.split("\n"):
+        idx = line.find(_LLM_REQUEST_MARKER)
+        if idx == -1:
+            kept.append(line)
+            continue
+        markers += 1
+        if markers <= _LLM_MAX_MARKERS_PER_BLOCK:
+            try:
+                payload = json.loads(line[idx + len(_LLM_REQUEST_MARKER) :])
+            except Exception:
+                # Most likely stdout was truncated mid-batch by the sandbox.
+                # Drop it: the caller sees the marker was present and clears the
+                # sandbox's pending list anyway, so the prompts get resubmitted
+                # when the block is re-run.
+                logger.warning("RLM: malformed llm_query request payload — batch skipped.")
+                payload = None
+            if isinstance(payload, list):
+                prompts.extend(str(p) for p in payload if isinstance(p, (str, int, float)))
+        # Keep anything the block printed before the marker on the same line.
+        if line[:idx]:
+            kept.append(line[:idx])
+
+    if markers > _LLM_MAX_MARKERS_PER_BLOCK:
+        logger.warning(
+            f"RLM: {markers} llm_query request markers in one block — only the first {_LLM_MAX_MARKERS_PER_BLOCK} parsed."
+        )
+
+    return "\n".join(kept), prompts[:_LLM_MAX_PROMPTS_PER_BATCH]
 
 
 # Chunking Helpers (shared by parallel and rag modes)
@@ -442,9 +660,19 @@ class RLM(BaseResource, ToolableMixin):
       ``parallel`` when the index is reused across many calls.
 
     The recursive mode's sandbox is an aiXplain managed Python execution
-    environment. Each recursive ``run()`` call gets its own isolated session
-    (UUID), so variables persist across REPL iterations within a single run
-    but are cleaned up afterwards.
+    environment. Each recursive ``run()`` call gets its own pair of isolated
+    sessions (fresh UUIDs): a **setup** session that only ever receives
+    SDK-generated code, and a **repl** session holding the context and every
+    block the orchestrator emits. Variables persist across REPL iterations
+    within a single run; both sessions are torn down in a ``finally`` when the
+    run ends, on the success and the failure path alike. Use RLM as a context
+    manager (``with aix.RLM(...) as rlm:``) or call :meth:`close` to force
+    teardown early.
+
+    No credential is ever placed inside the sandbox. ``llm_query`` submits its
+    prompts on stdout and the SDK answers them in-process, so code the
+    orchestrator writes — which is steered by the analysed context and must be
+    treated as untrusted — has nothing to steal.
 
     RLM is a **local orchestrator** — it does not correspond to a platform
     endpoint and is not saved via ``save()``. It is registered on the
@@ -471,7 +699,9 @@ class RLM(BaseResource, ToolableMixin):
     Attributes:
         orchestrator_id: Platform model ID of the orchestrator LLM.
         worker_id: Platform model ID of the worker LLM.
-        max_iterations: Maximum orchestrator loop iterations (default 10).
+        max_iterations: Maximum orchestrator loop iterations (default 12). A
+            batch of ``llm_query`` calls costs two iterations in recursive mode
+            — one to submit the prompts and one to consume the answers.
         timeout: Maximum wall-clock seconds per ``run()`` call (default 600).
     """
 
@@ -481,7 +711,7 @@ class RLM(BaseResource, ToolableMixin):
     # Serializable configuration fields
     orchestrator_id: str = field(default="")
     worker_id: str = field(default="")
-    max_iterations: int = field(default=10)
+    max_iterations: int = field(default=12)
     timeout: float = field(default=600.0)
 
     # RAG mode — optional pre-built aIR index. When empty, mode="rag" creates
@@ -498,7 +728,19 @@ class RLM(BaseResource, ToolableMixin):
     rag_max_chunk_chars: int = field(default=_RAG_DEFAULT_MAX_CHUNK_CHARS)
 
     # Runtime state — excluded from serialization
-    _session_id: Optional[str] = field(
+    #
+    # Two sandbox sessions per recursive run (see the session constants above):
+    # ``_setup_session_id`` only ever receives SDK-generated code, while
+    # ``_repl_session_id`` holds the context, the credential-free ``llm_query``
+    # prelude, and all orchestrator-emitted blocks.
+    _setup_session_id: Optional[str] = field(
+        default=None,
+        repr=False,
+        compare=False,
+        metadata=dj_config(exclude=lambda x: True),
+        init=False,
+    )
+    _repl_session_id: Optional[str] = field(
         default=None,
         repr=False,
         compare=False,
@@ -551,6 +793,9 @@ class RLM(BaseResource, ToolableMixin):
         if not self.id:
             self.id = str(uuid.uuid4())
         self._credits_lock = threading.Lock()
+        # Resolved lazily on first teardown; ``_UNRESOLVED`` distinguishes
+        # "not looked up yet" from "the sandbox exposes no close action".
+        self._teardown_action_name: Any = _UNRESOLVED
 
     # Validation
 
@@ -667,10 +912,74 @@ class RLM(BaseResource, ToolableMixin):
                 pass
         return _DEFAULT_WORKER_WINDOW_TOKENS
 
+    # Secret Tripwire (BUG-936)
+
+    def _secret_values(self) -> Tuple[str, ...]:
+        """Credential values that must never reach the sandbox or its output.
+
+        Covers the client's resolved key plus the environment variables it is
+        normally sourced from, so the tripwire still fires if a credential
+        arrives by a path this class does not own.
+        """
+        candidates = (
+            getattr(self.context, "api_key", None),
+            os.environ.get("TEAM_API_KEY"),
+            os.environ.get("AIXPLAIN_API_KEY"),
+        )
+        return tuple({v for v in candidates if isinstance(v, str) and len(v) >= _MIN_SECRET_LEN})
+
+    def _contains_secret(self, text: str) -> bool:
+        """Return ``True`` if ``text`` contains any known credential value."""
+        if not isinstance(text, str) or not text:
+            return False
+        return any(secret in text for secret in self._secret_values())
+
+    def _assert_no_secrets(self, code: str) -> None:
+        """Refuse to transmit SDK-generated code containing a credential.
+
+        This is the BUG-936 regression tripwire: the worker call is made
+        SDK-side precisely so that no key is ever materialised in sandbox
+        source. Reaching this branch means that invariant was broken.
+
+        Raises:
+            ResourceError: If ``code`` contains a credential value.
+        """
+        if self._contains_secret(code):
+            raise ResourceError(
+                "RLM: refusing to send code containing an API key to the sandbox. "
+                "This is the BUG-936 guard — the worker call must be made SDK-side."
+            )
+
+    def _redact(self, text: str) -> str:
+        """Mask any credential value found in sandbox output.
+
+        Closes the reverse channel: emitted code that manages to print a
+        credential (e.g. by dumping ``os.environ``) must not get it into the
+        orchestrator transcript, ``repl_logs``, or the result.
+        """
+        if not isinstance(text, str) or not text:
+            return text
+        for secret in self._secret_values():
+            text = text.replace(secret, _REDACTION_PLACEHOLDER)
+        return text
+
     # Sandbox Setup
 
+    def _preflight(self) -> None:
+        """Start the setup session and confirm the sandbox is reachable.
+
+        The setup session receives SDK-generated code only — orchestrator-emitted
+        blocks are hard-wired to the REPL session — so it is the enforced home
+        for any bootstrap step that has to handle a credential. Nothing secret
+        is sent there today; the probe keeps the boundary live and turns a dead
+        sandbox into an early, clearly-attributed failure.
+        """
+        self._setup_session_id = str(uuid.uuid4())
+        logger.debug(f"RLM: sandbox setup session started (id={self._setup_session_id}).")
+        self._run_sandbox(self._get_sandbox(), _PREFLIGHT_CODE, session=_SETUP_SESSION)
+
     def _setup_repl(self, context: Union[str, dict, list]) -> None:
-        """Initialize a fresh sandbox session and load context + ``llm_query`` into it.
+        """Initialize a fresh REPL session and load context + ``llm_query`` into it.
 
         Two paths are used to get context into the sandbox:
 
@@ -683,15 +992,17 @@ class RLM(BaseResource, ToolableMixin):
           to aiXplain storage via :class:`~aixplain.v2.upload_utils.FileUploader`,
           then downloaded inside the sandbox.
 
-        In both cases a ``llm_query(prompt)`` helper is injected into the sandbox
-        after the context is loaded.
+        In both cases the credential-free ``llm_query(prompt)`` prelude is
+        injected after the context is loaded. It carries no API key and makes no
+        network call: prompts leave on stdout and the SDK answers them
+        in-process (see :data:`_LLM_QUERY_PRELUDE`).
 
         Args:
             context: Normalized context (str, dict, or list).
         """
-        self._session_id = str(uuid.uuid4())
+        self._repl_session_id = str(uuid.uuid4())
         sandbox = self._get_sandbox()
-        logger.info(f"RLM: sandbox session started (id={self._session_id}).")
+        logger.info(f"RLM: sandbox repl session started (id={self._repl_session_id}).")
 
         # --- URL fast path: stream directly into the sandbox, no re-upload ---
         if isinstance(context, str) and (context.startswith("http://") or context.startswith("https://")):
@@ -721,8 +1032,10 @@ if _is_json:
 else:
     with open(_filename, "r", encoding="utf-8") as _f:
         context = _f.read()
+
+del _url, _url_path, _r
 """
-            self._run_sandbox(sandbox, context_code)
+            self._run_sandbox(sandbox, context_code, session=_REPL_SESSION)
             logger.debug("RLM: context loaded into sandbox from URL (direct stream).")
 
         else:
@@ -769,6 +1082,13 @@ else:
 
             sandbox_filename = f"context{ext}"
 
+            # The temp download link is a bearer capability, so it is unbound as
+            # soon as the context is loaded: emitted code — which is steered by
+            # the analysed context — must not be able to read it back out and
+            # exfiltrate a reusable link. Same reasoning as the API key
+            # (BUG-936); the link is still transmitted to the sandbox service,
+            # which only per-session context injection from the platform could
+            # avoid, but it is no longer readable from the REPL namespace.
             context_code = f"""import requests as __requests
 
 _url = {repr(download_url)}
@@ -782,73 +1102,199 @@ with __requests.get(_url, stream=True) as _r:
                 _f.write(_chunk)
 
 {load_code}
+
+del _url, _r
 """
-            self._run_sandbox(sandbox, context_code)
+            self._run_sandbox(sandbox, context_code, session=_REPL_SESSION)
             logger.debug(f"RLM: context loaded into sandbox ({sandbox_filename}).")
 
-        # Inject llm_query
-        # worker_url = https://models.aixplain.com/api/v2/execute/<worker_id>
-        worker_url = f"{self.context.model_url}/{self.worker_id}"
-
-        llm_query_code = f"""import requests as __requests
-import time as __time
-import json as __json
-
-_total_llm_query_credits = 0.0
-
-def llm_query(prompt):
-    global _total_llm_query_credits
-    _headers = {{"x-api-key": "{self.context.api_key}", "Content-Type": "application/json"}}
-    _payload = __json.dumps({{"data": prompt, "max_tokens": 8192}})
-    try:
-        _resp = __requests.post("{worker_url}", headers=_headers, data=_payload, timeout=60)
-        _result = _resp.json()
-        if _result.get("status") == "IN_PROGRESS":
-            _poll_url = _result.get("url")
-            _wait = 0.5
-            _start = __time.time()
-            while not _result.get("completed") and (__time.time() - _start) < 300:
-                __time.sleep(_wait)
-                _r = __requests.get(_poll_url, headers=_headers, timeout=30)
-                _result = _r.json()
-                _wait = min(_wait * 1.1, 60)
-        _total_llm_query_credits += float(_result.get("usedCredits", 0) or 0)
-        return str(_result.get("data", "Error: no data in worker response"))
-    except Exception as _e:
-        return f"Error: llm_query failed \u2014 {{_e}}"
-"""
-        self._run_sandbox(sandbox, llm_query_code)
-        logger.debug("RLM: llm_query injected into sandbox.")
+        # Inject the credential-free llm_query prelude. It is a module-level
+        # constant with no interpolation precisely so no caller value — least of
+        # all an API key — can end up inside sandbox-executed source (BUG-936).
+        self._run_sandbox(sandbox, _LLM_QUERY_PRELUDE, session=_REPL_SESSION)
+        logger.debug("RLM: credential-free llm_query prelude injected into sandbox.")
 
     # Sandbox Helpers
 
-    def _run_sandbox(self, sandbox: Any, code: str) -> Any:
-        """Execute code in the sandbox and return the raw ToolResult."""
+    def _session_id_for(self, session: str) -> str:
+        """Resolve a session name to its live session id.
+
+        Raises:
+            ValueError: If ``session`` is not a known session name.
+            ResourceError: If that session has not been started yet.
+        """
+        if session == _SETUP_SESSION:
+            session_id = self._setup_session_id
+        elif session == _REPL_SESSION:
+            session_id = self._repl_session_id
+        else:
+            raise ValueError(f"RLM: unknown sandbox session {session!r}.")
+        if not session_id:
+            raise ResourceError(f"RLM: sandbox {session!r} session has not been started.")
+        return session_id
+
+    def _run_sandbox(self, sandbox: Any, code: str, *, session: str) -> Any:
+        """Execute code in the named sandbox session and return the raw ToolResult.
+
+        ``session`` is a required keyword so that every call site has to state
+        which trust boundary it is on. Model-emitted code is always routed to
+        :data:`_REPL_SESSION`; it can never reach the setup session.
+
+        Args:
+            sandbox: Resolved sandbox Tool instance.
+            code: Python source to execute.
+            session: :data:`_SETUP_SESSION` or :data:`_REPL_SESSION`.
+
+        Returns:
+            The raw ToolResult from the sandbox.
+
+        Raises:
+            ResourceError: If the code contains a credential value, or the
+                requested session has not been started.
+        """
+        session_id = self._session_id_for(session)
+        self._assert_no_secrets(code)
         result = sandbox.run(
-            data={"code": code, "sessionId": self._session_id},
+            data={"code": code, "sessionId": session_id},
             action="run",
         )
         self._used_credits += float(getattr(result, "used_credits", 0) or 0)
         return result
 
-    def _execute_code(self, code: str) -> str:
-        """Execute a code block in the sandbox and return formatted output.
+    # Sandbox Teardown
 
-        Runs the code in the current session (preserving all previously defined
-        variables), captures stdout and stderr, and returns them as a string
-        truncated to :data:`_REPL_OUTPUT_MAX_CHARS` characters.
+    def _teardown_action(self, sandbox: Any) -> Optional[str]:
+        """Discover the sandbox's session-close action name, or ``None``.
+
+        ``Tool.run`` validates ``action`` against the tool's advertised actions,
+        so the name cannot be hard-coded. Resolved once per instance; failures
+        are non-fatal and fall back to wiping session state.
+        """
+        cached = getattr(self, "_teardown_action_name", _UNRESOLVED)
+        if cached is not _UNRESOLVED:
+            return cached
+
+        action: Optional[str] = None
+        try:
+            available = set()
+            for spec in sandbox.list_actions() or []:
+                for attr in ("name", "slug", "code"):
+                    value = getattr(spec, attr, None)
+                    if isinstance(value, str):
+                        available.add(value)
+            for candidate in _TEARDOWN_ACTION_CANDIDATES:
+                if candidate in available:
+                    action = candidate
+                    break
+        except Exception as exc:
+            logger.debug(f"RLM: could not list sandbox actions for teardown: {exc}")
+
+        self._teardown_action_name = action
+        return action
+
+    def _close_session(self, session_id: str) -> None:
+        """Close one sandbox session, best effort.
+
+        Never raises: a teardown failure must not convert a successful run into
+        a failure, nor mask an exception already in flight.
+        """
+        sandbox = self._sandbox_tool
+        if sandbox is None:
+            return
+
+        action = None
+        try:
+            action = self._teardown_action(sandbox)
+            if action:
+                sandbox.run(data={"sessionId": session_id}, action=action)
+                logger.debug(f"RLM: sandbox session closed (id={session_id}).")
+                return
+        except Exception as exc:
+            # A rejected close action must not leave the session untouched —
+            # fall through to the wipe rather than leaking the uploaded context.
+            logger.warning(f"RLM: sandbox close action {action!r} failed (id={session_id}): {exc}")
+
+        try:
+            # No usable close action — at minimum drop what the session holds
+            # (uploaded context, cached answers, download URL).
+            sandbox.run(data={"code": _SESSION_WIPE_CODE, "sessionId": session_id}, action="run")
+            if action is None:
+                logger.warning("RLM: sandbox exposes no session-close action; wiped session state instead.")
+            logger.debug(f"RLM: sandbox session state wiped (id={session_id}).")
+        except Exception as exc:
+            logger.warning(f"RLM: sandbox session teardown failed (id={session_id}): {exc}")
+
+    def close(self) -> None:
+        """Tear down any live sandbox sessions. Idempotent; never raises.
+
+        Called automatically in a ``finally`` at the end of every recursive run
+        and on ``__exit__``. Safe to call directly, and safe to call twice.
+        """
+        for attr in ("_repl_session_id", "_setup_session_id"):
+            session_id = getattr(self, attr, None)
+            if session_id:
+                self._close_session(session_id)
+            setattr(self, attr, None)
+
+    def __enter__(self) -> "RLM":
+        """Enter a context manager whose exit tears down sandbox sessions."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        """Tear down sandbox sessions on scope exit."""
+        self.close()
+
+    # Model-Emitted Code Execution
+
+    def _execute_code(self, code: str) -> str:
+        """Execute an orchestrator-emitted code block and return formatted output.
+
+        Runs in the REPL session (preserving all previously defined variables),
+        captures stdout and stderr, resolves any ``llm_query`` prompts the block
+        submitted, and returns the result truncated to
+        :data:`_REPL_OUTPUT_MAX_CHARS` characters.
+
+        Emitted code is steered by the analysed context and treated as
+        untrusted: it is hard-wired to the REPL session, screened for credential
+        values before execution, and its output is redacted on the way back.
 
         Args:
             code: Python source code to execute.
 
         Returns:
-            Formatted string combining stdout and stderr. Returns ``"No output"``
-            if both are empty.
+            Formatted string combining stdout, stderr, and any protocol notes.
+            Returns ``"No output"`` if there is nothing to report.
         """
-        result = self._run_sandbox(self._get_sandbox(), code)
+        if self._contains_secret(code):
+            # Not fatal — refusing the block and telling the orchestrator keeps
+            # the run alive while denying the exfiltration attempt.
+            logger.error("RLM: refusing to execute emitted code containing a credential (BUG-936 guard).")
+            return "[blocked] This block referenced a credential and was not executed."
+
+        result = self._run_sandbox(self._get_sandbox(), code, session=_REPL_SESSION)
         inner = result.data if isinstance(result.data, dict) else {}
-        stdout = inner.get("stdout", "")
-        stderr = inner.get("stderr", "")
+        stdout = inner.get("stdout", "") or ""
+        stderr = inner.get("stderr", "") or ""
+
+        # Whether the block submitted at all is tracked separately from what was
+        # successfully parsed: a payload the sandbox truncated mid-batch yields
+        # no prompts, and the sandbox-side pending list would keep suppressing
+        # those prompts forever if it were not cleared.
+        submitted = _LLM_REQUEST_MARKER in stdout
+        stdout, prompts = _extract_llm_requests(stdout)
+
+        notes: List[str] = []
+        if submitted:
+            answers = self._resolve_llm_queries(prompts) if prompts else {}
+            # Always injected, even when empty: this is also what clears the
+            # sandbox's pending list so unrecovered prompts resubmit next turn.
+            self._inject_llm_answers(answers)
+            if answers:
+                notes.append(
+                    f"[aiXplain] {len(answers)} llm_query answer(s) are now cached in the REPL. "
+                    f"Any llm_query call that returned {_LLM_PENDING_SENTINEL} did NOT get a real "
+                    "answer — re-run that same block now to receive the real answers."
+                )
 
         parts = []
         if stdout:
@@ -856,47 +1302,111 @@ def llm_query(prompt):
         if stderr:
             parts.append(f"[stderr]: {stderr}")
 
-        raw_output = "\n".join(parts) if parts else "No output"
-        return _truncate(raw_output)
+        # Truncate the block's own output *before* appending protocol notes:
+        # notes are the orchestrator's signal that answers are ready, and a
+        # block printing more than _REPL_OUTPUT_MAX_CHARS would otherwise push
+        # them off the end. Redact first so a secret cannot survive as a
+        # fragment split by the truncation boundary.
+        body = _truncate(self._redact("\n".join(parts))) if parts else ""
+
+        output = "\n".join(([body] if body else []) + notes)
+        return output if output else "No output"
 
     def _get_repl_variable(self, variable_name: str) -> Optional[str]:
-        """Retrieve a named variable's string value from the current sandbox session.
+        """Retrieve a named variable's string value from the REPL session.
 
-        Called when the orchestrator declares ``FINAL_VAR(variable_name)``.
+        Called when the orchestrator declares ``FINAL_VAR(variable_name)``. The
+        name is model-controlled and gets interpolated into SDK-generated code,
+        so anything that is not a plain identifier is rejected outright rather
+        than executed.
 
         Args:
             variable_name: Name of the variable to retrieve (quotes are stripped).
 
         Returns:
-            String representation of the variable, or ``None`` on error.
+            String representation of the variable, or ``None`` if the name is
+            invalid, the lookup errored, or the value still holds an unresolved
+            ``llm_query`` placeholder.
         """
         var = variable_name.strip().strip("\"'")
-        result = self._run_sandbox(self._get_sandbox(), f"print(str({var}))")
+        if not var.isidentifier():
+            logger.warning(f"RLM: FINAL_VAR({variable_name!r}) is not a valid identifier — ignored.")
+            return None
+
+        result = self._run_sandbox(self._get_sandbox(), f"print(str({var}))", session=_REPL_SESSION)
         inner = result.data if isinstance(result.data, dict) else {}
-        stdout = inner.get("stdout", "")
-        stderr = inner.get("stderr", "")
+        stdout = inner.get("stdout", "") or ""
+        stderr = inner.get("stderr", "") or ""
 
         if stderr and not stdout:
             logger.warning(f"RLM: FINAL_VAR('{var}') error: {stderr.strip()}")
             return None
-        return stdout.strip() if stdout else None
+        if not stdout:
+            return None
 
-    # Credit Tracking
+        value = self._redact(stdout.strip())
+        if _LLM_PENDING_SENTINEL in value:
+            logger.warning(f"RLM: FINAL_VAR('{var}') still holds an unresolved llm_query placeholder — rejected.")
+            return None
+        return value
 
-    def _collect_llm_query_credits(self) -> None:
-        """Retrieve accumulated ``llm_query`` worker credits from the sandbox.
+    # llm_query Resolution (SDK-side, credentialled)
 
-        The injected ``llm_query`` function tracks per-call ``usedCredits``
-        from the worker model API in a global ``_total_llm_query_credits``
-        variable inside the sandbox session. This method reads that variable
-        and adds it to ``self._used_credits``.
+    def _resolve_llm_queries(self, prompts: List[str]) -> Dict[str, str]:
+        """Answer submitted prompts with the worker model, in-process.
+
+        This is where the credential stays: the worker call is made by the SDK,
+        which already holds the key, instead of by sandbox-resident code. Runs
+        the batch concurrently, deduplicates by prompt hash, and never lets a
+        single failure kill the run — a failed prompt is answered with an error
+        marker, matching :meth:`_parallel_map`.
+
+        Args:
+            prompts: Prompts submitted by the sandbox this turn.
+
+        Returns:
+            Mapping of prompt hash → answer, keyed exactly as the sandbox
+            prelude keys ``_llm_answers``.
         """
-        try:
-            raw = self._get_repl_variable("_total_llm_query_credits")
-            if raw is not None:
-                self._used_credits += float(raw)
-        except Exception:
-            logger.debug("RLM: could not retrieve llm_query credits from sandbox.")
+        uniq: Dict[str, str] = {}
+        for prompt in prompts[:_LLM_MAX_PROMPTS_PER_BATCH]:
+            # Key on the full prompt (the sandbox hashed it untruncated); only
+            # the text forwarded to the worker is bounded.
+            uniq.setdefault(_prompt_key(prompt), prompt[:_LLM_MAX_PROMPT_CHARS])
+        if not uniq:
+            return {}
+
+        # Warm the lazy worker cache before threads start, as parallel mode does.
+        self._get_worker()
+
+        answers: Dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=min(len(uniq), _MAX_PARALLEL_WORKERS)) as ex:
+            futures = {ex.submit(self._worker_call, prompt, _LLM_QUERY_MAX_TOKENS): key for key, prompt in uniq.items()}
+            for f in as_completed(futures):
+                key = futures[f]
+                try:
+                    answers[key] = f.result()
+                except Exception as exc:
+                    logger.warning(f"RLM: llm_query failed: {exc}")
+                    answers[key] = f"Error: llm_query failed — {exc}"
+
+        logger.debug(f"RLM: resolved {len(answers)} llm_query prompt(s) SDK-side.")
+        return answers
+
+    def _inject_llm_answers(self, answers: Dict[str, str]) -> None:
+        """Push resolved answers into the REPL session as a JSON string literal.
+
+        Answer text may itself be attacker-influenced, so it is carried as the
+        ``repr()`` of a ``json.dumps`` result — a plain Python string literal
+        that cannot break out into executable code.
+
+        Also clears the sandbox's pending list, which is why it is called even
+        with an empty mapping: a prompt left pending is never re-printed, so
+        skipping the clear would strand it for the rest of the run.
+        """
+        payload = json.dumps(answers)
+        code = f"_llm_answers.update(__json.loads({payload!r}))\n_llm_query_pending.clear()"
+        self._run_sandbox(self._get_sandbox(), code, session=_REPL_SESSION)
 
     # Orchestrator
 
@@ -925,13 +1435,14 @@ def llm_query(prompt):
 
     # Parallel Mode
 
-    def _worker_call(self, prompt: str) -> str:
+    def _worker_call(self, prompt: str, max_tokens: int = _RESERVED_OUTPUT_TOKENS) -> str:
         """Call the worker model once and return its text output.
 
         Thread-safe credit accumulation so this can run inside a
-        ``ThreadPoolExecutor`` from the parallel map step.
+        ``ThreadPoolExecutor`` from the parallel map step or from
+        :meth:`_resolve_llm_queries`.
         """
-        response = self._get_worker().run(text=prompt, max_tokens=_RESERVED_OUTPUT_TOKENS)
+        response = self._get_worker().run(text=prompt, max_tokens=max_tokens)
         credits = float(getattr(response, "used_credits", 0) or 0)
         with self._credits_lock:
             self._used_credits += credits
@@ -1369,16 +1880,22 @@ def llm_query(prompt):
         start_time: float,
         effective_timeout: float,
     ) -> RLMResult:
-        """Iterative REPL-loop path: orchestrator drives a sandbox session."""
+        """Iterative REPL-loop path: orchestrator drives a sandbox session.
+
+        Setup runs inside the ``try`` so a failure while bootstrapping the
+        sandbox still reaches the ``finally`` that tears down whichever sessions
+        were started.
+        """
         iterations_used = 0
         final_answer: Optional[str] = None
         repl_logs: List[Dict] = []
         self._used_credits = 0.0
 
-        self._setup_repl(context)
-        self._messages = _build_system_messages(self._get_worker_context_window())
-
         try:
+            self._preflight()
+            self._setup_repl(context)
+            self._messages = _build_system_messages(self._get_worker_context_window())
+
             for iteration in range(self.max_iterations):
                 iterations_used = iteration + 1
 
@@ -1414,25 +1931,36 @@ def llm_query(prompt):
                 if final_result is not None:
                     answer_type, content = final_result
                     if answer_type == "FINAL":
-                        final_answer = content
+                        # An unresolved llm_query placeholder is not an answer —
+                        # send the orchestrator back to re-run its block.
+                        if _LLM_PENDING_SENTINEL in content:
+                            logger.warning(f"RLM '{name}': FINAL(...) contained a pending placeholder — rejected.")
+                            self._messages.append({"role": "user", "content": _PENDING_REJECTED_PROMPT})
+                            continue
+                        final_answer = self._redact(content)
                         break
                     elif answer_type == "FINAL_VAR":
                         retrieved = self._get_repl_variable(content)
                         if retrieved is not None:
                             final_answer = retrieved
                             break
-                        logger.warning(f"RLM '{name}': FINAL_VAR('{content}') not found in sandbox — continuing.")
+                        logger.warning(f"RLM '{name}': FINAL_VAR('{content}') unusable — continuing.")
 
             # Force a final answer if loop exhausted or timed out without one
             if final_answer is None:
                 logger.info(f"RLM '{name}': requesting forced final answer after {iterations_used} iteration(s).")
                 self._messages.append(_next_action_message(query, iterations_used, force_final=True))
-                final_answer = self._orchestrator_completion(self._messages)
+                final_answer = self._redact(self._orchestrator_completion(self._messages))
+                if _LLM_PENDING_SENTINEL in final_answer:
+                    # Last resort: the placeholder must never surface as content.
+                    logger.warning(f"RLM '{name}': forced final answer contained pending placeholder(s) — stripped.")
+                    final_answer = final_answer.replace(_LLM_PENDING_SENTINEL, "[unanswered]")
 
         except Exception as exc:
-            error_msg = f"RLM run error: {exc}"
+            # Redacted before it is logged or returned: an exception raised deep
+            # in the client stack can quote a request that carried the key.
+            error_msg = self._redact(f"RLM run error: {exc}")
             logger.error(error_msg)
-            self._collect_llm_query_credits()
             result = RLMResult(
                 status="FAILED",
                 completed=True,
@@ -1443,8 +1971,10 @@ def llm_query(prompt):
             result.used_credits = self._used_credits
             result.repl_logs = repl_logs
             return result
+        finally:
+            # Unconditional: success, exception, and timeout paths all land here.
+            self.close()
 
-        self._collect_llm_query_credits()
         run_time = time.time() - start_time
         logger.info(f"RLM '{name}': done in {iterations_used} iteration(s), {run_time:.1f}s.")
 

--- a/tests/unit/rlm_test.py
+++ b/tests/unit/rlm_test.py
@@ -1,12 +1,33 @@
-"""Unit tests for RLM context resolution, sandbox setup, credit tracking, and context window."""
+"""Unit tests for RLM context resolution, sandbox setup, credit tracking, and context window.
 
+The v2 suite additionally covers BUG-936: no credential may reach the sandbox,
+model-emitted code must run in its own session, and sessions must be torn down.
+"""
+
+import ast
+import contextlib
+import inspect
+import io
 import json
+import threading
+import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import aixplain.v2.rlm as rlm_v2
 from aixplain.v1.modules.model.rlm import RLM as RLMV1
-from aixplain.v2.rlm import RLM as RLMV2, RLMResult
+from aixplain.v2.rlm import (
+    RLM as RLMV2,
+    RLMResult,
+    _LLM_PENDING_SENTINEL,
+    _LLM_REQUEST_MARKER,
+    _REPL_SESSION,
+    _SETUP_SESSION,
+    _extract_llm_requests,
+    _prompt_key,
+)
 
 
 # Parametrize over both implementations
@@ -83,22 +104,25 @@ def _make_v1_rlm() -> RLMV1:
     return rlm
 
 
-def _make_v2_rlm() -> RLMV2:
+def _make_v2_rlm(api_key: str = "test-key", max_iterations: int = 10) -> RLMV2:
     """Minimal v2 RLM with stubbed context client."""
     rlm = RLMV2.__new__(RLMV2)
     rlm.orchestrator_id = "orch-id"
     rlm.worker_id = "worker-id"
-    rlm.max_iterations = 10
+    rlm.max_iterations = max_iterations
     rlm.timeout = 600.0
-    rlm._session_id = None
+    rlm._setup_session_id = None
+    rlm._repl_session_id = None
     rlm._sandbox_tool = None
     rlm._orchestrator = None
     rlm._worker = None
     rlm._messages = []
     rlm._used_credits = 0.0
+    rlm._credits_lock = threading.Lock()
+    rlm._teardown_action_name = rlm_v2._UNRESOLVED
     client = MagicMock()
     client.backend_url = "https://platform-api.aixplain.com"
-    client.api_key = "test-key"
+    client.api_key = api_key
     client.model_url = "https://models.aixplain.com/api/v2/execute"
     rlm.context = client
     return rlm
@@ -274,9 +298,9 @@ class TestV2CreditTracking:
         rlm._used_credits = 0.0
         sandbox = MagicMock()
         sandbox.run.return_value = _sandbox_result(used_credits=0.03)
-        rlm._session_id = "test-session"
+        rlm._repl_session_id = "test-session"
 
-        rlm._run_sandbox(sandbox, "print('hi')")
+        rlm._run_sandbox(sandbox, "print('hi')", session=_REPL_SESSION)
 
         assert rlm._used_credits == pytest.approx(0.03)
 
@@ -286,23 +310,32 @@ class TestV2CreditTracking:
         sandbox = MagicMock()
         sandbox.run.return_value = _sandbox_result(stdout="done", used_credits=0.04)
         rlm._sandbox_tool = sandbox
-        rlm._session_id = "test-session"
+        rlm._repl_session_id = "test-session"
 
         output = rlm._execute_code("print('done')")
 
         assert "done" in output
         assert rlm._used_credits == pytest.approx(0.04)
 
-    def test_collect_llm_query_credits(self):
+    def test_llm_query_credits_accumulated_via_worker_call(self):
+        """Worker credits now come from SDK-side calls, not a sandbox variable.
+
+        Replaces the old ``_collect_llm_query_credits`` test: the sandbox no
+        longer tracks (or can tamper with) worker spend.
+        """
         rlm = _make_v2_rlm()
         rlm._used_credits = 2.0
-        sandbox = MagicMock()
-        sandbox.run.return_value = _sandbox_result(stdout="0.50", used_credits=0.0)
-        rlm._sandbox_tool = sandbox
-        rlm._session_id = "test-session"
+        assert not hasattr(rlm, "_collect_llm_query_credits")
 
-        rlm._collect_llm_query_credits()
+        worker = MagicMock()
+        worker.attributes = {}
+        resp = MagicMock(completed=True, status="SUCCESS", data="answer", used_credits=0.25)
+        worker.run.return_value = resp
+        rlm._worker = worker
 
+        answers = rlm._resolve_llm_queries(["a", "b"])
+
+        assert len(answers) == 2
         assert rlm._used_credits == pytest.approx(2.50)
 
     def test_used_credits_field_on_rlm_result(self):
@@ -340,8 +373,9 @@ class TestLlmQueryCodeCreditsTracking:
         assert "global _total_llm_query_credits" in llm_query_code
         assert "usedCredits" in llm_query_code
 
-    def test_v2_llm_query_code_accumulates_credits(self):
-        rlm = _make_v2_rlm()
+    def test_v2_llm_query_prelude_is_credential_free(self):
+        """v2's prelude makes no network call and tracks no credits (BUG-936)."""
+        rlm = _make_v2_rlm(api_key="SENTINEL-KEY-DO-NOT-LEAK")
         sandbox_mock = MagicMock()
         captured = []
 
@@ -358,10 +392,13 @@ class TestLlmQueryCodeCreditsTracking:
             mock_uploader.return_value = uploader_instance
             rlm._setup_repl("raw text context")
 
-        llm_query_code = captured[-1]
-        assert "_total_llm_query_credits" in llm_query_code
-        assert "global _total_llm_query_credits" in llm_query_code
-        assert "usedCredits" in llm_query_code
+        prelude = captured[-1]
+        assert "def llm_query(" in prelude
+        assert "SENTINEL-KEY-DO-NOT-LEAK" not in prelude
+        assert "x-api-key" not in prelude
+        assert "requests" not in prelude
+        assert "_total_llm_query_credits" not in prelude
+        assert _LLM_REQUEST_MARKER in prelude
 
 
 # Worker context window
@@ -439,3 +476,746 @@ class TestV2WorkerContextWindow:
         mock_worker.attributes = {"max_context_length": 32000}
         rlm._worker = mock_worker
         assert rlm._get_worker_context_window() == "32K tokens"
+
+
+# BUG-936 — v2 sandbox credential isolation, session split, and teardown
+
+SENTINEL_KEY = "SENTINEL-KEY-DO-NOT-LEAK-8f3c1a"
+FAKE_CONTEXT = "alpha beta gamma delta"
+
+
+class _FakeSandbox:
+    """Sandbox double that really ``exec()``s payloads, one namespace per session.
+
+    Executing for real is the point: a ``co_consts`` probe runs against the
+    actual generated prelude, and separate namespaces mean the session split is
+    exercised rather than merely asserted on call arguments.
+
+    The only faked step is the context bootstrap, which would otherwise make a
+    live HTTP request — ``context`` is assigned ``context_value`` instead.
+    """
+
+    def __init__(self, context_value: str = FAKE_CONTEXT, close_action: str = "close_session"):
+        self.context_value = context_value
+        self.close_action = close_action
+        self.namespaces: dict = {}
+        self.calls: list = []  # {"session", "action", "code"}
+        self.closed: list = []
+        self.close_raises = False
+
+    def list_actions(self):
+        actions = [SimpleNamespace(name="run")]
+        if self.close_action:
+            actions.append(SimpleNamespace(name=self.close_action))
+        return actions
+
+    @property
+    def codes(self) -> list:
+        return [c["code"] for c in self.calls if c["code"] is not None]
+
+    def codes_for(self, session_id) -> list:
+        return [c["code"] for c in self.calls if c["session"] == session_id and c["code"] is not None]
+
+    def run(self, data=None, action="run"):
+        data = data or {}
+        session_id = data.get("sessionId")
+        code = data.get("code")
+        self.calls.append({"session": session_id, "action": action, "code": code})
+
+        if action != "run":
+            if self.close_raises:
+                raise RuntimeError("close failed")
+            self.closed.append(session_id)
+            self.namespaces.pop(session_id, None)
+            return MagicMock(used_credits=0.0, data={})
+
+        ns = self.namespaces.setdefault(session_id, {})
+        buf = io.StringIO()
+        err = ""
+        if "__requests.get(_url" in (code or ""):
+            # Context bootstrap — don't hit the network.
+            ns["context"] = self.context_value
+        else:
+            try:
+                with contextlib.redirect_stdout(buf):
+                    exec(code, ns, ns)
+            except Exception as exc:  # noqa: BLE001 - mirrors the real sandbox
+                err = f"{type(exc).__name__}: {exc}"
+        return MagicMock(used_credits=0.0, data={"stdout": buf.getvalue(), "stderr": err})
+
+
+def _worker_response(data="worker answer", used_credits=0.0):
+    return MagicMock(completed=True, status="SUCCESS", data=data, used_credits=used_credits)
+
+
+def _drive_recursive(rlm, sandbox, responses, query="what is in here?", max_iterations=None):
+    """Run ``_run_recursive`` against a fake sandbox and scripted orchestrator turns.
+
+    ``responses`` is a list of orchestrator reply strings (or exceptions to
+    raise). Anything past the end repeats the last entry.
+    """
+    rlm._sandbox_tool = sandbox
+    if max_iterations is not None:
+        rlm.max_iterations = max_iterations
+
+    worker = MagicMock()
+    worker.attributes = {"max_context_length": "128000"}
+    worker.run.return_value = _worker_response()
+    rlm._worker = worker
+
+    turns = list(responses)
+
+    def _completion(messages):
+        reply = turns.pop(0) if len(turns) > 1 else turns[0]
+        if isinstance(reply, BaseException):
+            raise reply
+        return reply
+
+    with patch.object(type(rlm), "_orchestrator_completion", side_effect=_completion, autospec=False):
+        return rlm._run_recursive(FAKE_CONTEXT, query, "test", time.time(), 600.0)
+
+
+class TestNoCredentialInSandbox:
+    """AC 1 — the key must not appear in anything sent to the sandbox."""
+
+    def test_no_api_key_in_any_sandbox_payload(self):
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(rlm, sandbox, ["FINAL(all done)"])
+
+        assert result.status == "SUCCESS"
+        assert sandbox.calls, "expected the run to touch the sandbox"
+        for code in sandbox.codes:
+            assert SENTINEL_KEY not in code
+            assert "x-api-key" not in code
+
+    def test_module_source_never_interpolates_a_key_into_generated_code(self):
+        """Static tripwire: fails if a credential is reintroduced into generated code."""
+        tree = ast.parse(inspect.getsource(rlm_v2))
+        offenders = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.JoinedStr):
+                for value in node.values:
+                    if isinstance(value, ast.FormattedValue):
+                        expr = ast.unparse(value.value)
+                        if "api_key" in expr.lower():
+                            offenders.append(expr)
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if "x-api-key" in node.value:
+                    offenders.append(node.value[:120])
+        assert offenders == [], f"credential reached generated code: {offenders}"
+
+    def test_run_sandbox_refuses_sdk_code_containing_a_secret(self):
+        """AC 5 — the tripwire raises rather than transmitting a credential."""
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+        rlm._repl_session_id = "repl-1"
+
+        with pytest.raises(rlm_v2.ResourceError, match="BUG-936"):
+            rlm._run_sandbox(sandbox, f'headers = {{"x-api-key": "{SENTINEL_KEY}"}}', session=_REPL_SESSION)
+
+        assert sandbox.calls == []
+
+    def test_emitted_code_containing_secret_is_blocked_not_fatal(self):
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+
+        output = rlm._execute_code(f"print({SENTINEL_KEY!r})")
+
+        assert "[blocked]" in output
+        assert SENTINEL_KEY not in output
+        assert sandbox.calls == []
+
+    def test_secret_values_ignores_non_string_and_short_values(self):
+        rlm = _make_v2_rlm(api_key="short")
+        with patch.dict("os.environ", {}, clear=True):
+            assert rlm._secret_values() == ()
+            assert rlm._contains_secret("short") is False
+
+        rlm.context.api_key = object()
+        with patch.dict("os.environ", {}, clear=True):
+            assert rlm._secret_values() == ()
+
+    def test_env_sourced_key_is_also_guarded(self):
+        rlm = _make_v2_rlm(api_key="test-key-that-is-long")
+        with patch.dict("os.environ", {"TEAM_API_KEY": SENTINEL_KEY}, clear=True):
+            assert SENTINEL_KEY in rlm._secret_values()
+            assert rlm._contains_secret(f"k = {SENTINEL_KEY}") is True
+
+
+class TestSandboxCannotRecoverKey:
+    """AC 2 — probing from inside the sandbox yields nothing."""
+
+    def _probe(self, probe_code):
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(
+                rlm,
+                sandbox,
+                [f"Let me look.\n```repl\n{probe_code}\n```", "FINAL(nothing found)"],
+            )
+        return rlm, sandbox, result
+
+    def test_co_consts_probe_cannot_recover_key(self):
+        rlm, sandbox, result = self._probe(
+            "import json\nprint(llm_query.__code__.co_consts)\nprint(sorted(llm_query.__globals__))"
+        )
+
+        assert result.status == "SUCCESS"
+        assert result.repl_logs, "probe block should have executed"
+        probe_output = result.repl_logs[0]["output"]
+        # The probe really ran against the real prelude: its only constants are
+        # the docstring and the pending placeholder.
+        assert _LLM_PENDING_SENTINEL in probe_output
+        assert "llm_query" in probe_output
+        assert SENTINEL_KEY not in probe_output
+        assert "x-api-key" not in probe_output
+        assert "models.aixplain.com" not in probe_output
+        assert SENTINEL_KEY not in json.dumps(result.repl_logs)
+        assert SENTINEL_KEY not in json.dumps(rlm._messages)
+        assert SENTINEL_KEY not in str(result.data)
+
+    def test_getsource_and_environ_probe_cannot_recover_key(self):
+        rlm, sandbox, result = self._probe(
+            "import inspect, os\n"
+            "print(inspect.getsource(llm_query))\n"
+            "print({k: v for k, v in os.environ.items() if 'KEY' in k.upper()})"
+        )
+
+        assert SENTINEL_KEY not in json.dumps(result.repl_logs)
+        assert SENTINEL_KEY not in json.dumps(rlm._messages)
+
+    def test_secret_echoed_by_emitted_code_is_redacted(self):
+        """Reverse channel: a printed credential must not enter the transcript."""
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        sandbox.namespaces["repl-1"] = {"leaked": SENTINEL_KEY}
+
+        output = rlm._execute_code("print(leaked)")
+
+        assert SENTINEL_KEY not in output
+        assert "***REDACTED***" in output
+
+    def test_failure_message_is_redacted(self):
+        """A client exception quoting the key must not land in the result."""
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(
+                rlm,
+                sandbox,
+                [RuntimeError(f"POST failed, headers={{'x-api-key': '{SENTINEL_KEY}'}}")],
+            )
+
+        assert result.status == "FAILED"
+        assert SENTINEL_KEY not in result.error_message
+        assert "***REDACTED***" in result.error_message
+
+
+class TestSessionSplit:
+    """AC 3 — model-emitted code never shares a session with SDK setup code."""
+
+    def _run(self):
+        rlm = _make_v2_rlm(api_key=SENTINEL_KEY)
+        sandbox = _FakeSandbox()
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(
+                rlm,
+                sandbox,
+                ["```repl\nprint(len(context))\n```", "FINAL(done)"],
+            )
+        return rlm, sandbox, result
+
+    def test_setup_and_repl_sessions_are_distinct(self):
+        rlm, sandbox, result = self._run()
+        sessions = {c["session"] for c in sandbox.calls}
+
+        assert len(sessions) == 2
+        assert None not in sessions
+
+    def test_emitted_code_runs_only_in_the_repl_session(self):
+        rlm, sandbox, result = self._run()
+
+        setup_calls = [c for c in sandbox.calls if c["code"] == rlm_v2._PREFLIGHT_CODE]
+        assert setup_calls, "preflight should have run"
+        setup_session = setup_calls[0]["session"]
+
+        emitted = [c for c in sandbox.calls if c["code"] and "print(len(context))" in c["code"]]
+        assert emitted, "emitted block should have run"
+        for call in emitted:
+            assert call["session"] != setup_session
+
+        # The prelude and the context bootstrap share the REPL session by design.
+        prelude_calls = [c for c in sandbox.calls if c["code"] and "def llm_query(" in c["code"]]
+        assert prelude_calls
+        assert prelude_calls[0]["session"] == emitted[0]["session"]
+
+    def test_setup_session_state_is_unreachable_from_repl_session(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._setup_session_id = "setup-1"
+        rlm._repl_session_id = "repl-1"
+
+        rlm._run_sandbox(sandbox, "setup_only_secret = 'xyz'", session=_SETUP_SESSION)
+        output = rlm._execute_code("print(setup_only_secret)")
+
+        assert "NameError" in output
+        assert "xyz" not in output
+
+    def test_run_sandbox_requires_an_explicit_session(self):
+        rlm = _make_v2_rlm()
+        with pytest.raises(TypeError):
+            rlm._run_sandbox(_FakeSandbox(), "pass")
+
+    def test_run_sandbox_rejects_unstarted_session(self):
+        rlm = _make_v2_rlm()
+        with pytest.raises(rlm_v2.ResourceError, match="has not been started"):
+            rlm._run_sandbox(_FakeSandbox(), "pass", session=_REPL_SESSION)
+
+    def test_run_sandbox_rejects_unknown_session_name(self):
+        rlm = _make_v2_rlm()
+        with pytest.raises(ValueError, match="unknown sandbox session"):
+            rlm._run_sandbox(_FakeSandbox(), "pass", session="nope")
+
+
+class TestSessionTeardown:
+    """AC 4 — sessions are closed on every exit path."""
+
+    def _run(self, responses, sandbox=None):
+        rlm = _make_v2_rlm()
+        sandbox = sandbox or _FakeSandbox()
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(rlm, sandbox, responses)
+        return rlm, sandbox, result
+
+    def test_sessions_closed_on_success(self):
+        rlm, sandbox, result = self._run(["FINAL(done)"])
+
+        assert result.status == "SUCCESS"
+        assert len(sandbox.closed) == 2
+        assert all(c["action"] == "close_session" for c in sandbox.calls if c["action"] != "run")
+        assert rlm._setup_session_id is None
+        assert rlm._repl_session_id is None
+
+    def test_sessions_closed_on_exception(self):
+        rlm, sandbox, result = self._run([RuntimeError("orchestrator exploded")])
+
+        assert result.status == "FAILED"
+        assert "orchestrator exploded" in result.error_message
+        assert len(sandbox.closed) == 2
+
+    def test_session_closed_when_setup_fails(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        worker = MagicMock()
+        worker.attributes = {}
+        rlm._worker = worker
+
+        with patch("aixplain.v2.rlm.FileUploader", side_effect=RuntimeError("upload down")):
+            result = rlm._run_recursive(FAKE_CONTEXT, "q", "test", time.time(), 600.0)
+
+        assert result.status == "FAILED"
+        assert "upload down" in result.error_message
+        # Setup blew up between starting the sessions and loading the context;
+        # every session that had been started is still torn down.
+        assert len(sandbox.closed) == 2
+        assert rlm._setup_session_id is None
+        assert rlm._repl_session_id is None
+
+    def test_teardown_failure_does_not_mask_result(self):
+        sandbox = _FakeSandbox()
+        sandbox.close_raises = True
+        rlm, sandbox, result = self._run(["FINAL(done)"], sandbox=sandbox)
+
+        assert result.status == "SUCCESS"
+        assert result.data == "done"
+        assert sandbox.closed == []
+
+    def test_failed_close_action_still_wipes_the_session(self):
+        """A rejected close action must not leave the uploaded context behind."""
+        sandbox = _FakeSandbox()
+        sandbox.close_raises = True
+        rlm, sandbox, result = self._run(["FINAL(done)"], sandbox=sandbox)
+
+        wipes = [c for c in sandbox.calls if c["code"] and "_aix_gc.collect()" in c["code"]]
+        assert len(wipes) == 2
+        assert {c["session"] for c in wipes} == set(sandbox.namespaces)
+        for session in sandbox.namespaces.values():
+            assert "context" not in session
+
+    def test_teardown_falls_back_to_wipe_without_a_close_action(self):
+        sandbox = _FakeSandbox(close_action="")
+        rlm, sandbox, result = self._run(["FINAL(done)"], sandbox=sandbox)
+
+        assert result.status == "SUCCESS"
+        wipes = [c for c in sandbox.calls if c["code"] and "_aix_gc.collect()" in c["code"]]
+        assert len(wipes) == 2
+
+    def test_close_is_idempotent_and_safe_without_a_sandbox(self):
+        rlm = _make_v2_rlm()
+        rlm.close()  # no sandbox resolved at all
+
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        rlm.close()
+        rlm.close()
+
+        assert sandbox.closed == ["repl-1"]
+
+    def test_context_manager_closes_sessions(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        with rlm as ctx:
+            assert ctx is rlm
+            rlm._repl_session_id = "repl-1"
+
+        assert sandbox.closed == ["repl-1"]
+
+
+class TestLlmQueryProtocol:
+    """The SDK-mediated request/answer protocol replacing in-sandbox HTTP."""
+
+    def test_extract_llm_requests_strips_markers_and_keeps_output(self):
+        stdout = f"hello\n{_LLM_REQUEST_MARKER}{json.dumps(['a', 'b'])}\nworld"
+        clean, prompts = _extract_llm_requests(stdout)
+
+        assert prompts == ["a", "b"]
+        assert _LLM_REQUEST_MARKER not in clean
+        assert clean == "hello\nworld"
+
+    def test_extract_llm_requests_ignores_malformed_payloads(self):
+        clean, prompts = _extract_llm_requests(f"x\n{_LLM_REQUEST_MARKER}not json\ny")
+
+        assert prompts == []
+        assert clean == "x\ny"
+
+    def test_extract_llm_requests_keeps_same_line_prefix(self):
+        clean, prompts = _extract_llm_requests(f"tail{_LLM_REQUEST_MARKER}{json.dumps(['p'])}")
+
+        assert prompts == ["p"]
+        assert clean == "tail"
+
+    def test_pending_then_resolved_across_two_turns(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        sandbox.namespaces["repl-1"] = {}
+        rlm._run_sandbox(sandbox, rlm_v2._LLM_QUERY_PRELUDE, session=_REPL_SESSION)
+
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response("REAL ANSWER")
+        rlm._worker = worker
+
+        block = "a = llm_query('summarize chunk 1')\nprint(a)"
+
+        first = rlm._execute_code(block)
+        assert _LLM_PENDING_SENTINEL in first
+        assert "1 llm_query answer(s) are now cached" in first
+        assert worker.run.call_count == 1
+        assert _LLM_REQUEST_MARKER not in first
+
+        second = rlm._execute_code(block)
+        assert "REAL ANSWER" in second
+        assert _LLM_PENDING_SENTINEL not in second
+        # Answer was cached — no second worker call.
+        assert worker.run.call_count == 1
+
+    def test_batch_is_deduplicated_by_prompt_hash(self):
+        rlm = _make_v2_rlm()
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response()
+        rlm._worker = worker
+
+        answers = rlm._resolve_llm_queries(["a", "b", "a", "c", "b"])
+
+        assert len(answers) == 3
+        assert worker.run.call_count == 3
+        assert set(answers) == {_prompt_key(p) for p in ("a", "b", "c")}
+
+    def test_resolve_keys_on_full_prompt_but_truncates_worker_input(self):
+        rlm = _make_v2_rlm()
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response()
+        rlm._worker = worker
+        long_prompt = "x" * (rlm_v2._LLM_MAX_PROMPT_CHARS + 500)
+
+        answers = rlm._resolve_llm_queries([long_prompt])
+
+        assert list(answers) == [_prompt_key(long_prompt)]
+        sent = worker.run.call_args.kwargs["text"]
+        assert len(sent) == rlm_v2._LLM_MAX_PROMPT_CHARS
+
+    def test_worker_output_budget_matches_the_old_in_sandbox_call(self):
+        rlm = _make_v2_rlm()
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response()
+        rlm._worker = worker
+
+        rlm._resolve_llm_queries(["a"])
+
+        assert worker.run.call_args.kwargs["max_tokens"] == 8192
+
+    def test_worker_failure_becomes_an_error_answer_not_a_crash(self):
+        rlm = _make_v2_rlm()
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.side_effect = RuntimeError("worker down")
+        rlm._worker = worker
+
+        answers = rlm._resolve_llm_queries(["a"])
+
+        assert "Error: llm_query failed" in answers[_prompt_key("a")]
+
+    def test_answers_with_quotes_and_backslashes_round_trip_safely(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        rlm._run_sandbox(sandbox, rlm_v2._LLM_QUERY_PRELUDE, session=_REPL_SESSION)
+
+        nasty = "he said \"\"\"hi\"\"\"\\n');import os;os.system('x')\n\ttab"
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response(nasty)
+        rlm._worker = worker
+
+        block = "print(repr(llm_query('q')))"
+        rlm._execute_code(block)
+        second = rlm._execute_code(block)
+
+        assert repr(nasty) in second
+        ns = sandbox.namespaces["repl-1"]
+        assert ns["_llm_answers"][_prompt_key("q")] == nasty
+        assert "os" not in ns  # the injected payload never executed
+
+    def test_request_marker_never_reaches_the_transcript(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(
+                rlm,
+                sandbox,
+                ["```repl\nprint(llm_query('what is this?'))\n```", "FINAL(done)"],
+            )
+
+        assert result.status == "SUCCESS"
+        assert _LLM_REQUEST_MARKER not in json.dumps(result.repl_logs)
+        assert _LLM_REQUEST_MARKER not in json.dumps(rlm._messages)
+
+    def test_pending_prompts_resubmit_after_answers_are_injected(self):
+        """Pending state clears on injection so unanswered prompts can retry."""
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        rlm._run_sandbox(sandbox, rlm_v2._LLM_QUERY_PRELUDE, session=_REPL_SESSION)
+
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response()
+        rlm._worker = worker
+
+        rlm._execute_code("llm_query('p1')")
+        assert sandbox.namespaces["repl-1"]["_llm_query_pending"] == []
+
+    def test_truncated_request_payload_does_not_strand_the_prompt(self):
+        """A batch line cut mid-JSON must not suppress the prompt forever.
+
+        The sandbox only prints a prompt while it is not already pending, so
+        pending state has to be cleared even when nothing could be parsed —
+        otherwise ``llm_query`` returns PENDING for the rest of the run.
+        """
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        rlm._run_sandbox(sandbox, rlm_v2._LLM_QUERY_PRELUDE, session=_REPL_SESSION)
+
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response("REAL ANSWER")
+        rlm._worker = worker
+
+        real_run = sandbox.run
+        corrupt_next = {"on": True}
+
+        def truncating_run(data=None, action="run"):
+            result = real_run(data=data, action=action)
+            inner = result.data if isinstance(result.data, dict) else {}
+            if corrupt_next["on"] and _LLM_REQUEST_MARKER in inner.get("stdout", ""):
+                corrupt_next["on"] = False
+                # Cut the batch line mid-JSON, as an output cap would.
+                lines = [ln[:-4] if _LLM_REQUEST_MARKER in ln else ln for ln in inner["stdout"].split("\n")]
+                result.data = {**inner, "stdout": "\n".join(lines)}
+            return result
+
+        sandbox.run = truncating_run
+        block = "print(llm_query('summarize'))"
+
+        first = rlm._execute_code(block)
+        assert _LLM_PENDING_SENTINEL in first
+        assert worker.run.call_count == 0  # nothing was recoverable
+        assert sandbox.namespaces["repl-1"]["_llm_query_pending"] == []
+
+        rlm._execute_code(block)  # same block re-runs and resubmits
+        assert worker.run.call_count == 1
+        assert "REAL ANSWER" in rlm._execute_code(block)
+
+    def test_answer_ready_note_survives_a_very_long_block_output(self):
+        """The 'answers are cached' note must not be truncated away.
+
+        Long REPL output is exactly the case RLM exists for, and the note is
+        the orchestrator's signal that re-running the block will pay off.
+        """
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        rlm._run_sandbox(sandbox, rlm_v2._LLM_QUERY_PRELUDE, session=_REPL_SESSION)
+
+        worker = MagicMock()
+        worker.attributes = {}
+        worker.run.return_value = _worker_response()
+        rlm._worker = worker
+
+        output = rlm._execute_code(f"print('x' * {rlm_v2._REPL_OUTPUT_MAX_CHARS + 5000})\nllm_query('q')")
+
+        assert "truncated" in output
+        assert "1 llm_query answer(s) are now cached" in output
+
+
+class TestContextBootstrap:
+    """The context download link is a bearer capability — emitted code must not read it."""
+
+    @staticmethod
+    def _fake_response(body=b"raw text context", content_type="text/plain"):
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        resp.headers = {"Content-Type": content_type}
+        resp.iter_content.return_value = [body]
+        return resp
+
+    def test_upload_path_unbinds_the_download_url(self, tmp_path, monkeypatch):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt?sig=SECRETSIG"
+            rlm._setup_repl("raw text context")
+
+        code = next(c for c in sandbox.codes if "SECRETSIG" in c)
+        monkeypatch.chdir(tmp_path)
+        ns: dict = {}
+        with patch("requests.get", return_value=self._fake_response()):
+            exec(code, ns, ns)
+
+        assert ns["context"] == "raw text context"
+        assert "_url" not in ns
+        assert "_r" not in ns
+        assert not any("SECRETSIG" in str(v) for v in ns.values())
+
+    def test_url_fast_path_unbinds_the_source_url(self, tmp_path, monkeypatch):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+
+        rlm._setup_repl("https://example.com/big.txt?token=SECRETTOKEN")
+
+        code = next(c for c in sandbox.codes if "SECRETTOKEN" in c)
+        monkeypatch.chdir(tmp_path)
+        ns: dict = {}
+        with patch("requests.get", return_value=self._fake_response(b"streamed body")):
+            exec(code, ns, ns)
+
+        assert ns["context"] == "streamed body"
+        assert "_url" not in ns
+        assert "_url_path" not in ns
+        assert "_r" not in ns
+        assert not any("SECRETTOKEN" in str(v) for v in ns.values())
+
+
+class TestFinalAnswerHardening:
+    """FINAL_VAR validation and pending-placeholder rejection."""
+
+    def test_final_var_rejects_non_identifier(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+
+        assert rlm._get_repl_variable("__import__('os').system('x')") is None
+        assert sandbox.calls == []
+
+    def test_final_var_accepts_plain_identifier(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        sandbox.namespaces["repl-1"] = {"buf": "the answer"}
+
+        assert rlm._get_repl_variable('"buf"') == "the answer"
+
+    def test_final_var_rejects_pending_sentinel(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        rlm._sandbox_tool = sandbox
+        rlm._repl_session_id = "repl-1"
+        sandbox.namespaces["repl-1"] = {"buf": f"partial {_LLM_PENDING_SENTINEL}"}
+
+        assert rlm._get_repl_variable("buf") is None
+
+    def test_final_with_pending_sentinel_is_rejected_and_run_continues(self):
+        rlm = _make_v2_rlm()
+        sandbox = _FakeSandbox()
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(
+                rlm,
+                sandbox,
+                [f"FINAL(the answer is {_LLM_PENDING_SENTINEL})", "FINAL(the real answer)"],
+            )
+
+        assert result.status == "SUCCESS"
+        assert result.data == "the real answer"
+        assert _LLM_PENDING_SENTINEL not in result.data
+
+    def test_forced_final_strips_pending_sentinel(self):
+        rlm = _make_v2_rlm(max_iterations=1)
+        sandbox = _FakeSandbox()
+        with patch("aixplain.v2.rlm.FileUploader") as mock_uploader:
+            mock_uploader.return_value.upload.return_value = "https://storage.example.com/ctx.txt"
+            result = _drive_recursive(
+                rlm,
+                sandbox,
+                [f"still thinking {_LLM_PENDING_SENTINEL}"],
+                max_iterations=1,
+            )
+
+        assert result.status == "SUCCESS"
+        assert _LLM_PENDING_SENTINEL not in result.data
+        assert "[unanswered]" in result.data


### PR DESCRIPTION
## Problem (SEV1)

`RLM`'s recursive mode injected an `llm_query` helper into the code-execution sandbox with the caller's **account-level `TEAM_API_KEY` interpolated straight into the generated source**:

```python
_headers = {"x-api-key": "<TEAM_API_KEY>", "Content-Type": "application/json"}
```

The sandbox is a third-party execution service with outbound network access, and the code running inside it is written by an orchestrator model that is steered by the analysed context. Any prompt injection in that context could recover the key — `llm_query.__code__.co_consts`, `inspect.getsource`, etc. — and POST it anywhere. The account key grants full platform access, so this is credential compromise, not just data leakage.

Two related gaps: the sandbox session was never torn down (uploaded context and state outlived the run), and SDK-generated setup code shared one session with model-emitted code.

## Approach

Rather than *hide* the key inside the sandbox, **remove it**. The worker call moves SDK-side, where the credential already lives.

### 1. Credential-free `llm_query`

The prelude is now a module-level constant with **no interpolation at all** — no caller value, least of all a key, can reach sandbox-executed source. It submits prompts on stdout behind a marker; the SDK strips them out of the output, answers them in-process (concurrently, deduplicated by prompt hash), and pushes answers back as a plain JSON string literal.

Because answers are fetched *between* REPL turns, a batch resolves over two turns:

| Turn | Behaviour |
|---|---|
| A | `llm_query(p)` submits `p`, returns a `PENDING` placeholder |
| B | Re-run the **same block** — every prompt returns its real answer, batch answered in parallel |

The system prompt and REPL example teach this shape explicitly, and placeholders are barred from every exit: `FINAL(...)` is rejected with a retry prompt, `FINAL_VAR(...)` returns `None`, and the forced final answer strips them.

- `max_iterations` default **10 → 12** to absorb the extra submit turn.
- Credit tracking moves into `_worker_call` — worker spend is now counted SDK-side instead of read back from a sandbox global (which also removes a trust dependency on a sandbox-resident counter).

### 2. Session isolation

Every run now gets two sessions with fresh UUIDs:

- **`setup`** — SDK-generated code only. Orchestrator-emitted code can never reach it, making it the enforced home for any future bootstrap step that must handle a credential.
- **`repl`** — the context, the prelude, and every model-emitted block.

`_run_sandbox` takes a **required keyword-only `session`**, so every call site has to state which side of the trust boundary it is on; emitted code is hard-wired to `repl`. A cheap preflight probe keeps the split exercised rather than merely declared, and turns a dead sandbox into an early, clearly-attributed failure.

### 3. Teardown

Both sessions are closed in a `finally` that covers the success, exception, and timeout paths. The close action name is discovered at runtime (`Tool.run` validates `action` against advertised actions, so it can't be hard-coded) and falls back to wiping session globals when the tool exposes none — a rejected close action still wipes rather than leaking the uploaded context. `close()` is idempotent and never raises, so a teardown failure can't turn a good run bad or mask an in-flight exception. `RLM` is also usable as a context manager.

### 4. Defence in depth

- **Tripwire** — SDK-generated code containing a credential raises `ResourceError` (a BUG-936 regression guard); emitted code containing one is refused without killing the run.
- **Redaction** — sandbox stdout, `FINAL_VAR` values, final answers, and error messages are scrubbed of credential values. Covers the resolved client key *and* `TEAM_API_KEY` / `AIXPLAIN_API_KEY` from the environment, so the tripwire still fires if a key arrives by a path this class doesn't own. Redaction happens before truncation so a secret can't survive as a fragment.
- **Download URL** — the temp context link is a bearer capability; it's now unbound after load on both the upload and URL fast paths.
- **`FINAL_VAR` names** are model-controlled and interpolated into generated code, so non-identifiers are rejected instead of executed.
- **Answer injection** carries answers as `repr(json.dumps(...))` — attacker-influenced answer text can't break out into executable code.

## Tests

53 new tests (90 total in `rlm_test.py`, all passing):

- **No credential in the sandbox** — asserts the key appears in *no* sandbox payload; asserts module source never interpolates a key into generated code.
- **Recovery probes** — `co_consts`, `getsource`, and `os.environ` dumps can't recover the key; echoed secrets and failure messages are redacted.
- **Session split** — sessions are distinct, emitted code only ever hits `repl`, setup state is unreachable from `repl`, unstarted/unknown sessions are rejected.
- **Teardown** — on success, on exception, on setup failure; failed close still wipes; wipe fallback without a close action; idempotency; context manager.
- **Protocol** — marker stripping, malformed and truncated payloads, same-line prefixes, two-turn resolution, hash dedup, keying on the full prompt while truncating worker input, quote/backslash round-trips, marker never reaching the transcript, stranded-prompt resubmission, notes surviving a very long block output.
- **Bootstrap & final answer** — URL unbinding on both paths; `FINAL_VAR` identifier and placeholder rejection; `FINAL` placeholder rejection with run continuation; forced-final stripping.

```
90 passed in 0.64s
```

Full pre-commit suite (ruff, ruff format, pytest-check) passes. No other module touched.

## Compatibility

`llm_query(prompt)` keeps its signature and its 8192-token output budget, so answer length is unchanged. The behavioural change is the two-turn resolution — the orchestrator is instructed on it directly, and `max_iterations` was raised to match. `llm_query_request([...])` is available to submit a whole batch in one call.