### PR TITLE
ENG-3431: unit test integrity — coverage gate, credential-free collect, v2 effect assertions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,15 +8,65 @@ on:
       - test
   workflow_dispatch:
 
+env:
+  # Coverage floor for the unit suite, enforced by the `unit-coverage` job.
+  # Measured at 64% on `development` @ 42ed1e02; set two points below to absorb
+  # ordering/version jitter. Ratchet it up here as coverage improves.
+  COVERAGE_FLOOR: "62"
+
 jobs:
+  # The unit suite is deliberately credential-free: no TEAM_API_KEY, no
+  # BACKEND_URL. If this job starts failing on a missing key, the regression is
+  # in the code under test (something validating credentials at import time),
+  # not in this workflow.
+  unit-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # `coverage[toml]` (not plain `coverage`): the coverage settings live in
+          # pyproject.toml, and on Python < 3.11 coverage needs the `tomli` extra to
+          # read it. Without the extra it aborts with "Can't read 'pyproject.toml'
+          # without TOML support" before a single test runs.
+          pip install ".[test]" "coverage[toml]"
+
+      - name: Run unit tests with coverage
+        run: coverage run -m pytest tests/unit
+
+      - name: Enforce coverage floor
+        run: coverage report --fail-under=${{ env.COVERAGE_FLOOR }}
+
+      - name: Write coverage.xml
+        if: always()
+        run: coverage xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
   setup-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 45  # Global timeout fallback
     strategy:
       fail-fast: false
       matrix:
+        # 'unit' is absent on purpose: it runs in the credential-free
+        # `unit-coverage` job above, so it is not executed twice.
         test-suite: [
-          'unit',
           'file_asset',
           'data_asset',
           'model',
@@ -28,9 +78,6 @@ jobs:
           'v2',
         ]
         include:
-          - test-suite: 'unit'
-            path: 'tests/unit'
-            timeout: 45  # Tweaked timeout for each unit tests
           - test-suite: 'file_asset'
             path: 'tests/functional/file_asset'
             timeout: 45

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,18 +22,24 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry: coverage run --source=. -m pytest tests/unit
+        # Coverage scope lives in pyproject.toml ([tool.coverage.run]); `--source=.`
+        # measured the test files too and inflated the figure. The floor is only
+        # enforced in CI, so a local run is never blocked mid-refactor.
+        entry: coverage run -m pytest tests/unit
         language: python
         pass_filenames: false
         types: [python]
         always_run: true
         additional_dependencies:
-          - coverage
+          # `[toml]` extra required to read [tool.coverage.run] from pyproject.toml
+          # on Python < 3.11; plain `coverage` hard-errors there.
+          - coverage[toml]
           - pytest
           - pytest-mock
           - pytest-rerunfailures
           - pytest-xdist
           - requests-mock
+          - plotly>=5.18.0  # keeps the plotting tests from silently skipping here too
           - Babel>=2.12.0
           - requests>=2.1.0
           - tqdm>=4.1.0

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -28,23 +28,32 @@ AIXPLAIN_API_KEY = os.getenv("AIXPLAIN_API_KEY", "")
 ENV = "dev" if "dev" in BACKEND_URL else "test" if "test" in BACKEND_URL else "prod"
 
 
-def validate_api_keys():
-    """Centralized API key validation function - single source of truth.
+def _normalize_api_keys():
+    """Reconcile the two API key environment variables. Never raises on absence.
 
-    This function handles all API key validation logic:
-    1. Ensures at least one API key is provided
-    2. Prevents conflicting API keys
-    3. Auto-normalizes AIXPLAIN_API_KEY to TEAM_API_KEY if needed
+    Importing this module must stay side-effect-safe when no credential is set:
+    the unit test suite has to be collectible without one. Only *normalisation*
+    happens eagerly, because roughly 40 v1 call sites bind ``config.TEAM_API_KEY``
+    as a default argument value, which is evaluated once at import time - so the
+    ``AIXPLAIN_API_KEY -> TEAM_API_KEY`` copy has to happen before those modules
+    are imported.
+
+    A missing key is instead reported at the point of use: ``Aixplain()`` (v2)
+    refuses to construct without one. NOTE: v1 has no equivalent check -- the
+    ``@check_api_key`` decorator in ``aixplain/v1/decorators`` is applied to no
+    call site, so the import-time raise removed here was the only credential
+    error v1 ever produced. A v1 caller with no key now gets a backend 401
+    rather than an actionable message. v1 is deprecated, so this is accepted
+    rather than fixed here; see ENG-3431.
+
+    Two conflicting keys, on the other hand, are a misconfiguration that can
+    only be intentional, so it still fails loudly and early (it cannot fire when
+    no key is set, so it never blocks collection).
 
     Raises:
