### PR TITLE
fix(v2/rlm): restore max_iterations default to 10 (regression from BUG-936)

### DIFF
--- a/aixplain/v2/rlm.py
+++ b/aixplain/v2/rlm.py
@@ -699,7 +699,7 @@ class RLM(BaseResource, ToolableMixin):
     Attributes:
         orchestrator_id: Platform model ID of the orchestrator LLM.
         worker_id: Platform model ID of the worker LLM.
-        max_iterations: Maximum orchestrator loop iterations (default 12). A
+        max_iterations: Maximum orchestrator loop iterations (default 10). A
             batch of ``llm_query`` calls costs two iterations in recursive mode
             — one to submit the prompts and one to consume the answers.
         timeout: Maximum wall-clock seconds per ``run()`` call (default 600).
@@ -711,7 +711,7 @@ class RLM(BaseResource, ToolableMixin):
     # Serializable configuration fields
     orchestrator_id: str = field(default="")
     worker_id: str = field(default="")
-    max_iterations: int = field(default=12)
+    max_iterations: int = field(default=10)
     timeout: float = field(default=600.0)
 
     # RAG mode — optional pre-built aIR index. When empty, mode="rag" creates


### PR DESCRIPTION
## What
Revert the RLM `max_iterations` default from 12 back to 10 (field + docstring).

## Why
Merged PR #1042 (BUG-936, credential-handling scope) incidentally changed the default 10→12. That:
- regressed the documented contract — `tests/functional/v2/test_rlm.py::TestRLMCreation::test_create_rlm` asserts `max_iterations == 10  # default` (integration run on `development` failed `assert 12 == 10`);
- silently raised per-run LLM cost (two extra orchestrator iterations).

## Scope
Two lines in `aixplain/v2/rlm.py`. No behavior change beyond restoring the prior default. Unit suite green (`tests/unit/rlm_test.py` 90 passed).

Found by the `development` integration run https://github.com/aixplain/aiXplain/actions/runs/31691819799