-        Exception: If no API keys are provided or if conflicting keys are detected
+        Exception: If conflicting API keys are detected
     """
     global TEAM_API_KEY, AIXPLAIN_API_KEY
-
-    if not TEAM_API_KEY and not AIXPLAIN_API_KEY:
-        raise Exception(
-            "Neither 'AIXPLAIN_API_KEY' nor 'TEAM_API_KEY' has been set. Please set either environment variable. For help, please refer to the documentation (https://github.com/aixplain/aixplain#api-key-setup)"
-        )
 
     if AIXPLAIN_API_KEY and TEAM_API_KEY and AIXPLAIN_API_KEY != TEAM_API_KEY:
         raise Exception(
@@ -53,6 +62,24 @@ def validate_api_keys():
 
     if AIXPLAIN_API_KEY and not TEAM_API_KEY:
         TEAM_API_KEY = AIXPLAIN_API_KEY
+
+
+def validate_api_keys():
+    """Centralized eager API key validation - normalize, then require a key.
+
+    This function handles all API key validation logic:
+    1. Auto-normalizes AIXPLAIN_API_KEY to TEAM_API_KEY if needed
+    2. Prevents conflicting API keys
+    3. Ensures at least one API key is provided
+
+    It is no longer called at import time (see :func:`_normalize_api_keys`), but
+    is kept for callers that want the eager, all-or-nothing check.
+
+    Raises:
+        Exception: If no API keys are provided or if conflicting keys are detected
+    """
+    _normalize_api_keys()
+    check_api_keys_available()
 
 
 def check_api_keys_available():
@@ -70,8 +97,9 @@ def check_api_keys_available():
         )
 
 
-# Perform initial validation at module import time
-validate_api_keys()
+# Normalize (but do not validate) the API keys at module import time, so that
+# importing aixplain never raises just because no credential is configured.
+_normalize_api_keys()
 
 PIPELINE_API_KEY = os.getenv("PIPELINE_API_KEY", "")
 MODEL_API_KEY = os.getenv("MODEL_API_KEY", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,4 +76,34 @@ test = [
     "pytest-mock>=3.10.0",
     "pytest-rerunfailures>=16.0",
     "pytest-xdist",
+    # Exercised by the agent_evaluator / eval_experiment plotting tests, which
+    # used to `pytest.importorskip("plotly")` and therefore never ran (ENG-3431).
+    "plotly>=5.18.0",
+]
+
+[tool.coverage.run]
+# Measure the product, not the test suite. `--source=.` also picks up `tests/`
+# (which ships as a package, see [tool.setuptools.packages.find]) and inflates
+# the headline figure.
+source = ["aixplain"]
+omit = [
+    "tests/*",
+    "aixplain/v2/enums_include.py",  # auto-generated
+]
+relative_files = true  # keeps coverage.xml paths portable for CI reporters
+branch = false  # statement coverage only for now
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+# NOTE: `fail_under` is deliberately NOT set here. The threshold is passed on
+# the CI command line (`coverage report --fail-under=$COVERAGE_FLOOR`) so the
+# gate is visible in the workflow and does not fail local/pre-commit runs
+# mid-refactor.
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "@(abc\\.)?abstractmethod",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+import ast
+import inspect
+import textwrap
+from pathlib import Path
+
 import pytest
 from typing import Any, Callable
 
@@ -82,6 +87,192 @@ def filter_sdk_version(items: list, sdk_version: str, sdk_param: str):
     filter_items(items, sdk_param, predicate)
 
 
+# ---------------------------------------------------------------------------
+# Assertion guard: no collected unit test may be silently assertion-free.
+#
+# A test that never asserts still reports "passed", so it contributes to a green
+# suite while checking nothing (ENG-3431). This runs at collection time, over
+# the items pytest actually collected, so it cannot drift out of sync with the
+# collection rules the way a standalone lint sweep would.
+# ---------------------------------------------------------------------------
+
+UNIT_TESTS_DIR = Path(__file__).resolve().parent / "unit"
+
+# nodeid (without parametrisation suffix) -> reason. Every entry needs a written
+# reason and a reviewer: this is an escape hatch for tests whose assertion is
+# genuinely expressed some other way, not a place to park unfinished tests.
+ASSERT_FREE_ALLOWLIST = {
+    # "tests/unit/example_test.py::test_x": "import-only smoke test; failure mode is an exception",
+}
+
+# How many levels of same-module helper functions to follow before giving up.
+_MAX_HELPER_DEPTH = 3
+
+# Calls that assert without using the `assert` statement. Names beginning with
+# `assert` (after any leading underscores) are additionally treated as asserting,
+# which covers project-local helpers like `_assert_payload`.
+_ASSERTING_CALLS = frozenset(
+    {
+        # pytest
+        "raises",
+        "warns",
+        "deprecated_call",
+        "fail",
+        "approx",
+        "xfail",
+        # unittest.mock
+        "assert_called",
+        "assert_called_once",
+        "assert_called_with",
+        "assert_called_once_with",
+        "assert_not_called",
+        "assert_has_calls",
+        "assert_any_call",
+        "assert_awaited",
+        "assert_awaited_once",
+        "assert_awaited_with",
+        "assert_awaited_once_with",
+        "assert_not_awaited",
+        # unittest.TestCase
+        "assertEqual",
+        "assertNotEqual",
+        "assertTrue",
+        "assertFalse",
+        "assertIn",
+        "assertNotIn",
+        "assertIs",
+        "assertIsNone",
+        "assertIsNotNone",
+        "assertRaises",
+        "assertRaisesRegex",
+        "assertAlmostEqual",
+        "assertListEqual",
+        "assertDictEqual",
+    }
+)
+
+
+def _source_tree(func: Callable):
+    """Parse *func*'s own source, or return None if it cannot be read."""
+    try:
+        return ast.parse(textwrap.dedent(inspect.getsource(inspect.unwrap(func))))
+    except (OSError, TypeError, SyntaxError, IndentationError):
+        return None
+
+
+def _is_asserting_name(name: str) -> bool:
+    return name in _ASSERTING_CALLS or name.lstrip("_").startswith("assert")
+
+
+def _asserts_in_tree(tree: ast.AST, namespace: dict, depth: int, seen: set) -> bool:
+    """True if *tree* asserts, directly or via a helper it calls.
+
+    Following helpers matters because delegating the assertion to a shared
+    ``_assert_payload(...)``/``_check_payload(...)`` helper is an ordinary,
+    correct way to write a test. Without this, such a test is reported as an
+    offender and -- because the guard raises ``UsageError`` -- takes the *entire*
+    suite down with it, which is a far worse failure than the one being guarded
+    against. Erring toward a false negative here is the right trade.
+    """
+    called_helpers = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assert):
+            return True
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if not name:
+                continue
+            if _is_asserting_name(name):
+                return True
+            # `helper(...)` resolves against module globals; `self.helper(...)`
+            # against the test class, which was merged into `namespace` by the
+            # caller. Both are ordinary ways to share an assertion.
+            is_self_method = isinstance(func, ast.Attribute) and getattr(func.value, "id", None) == "self"
+            if isinstance(func, ast.Name) or is_self_method:
+                called_helpers.append(name)
+
+    if depth >= _MAX_HELPER_DEPTH:
+        return False
+
+    for name in called_helpers:
+        helper = namespace.get(name)
+        if not inspect.isfunction(helper) or helper in seen:
+            continue
+        seen.add(helper)
+        subtree = _source_tree(helper)
+        if subtree is None:
+            # Unreadable helper: assume it asserts rather than aborting the run.
+            return True
+        if _asserts_in_tree(subtree, getattr(helper, "__globals__", {}), depth + 1, seen):
+            return True
+    return False
+
+
+def _has_assertion(func: Callable, cls=None) -> bool:
+    """True if the collected test function asserts something.
+
+    Reads the *resolved* function's source rather than sweeping the file, so a
+    nested helper named ``test_...`` inside a real test is never mistaken for a
+    test of its own -- a file-level AST sweep produces exactly that false
+    positive in ``tests/unit/utility_tool_decorator_test.py``.
+
+    *cls* is the enclosing test class, if any, so that ``self._helper(...)``
+    can be resolved the same way a module-level helper is.
+    """
+    tree = _source_tree(func)
+    if tree is None:
+        # Dynamically generated or otherwise unreadable: give it the benefit of
+        # the doubt rather than failing the whole run on a parsing limitation.
+        return True
+
+    namespace = dict(getattr(inspect.unwrap(func), "__globals__", {}))
+    if cls is not None:
+        for klass in reversed(getattr(cls, "__mro__", [cls])):
+            namespace.update(vars(klass))
+
+    return _asserts_in_tree(tree, namespace, depth=0, seen=set())
+
+
+def check_tests_have_assertions(items: list) -> None:
+    """Raise if any collected unit test has no assertion.
+
+    Scoped to ``tests/unit`` on purpose: functional tests hit a live backend and
+    some of them legitimately assert only by not raising. Widening the scope is
+    a follow-up, not a silent side effect of this guard.
+    """
+    offenders = {}
+    for item in items:
+        if not isinstance(item, pytest.Function):
+            continue
+        # `item.path` is pytest >= 7; `item.fspath` covers the >= 6.1 floor in
+        # pyproject.toml. Without the fallback the guard would silently inspect
+        # nothing on an older pytest -- the exact "green but checking nothing"
+        # failure it exists to prevent. `.resolve()` for the same reason: an
+        # unresolved item path never matches the resolved UNIT_TESTS_DIR when the
+        # checkout sits behind a symlink.
+        raw_path = getattr(item, "path", None) or getattr(item, "fspath", None)
+        if raw_path is None:  # pragma: no cover - defensive
+            continue
+        item_path = Path(str(raw_path)).resolve()
+        if UNIT_TESTS_DIR not in item_path.parents:
+            continue
+        # Parametrised tests collect as N items sharing one function; report once.
+        base_nodeid = item.nodeid.split("[")[0]
+        if base_nodeid in ASSERT_FREE_ALLOWLIST or base_nodeid in offenders:
+            continue
+        function = getattr(item, "function", None)
+        if function is None or _has_assertion(function, getattr(item, "cls", None)):
+            continue
+        offenders[base_nodeid] = None
+
+    if offenders:
+        raise pytest.UsageError(
+            "Tests with no assertion (add one, or allowlist it with a written "
+            "reason in ASSERT_FREE_ALLOWLIST in tests/conftest.py):\n  " + "\n  ".join(sorted(offenders))
+        )
+
+
 def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config, items: list):
     """Modify the items based on the pipeline version and the SDK version.
 
@@ -92,6 +283,7 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
 
     Raises:
         ValueError: If the pipeline version or the SDK version is invalid.
+        pytest.UsageError: If a collected unit test has no assertion.
     """
     pipeline_version = config.getoption(f"{PIPELINE_VERSION_ARG}")
     sdk_version = config.getoption(f"{SDK_VERSION_ARG}")
@@ -104,3 +296,6 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
         if not sdk_param:
             raise ValueError(f"{SDK_VERSION_PARAM_ARG} parameter is required when using {SDK_VERSION_ARG}")
         filter_sdk_version(items, sdk_version, sdk_param)
+
+    # Run last, so it only sees the items that survived the filters above.
+    check_tests_have_assertions(items)

--- a/tests/unit/image_upload_test.py
+++ b/tests/unit/image_upload_test.py
@@ -63,5 +63,9 @@ def test_get_functions():
         with open(Path("tests/mock_responses/list_functions_response.json")) as f:
             mock_json = json.load(f)
         mock.get(url, headers=AUTH_FIXED_HEADER, json=mock_json)
-        functions = ModelFactory.list_functions(config.TEAM_API_KEY)
+        # `verbose` is the first positional parameter, not `api_key`. This used
+        # to be called as `list_functions(config.TEAM_API_KEY)`, which only
+        # returned the raw payload because a non-empty key happens to be truthy
+        # -- so the test silently depended on a credential being set.
+        functions = ModelFactory.list_functions(True, api_key=config.TEAM_API_KEY)
     assert functions == mock_json

--- a/tests/unit/test_dependency_declarations.py
+++ b/tests/unit/test_dependency_declarations.py
@@ -1,0 +1,135 @@
+"""Guard: no test may skip itself on a package nobody installs.
+
+Four tests used to call ``pytest.importorskip("plotly")`` while ``plotly``
+appeared in no dependency list (ENG-3431). They skipped 100% of the time in CI,
+so three public plotting methods were untested by construction while the suite
+reported green.
+
+This test walks every test module, extracts the literal argument of each
+``importorskip`` call, and requires the corresponding distribution to be
+declared in ``pyproject.toml`` -- either as a runtime dependency or in an
+optional-dependency group CI installs.
+"""
+
+import ast
+import importlib
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO_ROOT / "tests"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# Import name -> distribution name, for the cases where they differ
+# (e.g. ``import yaml`` is provided by the ``PyYAML`` distribution).
+IMPORT_TO_DISTRIBUTION = {
+    "yaml": "pyyaml",
+    "dotenv": "python-dotenv",
+    "dateutil": "python-dateutil",
+}
+
+
+def _normalize(name: str) -> str:
+    """Normalise a distribution name per PEP 503."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _declared_distributions() -> set:
+    """Distribution names declared in pyproject's dependency arrays.
+
+    Hand-rolled rather than tomllib-based: the SDK supports Python 3.9, where
+    ``tomllib`` does not exist, and pulling in a TOML parser just for this check
+    is not worth a new dependency.
+    """
+    names = set()
+    section = None
+    in_array = False
+
+    for raw_line in PYPROJECT.read_text().splitlines():
+        line = raw_line.strip()
+
+        if line.startswith("[") and line.endswith("]") and "=" not in line:
+            section = line.strip("[]")
+            in_array = False
+            continue
+
+        if not in_array:
+            is_runtime_deps = section == "project" and line.startswith("dependencies")
+            is_optional_group = section == "project.optional-dependencies" and "= [" in line
+            if (is_runtime_deps or is_optional_group) and line.endswith("["):
+                in_array = True
+            continue
+
+        if line.startswith("]"):
+            in_array = False
+            continue
+
+        match = re.match(r'^"([^"]+)"', line)
+        if match:
+            # Strip version specifiers, extras and environment markers.
+            names.add(_normalize(re.split(r"[<>=!~\[;\s]", match.group(1))[0]))
+
+    return names
+
+
+def _importorskip_targets():
+    """Yield (path, module name) for every ``importorskip`` literal in tests/."""
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "importorskip" or not node.args:
+                continue
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                yield path.relative_to(REPO_ROOT), first.value
+
+
+def test_pyproject_dependencies_are_parsed():
+    """Sanity check on the hand-rolled parser used by the guard below."""
+    declared = _declared_distributions()
+
+    assert "requests" in declared, declared  # runtime dependency
+    assert "pytest" in declared, declared  # from the `test` extra
+
+
+def test_every_importorskip_target_is_a_declared_dependency():
+    """An `importorskip` on an undeclared package is a permanent silent skip."""
+    declared = _declared_distributions()
+
+    undeclared = [
+        f"{path}: importorskip({module!r})"
+        for path, module in _importorskip_targets()
+        if _normalize(IMPORT_TO_DISTRIBUTION.get(module, module)) not in declared
+    ]
+
+    assert not undeclared, (
+        "These tests skip on a package that is in no dependency list, so they "
+        "never run. Declare the package in pyproject.toml (or delete the "
+        "tests):\n  " + "\n  ".join(undeclared)
+    )
+
+
+@pytest.mark.parametrize("module", sorted({module for _, module in _importorskip_targets()}))
+def test_importorskip_targets_are_actually_importable(module):
+    """The declared packages must really be installed in the test environment.
+
+    Deliberately a failure, not a skip: declaring `plotly` but forgetting to
+    install it would silently put the four skipped plotting tests right back.
+    """
+    try:
+        importlib.import_module(module)
+    except ImportError as exc:  # pragma: no cover - only fires on a broken env
+        pytest.fail(
+            f"{module!r} is declared in pyproject.toml but is not installed, so every "
+            f"test guarded by importorskip({module!r}) silently skips. "
+            f"Install the test extra (`pip install '.[test]'`). Import error: {exc}"
+        )
+
+    assert importlib.util.find_spec(module) is not None

--- a/tests/unit/utility_test.py
+++ b/tests/unit/utility_test.py
@@ -327,6 +327,12 @@ def test_validate_existing_model():
         )
         utility_model.validate()  # Should not raise any exception
 
+        # validate() must actually perform the existence check against the
+        # backend rather than short-circuiting on an S3 code reference.
+        assert mock.call_count == 1
+        assert mock.last_request.path.endswith(f"/sdk/models/{model_id}")
+        assert utility_model.code == "s3://bucket/path/to/code"
+
 
 def test_model_exists_success():
     """Test _model_exists when model exists"""

--- a/tests/unit/utils/test_config_api_keys.py
+++ b/tests/unit/utils/test_config_api_keys.py
@@ -1,0 +1,122 @@
+"""Tests for the API key handling in ``aixplain.utils.config``.
+
+The split these tests lock in (ENG-3431):
+
+* **Normalisation is eager.** ``AIXPLAIN_API_KEY`` is copied into
+  ``TEAM_API_KEY`` at import time, because ~40 v1 call sites bind
+  ``config.TEAM_API_KEY`` as a default argument value.
+* **Validation is lazy.** Importing the module with no key set must *not*
+  raise, otherwise the unit suite cannot even be collected without a
+  credential. The "you need a key" error is raised at the point of use by
+  ``check_api_keys_available()``.
+"""
+
+import importlib
+
+import pytest
+
+from aixplain.utils import config
+
+
+@pytest.fixture
+def reload_config(monkeypatch):
+    """Reload ``aixplain.utils.config`` under a controlled environment.
+
+    Returns a callable taking the desired values of the two key env vars
+    (``None`` meaning "unset") and returning the freshly reloaded module.
+    The module is reloaded once more on teardown so that the process-wide
+    state seen by the rest of the suite is restored.
+    """
+    original_team = config.TEAM_API_KEY
+    original_aixplain = config.AIXPLAIN_API_KEY
+
+    def _reload(team_api_key=None, aixplain_api_key=None):
+        for name, value in (
+            ("TEAM_API_KEY", team_api_key),
+            ("AIXPLAIN_API_KEY", aixplain_api_key),
+        ):
+            if value is None:
+                monkeypatch.delenv(name, raising=False)
+            else:
+                monkeypatch.setenv(name, value)
+        return importlib.reload(config)
+
+    yield _reload
+
+    # Restore the module to the environment the rest of the session expects.
+    monkeypatch.setenv("TEAM_API_KEY", original_team)
+    monkeypatch.setenv("AIXPLAIN_API_KEY", original_aixplain)
+    importlib.reload(config)
+
+
+def test_import_without_any_key_succeeds(reload_config):
+    """Importing the config module with no credential must not raise."""
+    reloaded = reload_config(team_api_key=None, aixplain_api_key=None)
+
+    assert reloaded.TEAM_API_KEY == ""
+    assert reloaded.AIXPLAIN_API_KEY == ""
+
+
+def test_aixplain_key_normalized_to_team_key(reload_config):
+    """AIXPLAIN_API_KEY-only users still get a populated TEAM_API_KEY."""
+    reloaded = reload_config(team_api_key=None, aixplain_api_key="aixplain-key")
+
+    assert reloaded.TEAM_API_KEY == "aixplain-key"
+
+
+def test_team_key_is_left_alone(reload_config):
+    """TEAM_API_KEY-only is the common case and must pass through untouched."""
+    reloaded = reload_config(team_api_key="team-key", aixplain_api_key=None)
+
+    assert reloaded.TEAM_API_KEY == "team-key"
+
+
+def test_conflicting_keys_raise_on_import(reload_config):
+    """Two different keys are a misconfiguration; fail loudly and early."""
+    with pytest.raises(Exception, match="Conflicting API keys"):
+        reload_config(team_api_key="team-key", aixplain_api_key="other-key")
+
+
+def test_matching_keys_do_not_raise(reload_config):
+    """Setting both vars to the same value is redundant but legal."""
+    reloaded = reload_config(team_api_key="same-key", aixplain_api_key="same-key")
+
+    assert reloaded.TEAM_API_KEY == "same-key"
+
+
+def test_check_api_keys_available_raises_when_unset(reload_config):
+    """The lazy path is where a missing credential is reported."""
+    reloaded = reload_config(team_api_key=None, aixplain_api_key=None)
+
+    with pytest.raises(Exception, match="An API key is required"):
+        reloaded.check_api_keys_available()
+
+
+def test_check_api_keys_available_passes_when_set(reload_config):
+    """No exception, and the key that made it pass is the normalised one."""
+    reloaded = reload_config(team_api_key="team-key", aixplain_api_key=None)
+
+    reloaded.check_api_keys_available()  # must not raise
+
+    assert reloaded.TEAM_API_KEY == "team-key"
+
+
+def test_validate_api_keys_still_raises_when_unset(reload_config):
+    """The eager wrapper is kept for backwards compatibility."""
+    reloaded = reload_config(team_api_key=None, aixplain_api_key=None)
+
+    with pytest.raises(Exception, match="An API key is required"):
+        reloaded.validate_api_keys()
+
+
+def test_validate_api_keys_normalizes_then_passes(reload_config, monkeypatch):
+    """validate_api_keys() normalises before checking, as it always did."""
+    reloaded = reload_config(team_api_key=None, aixplain_api_key=None)
+    # Simulate a key arriving after import time, the way a caller that sets
+    # os.environ late would; validate_api_keys() re-reads module state only,
+    # so poke the module attribute directly.
+    monkeypatch.setattr(reloaded, "AIXPLAIN_API_KEY", "late-key")
+
+    reloaded.validate_api_keys()
+
+    assert reloaded.TEAM_API_KEY == "late-key"

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -1,0 +1,88 @@
+"""Guard: the unit suite must be collectible without any API credential.
+
+``aixplain/utils/config.py`` used to call ``validate_api_keys()`` at module
+import time, which made ~27 unit test files fail *at collection* when neither
+``TEAM_API_KEY`` nor ``AIXPLAIN_API_KEY`` was set. That coupled the unit suite
+to a secret it does not need, and made a rotated key look like a code failure.
+
+This test re-runs collection in a subprocess with both variables stripped. It
+also neutralises ``python-dotenv``: ``aixplain/__init__.py`` calls
+``load_dotenv()``, which walks *up* the directory tree, so a ``.env`` anywhere
+above the checkout would silently supply a key and hide the regression on a
+developer machine while still breaking CI.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Imported by the interpreter at startup (via `site`), before anything else can
+# read the environment, so the `from dotenv import load_dotenv` in
+# aixplain/__init__.py binds the neutered version.
+SITECUSTOMIZE = """
+import dotenv
+
+dotenv.load_dotenv = lambda *args, **kwargs: False
+dotenv.main.load_dotenv = dotenv.load_dotenv
+"""
+
+
+def _credential_free_env(sitecustomize_dir: Path) -> dict:
+    env = os.environ.copy()
+    env.pop("TEAM_API_KEY", None)
+    env.pop("AIXPLAIN_API_KEY", None)
+    existing_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (str(sitecustomize_dir), existing_path) if p)
+    return env
+
+
+def test_unit_suite_collects_without_api_key(tmp_path):
+    """`pytest tests/unit --collect-only` must exit 0 with no credential set."""
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/unit",
+            "--collect-only",
+            "-q",
+            # The rerun plugin binds a socket at startup, which collection does
+            # not need and which is blocked in some sandboxed environments.
+            "-p",
+            "no:rerunfailures",
+        ],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert "has been set" not in output, f"collection still requires a credential:\n{output[-4000:]}"
+    assert "errors during collection" not in output, f"collection errors:\n{output[-4000:]}"
+    assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"
+
+
+def test_dotenv_neutralisation_actually_works(tmp_path):
+    """The neutralisation above must really stop `.env` discovery.
+
+    Without this, `test_unit_suite_collects_without_api_key` could pass for the
+    wrong reason on any machine with an ancestor `.env` file.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "from aixplain.utils import config; print(repr(config.TEAM_API_KEY))"],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "''", f"a credential leaked into the subprocess: {result.stdout!r}"

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -260,9 +260,14 @@ class TestDeprecatedPersistedMaxIterations:
         assert "maxIterations" not in payload
 
     def test_no_warning_when_unset(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            _build_agent()  # must not raise
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            agent = _build_agent()
+
+        assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
+        # Nothing to fold in, so the budget stays empty rather than picking up a
+        # default max_iterations.
+        assert agent.budget.max_iterations is None
 
     def test_conflict_budget_wins(self):
         with warnings.catch_warnings(record=True) as caught:

--- a/tests/unit/v2/test_api_key.py
+++ b/tests/unit/v2/test_api_key.py
@@ -145,6 +145,12 @@ class TestAPIKeyLimits:
 
         limits.validate()  # Should not raise
 
+        # Validation must be a pure check: valid limits survive it untouched.
+        assert limits.token_per_minute == 100
+        assert limits.token_per_day == 1000
+        assert limits.request_per_minute == 10
+        assert limits.request_per_day == 100
+
     def test_limits_validate_negative_token_per_minute(self):
         """validate() should fail for negative token_per_minute."""
         limits = APIKeyLimits(token_per_minute=-1)
@@ -408,6 +414,11 @@ class TestAPIKey:
         )
 
         api_key._validate_limits()  # Should not raise
+
+        # Validation must be a pure check: valid limits survive it untouched.
+        assert api_key.budget == 1000.0
+        assert api_key.global_limits.token_per_minute == 100
+        assert api_key.asset_limits[0].token_per_minute == 50
 
     def test_api_key_validate_negative_budget(self):
         """_validate_limits() should fail for negative budget."""

--- a/tests/unit/v2/test_resource_paths.py
+++ b/tests/unit/v2/test_resource_paths.py
@@ -1,0 +1,166 @@
+"""Effect-based guards on the backend paths v2 resources talk to.
+
+These tests exist because renaming ``RESOURCE_PATH`` on ``Model``, ``Tool``,
+``Integration`` or ``Skill`` used to break *no* test (ENG-3431): every test for
+those resources mocks at a layer above URL construction, so an SDK pointed at
+the wrong endpoint would have shipped green.
+
+They are deliberately **effect-based**: each test drives the real code path and
+asserts on the path string the client actually received. Asserting the constant
+itself (``assert Model.RESOURCE_PATH == "v2/models"``) would kill the same
+mutants while proving nothing -- such a test moves in lockstep with the bug.
+"""
+
+import os
+
+import pytest
+from unittest.mock import Mock
+
+from aixplain.v2.integration import Integration
+from aixplain.v2.model import Model
+from aixplain.v2.skill import Skill
+from aixplain.v2.tool import Tool
+
+# (class, documented backend path). Kept as literals on purpose: this table is
+# the specification, not a mirror of the constant under test.
+RESOURCES = [
+    (Model, "v2/models"),
+    (Tool, "v2/tools"),
+    (Integration, "v2/integrations"),
+    (Skill, "sdk/skill"),
+]
+RESOURCE_IDS = [cls.__name__ for cls, _ in RESOURCES]
+
+RESOURCE_ID = "abc123"
+
+
+def _bind(monkeypatch, cls):
+    """Bind *cls* to a mock context and return that context.
+
+    ``monkeypatch`` restores the class attribute afterwards, so the real
+    resource classes are left untouched for the rest of the session.
+    """
+    context = Mock(client=Mock(), backend_url="https://platform-api.aixplain.com", api_key="test_key")
+    monkeypatch.setattr(cls, "context", context, raising=False)
+    return context
+
+
+def _bind_instance(monkeypatch, cls, payload):
+    """Build a saved instance of *cls* bound to a mock context."""
+    context = _bind(monkeypatch, cls)
+    instance = cls.from_dict(payload)
+    instance.context = context
+    return context, instance
+
+
+@pytest.mark.parametrize("cls, expected_path", RESOURCES, ids=RESOURCE_IDS)
+def test_get_uses_resource_path(monkeypatch, cls, expected_path):
+    """``get(id)`` must issue its GET against ``<RESOURCE_PATH>/<id>``."""
+    context = _bind(monkeypatch, cls)
+    context.client.get.return_value = {"id": RESOURCE_ID, "name": "fixture"}
+
+    cls.get(RESOURCE_ID)
+
+    context.client.get.assert_called_once()
+    assert context.client.get.call_args[0][0] == f"{expected_path}/{RESOURCE_ID}"
+
+
+@pytest.mark.parametrize("cls, expected_path", RESOURCES, ids=RESOURCE_IDS)
+def test_search_uses_resource_path(monkeypatch, cls, expected_path):
+    """``search()`` must paginate against ``<RESOURCE_PATH>/paginate``."""
+    context = _bind(monkeypatch, cls)
+    context.client.request.return_value = {"results": [], "total": 0, "pageTotal": 0}
+
+    cls.search()
+
+    context.client.request.assert_called_once()
+    method, path = context.client.request.call_args[0][:2]
+    assert method == "post"
+    assert path == f"{expected_path}/paginate"
+
+
+@pytest.mark.parametrize(
+    "cls, expected_path",
+    [(Model, "v2/models"), (Integration, "v2/integrations"), (Skill, "sdk/skill")],
+    ids=["Model", "Integration", "Skill"],
+)
+def test_create_posts_to_resource_path(monkeypatch, cls, expected_path):
+    """Creating an unsaved resource must POST to the collection root.
+
+    ``Tool`` is absent by design: a saved tool's metadata update goes to
+    ``sdk/utilities/<id>``, which is covered by ``test_tool.py``.
+    """
+    context = _bind(monkeypatch, cls)
+    context.client.request.return_value = {"id": "new-id", "name": "fixture"}
+    instance = cls(name="fixture")
+    instance.context = context
+
+    instance.save()
+
+    method, path = context.client.request.call_args[0][:2]
+    assert method == "post"
+    assert path == expected_path
+
+
+@pytest.mark.parametrize(
+    "cls, expected_path",
+    [(Tool, "v2/tools"), (Skill, "sdk/skill")],
+    ids=["Tool", "Skill"],
+)
+def test_delete_uses_resource_path(monkeypatch, cls, expected_path):
+    """``delete()`` must DELETE ``<RESOURCE_PATH>/<id>``.
+
+    Only the two resources that mix in ``DeleteResourceMixin`` are listed;
+    ``Model`` and ``Integration`` expose no ``delete()``.
+    """
+    context, instance = _bind_instance(monkeypatch, cls, {"id": RESOURCE_ID, "name": "fixture"})
+
+    instance.delete()
+
+    method, path = context.client.request_raw.call_args[0][:2]
+    assert method == "delete"
+    assert path == f"{expected_path}/{RESOURCE_ID}"
+
+
+def test_skill_download_composes_resource_path(monkeypatch, tmp_path):
+    """Skill sub-resources hang off RESOURCE_PATH and must move with it."""
+    context, skill = _bind_instance(monkeypatch, Skill, {"id": RESOURCE_ID, "name": "fixture"})
+    context.client.request_raw.return_value = Mock(content=b"bundle")
+    target = tmp_path / "bundle.zip"
+
+    skill.download(str(target))
+
+    method, path = context.client.request_raw.call_args[0][:2]
+    assert method == "get"
+    assert path == f"sdk/skill/{RESOURCE_ID}/download"
+
+
+def test_skill_file_upload_composes_resource_path(monkeypatch, tmp_path):
+    """The internal file-tree upload must target ``sdk/skill/<id>/file``."""
+    context, skill = _bind_instance(monkeypatch, Skill, {"id": RESOURCE_ID, "name": "fixture"})
+    monkeypatch.setattr(Skill, "_upload", lambda self, path: "https://uploaded/SKILL.md")
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("# fixture")
+
+    skill._upload_file_as_skill(str(skill_md))
+
+    method, path = context.client.request.call_args[0][:2]
+    assert method == "post"
+    assert path == f"sdk/skill/{RESOURCE_ID}/file"
+
+
+def test_skill_folder_upload_composes_resource_path(monkeypatch, tmp_path):
+    """Folder nodes are created under ``sdk/skill/<id>/folder``."""
+    context, skill = _bind_instance(monkeypatch, Skill, {"id": RESOURCE_ID, "name": "fixture"})
+    monkeypatch.setattr(Skill, "_upload", lambda self, path: "https://uploaded/file")
+    context.client.request.return_value = {"id": "folder-1"}
+    (tmp_path / "SKILL.md").write_text("# fixture")
+    nested = tmp_path / "references"
+    os.makedirs(str(nested))
+    (nested / "notes.md").write_text("notes")
+
+    skill._upload_folder(str(tmp_path))
+
+    paths = [call[0][1] for call in context.client.request.call_args_list]
+    assert f"sdk/skill/{RESOURCE_ID}/folder" in paths
+    assert f"sdk/skill/{RESOURCE_ID}/file" in paths

--- a/tests/unit/v2/test_upload_headers.py
+++ b/tests/unit/v2/test_upload_headers.py
@@ -1,0 +1,97 @@
+"""Effect-based guards on the headers the v2 file-upload path sends.
+
+``AixplainClient.__init__`` header building is covered by ``test_client.py``,
+but ``aixplain/v2/upload_utils.py`` builds its own headers outside the client
+and nothing asserted on them: renaming ``Authorization`` there killed no test
+(ENG-3431). These tests drive ``FileUploader.upload()`` and assert on the
+header dicts the HTTP layer actually received.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from aixplain.v2.upload_utils import FileUploader
+
+API_KEY = "test-team-key"
+PRESIGNED_URL = "https://test-bucket.s3.amazonaws.com/upload?signature=xyz"
+
+
+@pytest.fixture
+def upload_file_path(tmp_path):
+    """A small on-disk file that passes validation and MIME detection."""
+    path = tmp_path / "sample.csv"
+    path.write_text("col_a,col_b\n1,2\n")
+    return str(path)
+
+
+@pytest.fixture
+def captured_requests():
+    """Patch the retrying request layer and record every call made through it."""
+    presigned_response = Mock(
+        status_code=200,
+        **{
+            "json.return_value": {
+                "key": "data/sample.csv",
+                "uploadUrl": PRESIGNED_URL,
+                "downloadUrl": "https://download/sample.csv",
+            },
+            "raise_for_status.return_value": None,
+        },
+    )
+    s3_response = Mock(status_code=200)
+
+    with patch(
+        "aixplain.v2.upload_utils.RequestManager.request_with_retry",
+        side_effect=[presigned_response, s3_response],
+    ) as mock_request:
+        yield mock_request
+
+
+def _call_for(mock_request, method):
+    """Return the single recorded call made with *method*."""
+    calls = [call for call in mock_request.call_args_list if call[0][0] == method]
+    assert len(calls) == 1, f"expected exactly one {method!r} request, got {len(calls)}"
+    return calls[0]
+
+
+def test_presigned_url_request_sends_authorization_token(captured_requests, upload_file_path):
+    """The pre-signed URL request must authenticate with `Authorization: token <key>`."""
+    FileUploader(backend_url="https://platform-api.aixplain.com", api_key=API_KEY).upload(upload_file_path)
+
+    headers = _call_for(captured_requests, "post")[1]["headers"]
+    assert headers["Authorization"] == f"token {API_KEY}"
+
+
+def test_s3_upload_sends_content_type_and_no_credential(captured_requests, upload_file_path):
+    """The S3 PUT carries the content type -- and must not leak the API key.
+
+    The pre-signed URL already encodes the grant; forwarding the team key to a
+    third-party host would widen its exposure for no benefit.
+    """
+    FileUploader(backend_url="https://platform-api.aixplain.com", api_key=API_KEY).upload(upload_file_path)
+
+    put_call = _call_for(captured_requests, "put")
+    headers = put_call[1]["headers"]
+    assert put_call[0][1] == PRESIGNED_URL
+    assert headers["Content-Type"] == "text/csv"
+    assert "Authorization" not in headers
+    assert API_KEY not in str(headers)
+
+
+def test_temp_upload_targets_temp_url_endpoint(captured_requests, upload_file_path):
+    """A temporary upload negotiates against `sdk/file/upload/temp-url`."""
+    uploader = FileUploader(backend_url="https://platform-api.aixplain.com", api_key=API_KEY)
+    uploader.upload(upload_file_path, is_temp=True)
+
+    assert _call_for(captured_requests, "post")[0][1] == "https://platform-api.aixplain.com/sdk/file/upload/temp-url"
+
+
+def test_permanent_upload_targets_upload_url_endpoint(captured_requests, upload_file_path):
+    """A permanent upload negotiates against `sdk/file/upload-url`."""
+    FileUploader(backend_url="https://platform-api.aixplain.com", api_key=API_KEY).upload(
+        upload_file_path, is_temp=False, tags=["unit-test"]
+    )
+
+    post_call = _call_for(captured_requests, "post")
+    assert post_call[0][1] == "https://platform-api.aixplain.com/sdk/file/upload-url"
+    assert post_call[1]["headers"]["Authorization"] == f"token {API_KEY}"

--- a/tests/unit/v2/test_v2_agent_v3_compat.py
+++ b/tests/unit/v2/test_v2_agent_v3_compat.py
@@ -68,9 +68,14 @@ class TestR6JsonRequiresExpectedOutput:
         # Must not raise: text/markdown agents don't require expected_output.
         agent._validate_expected_output()
 
+        # Validation is a pure check -- it must not fabricate an expected_output.
+        assert agent.expected_output is None
+
     def test_json_with_dict_expected_output_is_valid(self):
         agent = Agent(name="t", instructions="x", output_format="json", expected_output={"a": "b"})
         agent._validate_expected_output()
+
+        assert agent.expected_output == {"a": "b"}
 
 
 class TestR3InspectorDeserialization:


### PR DESCRIPTION
## Summary

The unit suite could report green while checking very little. This PR closes four independent holes and adds the gates that keep them closed.

| Hole | Before | After |
|---|---|---|
| Assertion-free tests | Counted as passes | Collection fails, with an allowlist that requires a written reason |
| Silent `importorskip` | Whole plotting modules skipped on an undeclared package | `plotly` declared; a guard test fails if a new silent skip appears |
| Coverage | `--source=.` (inflated by the `tests/` package), never gated | Scoped to `aixplain`, gated in CI at 62% |
| Credentials | Unit suite couldn't be **collected** without `TEAM_API_KEY` | Import never raises on a missing key; a subprocess test proves it |

## Changes

### Coverage gate
- Coverage scope moved to `[tool.coverage.run]` in `pyproject.toml` (`source = ["aixplain"]`). `--source=.` was measuring the test files themselves — `tests/` ships as a package via `[tool.setuptools.packages.find]` — and inflating the headline number. The report now has **zero `tests/` rows**.
- New `unit-coverage` CI job runs the unit suite and enforces `coverage report --fail-under=$COVERAGE_FLOOR`.
  - Floor is **62**, two points below the 65% measured on this branch, to absorb ordering/version jitter. Ratchet it up in the workflow `env` block as coverage improves.
  - The threshold is passed on the command line rather than set as `fail_under` in `pyproject.toml`, so the gate is visible in the workflow and a local or pre-commit run is never blocked mid-refactor.
- `unit` removed from the `setup-and-test` matrix so it isn't run twice.
- CI and the pre-commit hook install `coverage[toml]`, not plain `coverage`: on Python < 3.11 coverage can't read `pyproject.toml` without the extra and aborts with *"Can't read 'pyproject.toml' without TOML support"* before a single test runs.

### Assertion guard (`tests/conftest.py`)
`pytest_collection_modifyitems` now raises `pytest.UsageError` if any collected `tests/unit` test has no assertion. Design notes:

- Inspects the **resolved function's** source, not a file-level AST sweep. A sweep false-positives on nested `test_`-named helpers inside real tests (`utility_tool_decorator_test.py` has exactly that).
- Follows same-module and `self.` helpers up to 3 levels, because delegating to a shared `_assert_payload(...)` is an ordinary, correct way to write a test. Since the guard takes the *whole suite* down when it fires, erring toward a false negative is the right trade.
- Recognises non-`assert` assertions: `pytest.raises`/`warns`, the `mock.assert_*` family, `unittest` `assertEqual` &c., plus any project-local name starting with `assert`.
- Unreadable or dynamically generated functions get the benefit of the doubt rather than failing the run on a parsing limitation.
- Runs **last**, so it only sees items that survived the existing version filters.
- Scoped to `tests/unit` on purpose — functional tests hit a live backend and some legitimately assert only by not raising. Widening is a follow-up, not a silent side effect.

### Credential-free collection (`aixplain/utils/config.py`)
`validate_api_keys()` ran at import time and raised when no key was set, so the unit suite couldn't even be collected without a credential. Split into:

- `_normalize_api_keys()` — runs at import, **never raises on absence**. Normalization has to stay eager because ~40 v1 call sites bind `config.TEAM_API_KEY` as a default argument value, evaluated once at import, so the `AIXPLAIN_API_KEY -> TEAM_API_KEY` copy must happen before those modules load.
- `validate_api_keys()` — kept, now normalize-then-require, for callers that want the eager all-or-nothing check.

Conflicting keys still fail loudly and early: that can only be intentional misconfiguration, and it can't fire when no key is set, so it never blocks collection.

> [!NOTE]
> **Accepted regression, called out in the docstring.** v1 has no runtime credential check — the `@check_api_key` decorator in `aixplain/v1/decorators` is applied to no call site, so the import-time raise removed here was the only credential error v1 ever produced. A v1 caller with no key now gets a backend 401 instead of an actionable message. v1 is deprecated, so this is accepted rather than fixed here.

New `tests/unit/utils/test_credential_free_collection.py` collects the entire unit suite in a subprocess with no credential in the environment and `load_dotenv` neutered via `sitecustomize` (imported by `site` at startup, before anything can read the environment) — plus a test that the neutering itself works, so the guard can't pass vacuously.

### Silent skips
- `plotly>=5.18.0` declared in the `test` extra and in the pre-commit hook deps. The `agent_evaluator` / `eval_experiment` plotting tests were `pytest.importorskip("plotly")`-ing themselves away and had **never run**.
- New `tests/unit/test_dependency_declarations.py` asserts every `importorskip` target in the suite is a declared dependency *and* is actually importable.

### Tests that asserted nothing, fixed
- **`image_upload_test.py`** — real bug in the test: `ModelFactory.list_functions(config.TEAM_API_KEY)` passed the key as the **`verbose` positional**, not `api_key`. It only passed because a non-empty key is truthy, so the test silently depended on a credential being set. Now `list_functions(True, api_key=...)`.
- Gave the "should not raise" tests in `utility_test.py`, `test_api_key.py`, `test_agent_budget.py` and `test_v2_agent_v3_compat.py` real assertions on the *effect* — request path and count, purity of validation (valid input survives untouched, nothing fabricated), and absence of a `DeprecationWarning` verified via `record=True` rather than `simplefilter("error")`.

### New v2 effect-based coverage
- **`test_resource_paths.py`** — asserts the backend path each v2 resource actually talks to for `get`/`search`/`create`/`delete`, plus Skill download / file upload / folder upload. The path table is kept as literals on purpose: it's the specification, not a mirror of the constant under test.
- **`test_upload_headers.py`** — asserts the presigned-URL request carries the Authorization token, the S3 PUT carries `Content-Type` and **leaks no credential**, and temp vs permanent uploads hit their respective endpoints.

## Verification

Ran locally in a clean venv with the `test` extra, no `TEAM_API_KEY` / `AIXPLAIN_API_KEY` / `BACKEND_URL` set:

```
$ coverage run -m pytest tests/unit -q
1528 passed in 16.05s

$ coverage report --fail-under=62   -> exit 0   (TOTAL 21164 stmts, 65%)
$ coverage report --fail-under=99   -> exit 2   (gate fails as expected)
$ coverage report | grep -c '^tests/'  -> 0     (test files no longer measured)
```

Assertion guard confirmed in the failing direction with a temporary probe:

```
ERROR: Tests with no assertion (add one, or allowlist it with a written reason
in ASSERT_FREE_ALLOWLIST in tests/conftest.py):
  tests/unit/zz_guard_probe_test.py::test_probe_has_no_assertion
```

All pre-commit hooks pass, including `pytest-check` under the updated hook dependencies.

## Reviewer notes

- The `COVERAGE_FLOOR` value (62) is the one knob worth arguing about — it's in the workflow `env` block, deliberately visible.
- The accepted v1 no-credential-message regression in the note above is the only behaviour change outside tests and CI.
