### PR TITLE
fix(v2): make debugger agent configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,3 +230,10 @@ Before finishing, check the following:
 | **Meta-agent** | Agents that improve other agents. The **Evolver** monitors KPIs and refines behavior. |
 | **Static orchestration** | Deterministic execution with predefined `AgentTask` ordering. |
 | **Dynamic orchestration** | Adaptive execution where the Mentalist generates the plan at runtime (default). |
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -534,6 +534,7 @@ class AgentRunResult(Result):
         self,
         prompt: Optional[str] = None,
         execution_id: Optional[str] = None,
+        debugger_agent_id: Optional[str] = None,
         **kwargs: Any,
     ) -> "DebugResult":
         """Debug this agent response using the Debugger meta-agent.
@@ -551,6 +552,9 @@ class AgentRunResult(Result):
             execution_id: Optional execution ID (poll ID) for the run. If not provided,
                          it will be extracted from the response's request_id or poll URL.
                          This allows the debugger to fetch additional logs and information.
+            debugger_agent_id: Optional debugger agent ID override. If not provided,
+                               uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+                               default debugger agent ID.
             **kwargs: Additional parameters to pass to the debugger.
 
         Returns:
@@ -565,6 +569,7 @@ class AgentRunResult(Result):
             debug_result = response.debug()  # Uses default prompt
             debug_result = response.debug("Why did it take so long?")  # Custom prompt
             debug_result = response.debug(execution_id="abc-123")  # With explicit ID
+            debug_result = response.debug(debugger_agent_id="my-debugger-id")  # With explicit debugger
             print(debug_result.analysis)
         """
         from .meta_agents import Debugger, DebugResult
@@ -578,7 +583,13 @@ class AgentRunResult(Result):
         # Create a bound Debugger class with the context
         BoundDebugger = type("Debugger", (Debugger,), {"context": self._context})
         debugger = BoundDebugger()
-        return debugger.debug_response(self, prompt=prompt, execution_id=execution_id, **kwargs)
+        return debugger.debug_response(
+            self,
+            prompt=prompt,
+            execution_id=execution_id,
+            debugger_agent_id=debugger_agent_id,
+            **kwargs,
+        )
 
 
 @dataclass_json

--- a/aixplain/v2/meta_agents.py
+++ b/aixplain/v2/meta_agents.py
@@ -21,8 +21,13 @@ Example usage:
     response = agent.run("Hello!")
     debug_result = response.debug()  # Uses default prompt
     debug_result = response.debug("Why did it take so long?")  # Custom prompt
+
+The debugger agent can be overridden per call with ``debugger_agent_id`` or by
+setting ``AIXPLAIN_DEBUGGER_AGENT_ID``. The explicit argument takes precedence,
+followed by the environment variable and then the default agent ID.
 """
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union, TYPE_CHECKING
 from dataclasses_json import dataclass_json, config
@@ -34,7 +39,22 @@ if TYPE_CHECKING:
 
 
 # Debugger agent ID - pre-configured aiXplain agent for debugging
-DEBUGGER_AGENT_ID = "696fdccad63e898317c097a0"
+DEBUGGER_AGENT_ID = "6a83989b20d5ce8082cdc775"
+
+
+def _resolve_debugger_agent_id(debugger_agent_id: Optional[str] = None) -> str:
+    """Resolve the debugger agent ID using the configured precedence.
+
+    Args:
+        debugger_agent_id: Optional explicit debugger agent ID.
+
+    Returns:
+        The explicit ID, the call-time environment override, or the default ID.
+    """
+    if debugger_agent_id is not None:
+        return debugger_agent_id
+
+    return os.getenv("AIXPLAIN_DEBUGGER_AGENT_ID") or DEBUGGER_AGENT_ID
 
 
 @dataclass_json
@@ -85,6 +105,9 @@ class Debugger:
     The Debugger uses a pre-configured aiXplain agent to provide insights into
     agent runs, errors, and potential improvements.
 
+    The debugger agent can be overridden per call with ``debugger_agent_id`` or
+    by setting ``AIXPLAIN_DEBUGGER_AGENT_ID``.
+
     Attributes:
         context: The Aixplain client context for API access.
 
@@ -115,8 +138,11 @@ class Debugger:
                 "Use: aix = Aixplain('<api_key>'); debugger = aix.Debugger()"
             )
 
-    def _get_debugger_agent(self) -> Any:
+    def _get_debugger_agent(self, debugger_agent_id: Optional[str] = None) -> Any:
         """Get the pre-configured debugger agent.
+
+        Args:
+            debugger_agent_id: Optional explicit debugger agent ID.
 
         Returns:
             The debugger Agent instance.
@@ -125,12 +151,13 @@ class Debugger:
 
         # Create a dynamically bound Agent class with our context
         BoundAgent = type("Agent", (Agent,), {"context": self.context})
-        return BoundAgent.get(DEBUGGER_AGENT_ID)
+        return BoundAgent.get(_resolve_debugger_agent_id(debugger_agent_id))
 
     def run(
         self,
         content: Optional[str] = None,
         prompt: Optional[str] = None,
+        debugger_agent_id: Optional[str] = None,
         **kwargs: Any,
     ) -> DebugResult:
         """Run the debugger on provided content.
@@ -143,6 +170,9 @@ class Debugger:
                     error messages, or any text requiring analysis.
             prompt: Optional custom prompt to guide the debugging analysis.
                    If not provided, uses a default debugging prompt.
+            debugger_agent_id: Optional debugger agent ID override. If not provided,
+                               uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+                               default debugger agent ID.
             **kwargs: Additional parameters to pass to the underlying agent.
 
         Returns:
@@ -157,7 +187,7 @@ class Debugger:
         query = self._build_query(content=content, prompt=prompt)
 
         # Get the debugger agent and run
-        agent = self._get_debugger_agent()
+        agent = self._get_debugger_agent(debugger_agent_id=debugger_agent_id)
         kwargs.setdefault("run_response_generation", True)
         agent_result = agent.run(query=query, **kwargs)
 
@@ -169,6 +199,7 @@ class Debugger:
         response: "AgentRunResult",
         prompt: Optional[str] = None,
         execution_id: Optional[str] = None,
+        debugger_agent_id: Optional[str] = None,
         **kwargs: Any,
     ) -> DebugResult:
         """Debug an agent response.
@@ -183,6 +214,9 @@ class Debugger:
                          extracted from the response's request_id or poll URL.
                          The execution_id allows the debugger to fetch additional
                          information like logs from the backend.
+            debugger_agent_id: Optional debugger agent ID override. If not provided,
+                               uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+                               default debugger agent ID.
             **kwargs: Additional parameters to pass to the underlying agent.
 
         Returns:
@@ -199,7 +233,7 @@ class Debugger:
         content = self._serialize_response(response, execution_id_override=execution_id)
 
         # Run debugging with the serialized content
-        return self.run(content=content, prompt=prompt, **kwargs)
+        return self.run(content=content, prompt=prompt, debugger_agent_id=debugger_agent_id, **kwargs)
 
     def _build_query(
         self,

--- a/docs/api-reference/python/aixplain/v2/agent.md
+++ b/docs/api-reference/python/aixplain/v2/agent.md
@@ -11,7 +11,7 @@ Agent module for aiXplain v2 SDK.
 class ConversationMessage(TypedDict)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L45)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L45)
 
 Type definition for a conversation message in agent history.
 
@@ -29,7 +29,7 @@ Type definition for a conversation message in agent history.
 def validate_history(history: List[Dict[str, Any]]) -> bool
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L62)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L62)
 
 Validates conversation history for agent sessions.
 
@@ -65,7 +65,7 @@ with each message containing the required &#x27;role&#x27; and &#x27;content&#x2
 class OutputFormat(str, Enum)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L120)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L120)
 
 Output format options for agent responses.
 
@@ -75,7 +75,7 @@ Output format options for agent responses.
 class ContextOverflowStrategy(str, Enum)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L128)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L128)
 
 Strategy for condensing the working context when a run exceeds the model&#x27;s context window.
 
@@ -96,7 +96,7 @@ Available in SDK 0.2.46+ (use the current 0.2.47). Set it as the agent&#x27;s sa
 class AgentRunParams(BaseRunParams)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L230)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L230)
 
 Parameters for running an agent.
 
@@ -140,7 +140,7 @@ Parameters for running an agent.
 class Budget()
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L285)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L285)
 
 Budget caps governing an agent run (cost / duration / iterations).
 
@@ -167,7 +167,7 @@ from ``to_dict()``.
 class AgentResponseData()
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L319)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L319)
 
 Data structure for agent response.
 
@@ -177,7 +177,7 @@ Data structure for agent response.
 def __post_init__() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L340)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L340)
 
 Assemble the nested ``governance`` dict from the flat wire fields.
 
@@ -190,7 +190,7 @@ Assemble the nested ``governance`` dict from the flat wire fields.
 class AgentRunResult(Result)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L352)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L352)
 
 Result from running an agent.
 
@@ -204,7 +204,7 @@ Override type from base class
 def __post_init__() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L362)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L362)
 
 Promote diagnostic codes the backend nests under ``data``.
 
@@ -218,7 +218,7 @@ inside ``executionStats`` on older builds), never top-level.
 def execution_id() -> Optional[str]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L401)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L401)
 
 Extract the execution ID from the poll URL or request_id.
 
@@ -235,10 +235,11 @@ without persisting the full URL.
 ```python
 def debug(prompt: Optional[str] = None,
           execution_id: Optional[str] = None,
+          debugger_agent_id: Optional[str] = None,
           **kwargs: Any) -> "DebugResult"
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L421)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L421)
 
 Debug this agent response using the Debugger meta-agent.
 
@@ -256,6 +257,9 @@ use the Debugger directly: aix.Debugger().debug_response(result)
 - `execution_id` - Optional execution ID (poll ID) for the run. If not provided,
   it will be extracted from the response&#x27;s request_id or poll URL.
   This allows the debugger to fetch additional logs and information.
+- `debugger_agent_id` - Optional debugger agent ID override. If not provided,
+  uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+  default debugger agent ID.
 - `**kwargs` - Additional parameters to pass to the debugger.
   
 
@@ -276,6 +280,7 @@ use the Debugger directly: aix.Debugger().debug_response(result)
   debug_result = response.debug()  # Uses default prompt
   debug_result = response.debug(&quot;Why did it take so long?&quot;)  # Custom prompt
   debug_result = response.debug(execution_id=&quot;abc-123&quot;)  # With explicit ID
+  debug_result = response.debug(debugger_agent_id=&quot;my-debugger-id&quot;)  # With explicit debugger
   print(debug_result.analysis)
 
 ### Task Objects
@@ -287,7 +292,7 @@ use the Debugger directly: aix.Debugger().debug_response(result)
 class Task()
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L474)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L485)
 
 A task definition for agent workflows.
 
@@ -297,7 +302,7 @@ A task definition for agent workflows.
 def __post_init__() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L482)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L493)
 
 Initialize task dependencies after dataclass creation.
 
@@ -314,7 +319,7 @@ class Agent(BaseResource, SearchResourceMixin[BaseSearchParams, "Agent"],
             RunnableResourceMixin[AgentRunParams, AgentRunResult])
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L492)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L503)
 
 Agent resource class.
 
@@ -324,7 +329,7 @@ Agent resource class.
 def __post_init__() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L596)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L607)
 
 Initialize agent after dataclass creation.
 
@@ -334,7 +339,7 @@ Initialize agent after dataclass creation.
 def __setattr__(name: str, value: Any) -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L682)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L693)
 
 Keep ``self.budget`` a (never-None) ``Budget`` instance.
 
@@ -351,7 +356,7 @@ by the time ``__post_init__`` executes.
 def mark_as_deleted() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L723)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L734)
 
 Mark the agent as deleted by setting status to DELETED and calling parent method.
 
@@ -362,7 +367,7 @@ def before_run(*args: Any,
                **kwargs: Unpack[AgentRunParams]) -> Optional[AgentRunResult]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L788)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L799)
 
 Hook called before running the agent to validate and prepare state.
 
@@ -373,7 +378,7 @@ def on_poll(response: AgentRunResult,
             **kwargs: Unpack[AgentRunParams]) -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L806)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L817)
 
 Hook called after each poll to update progress display.
 
@@ -389,7 +394,7 @@ def after_run(result: Union[AgentRunResult, Exception], *args: Any,
               **kwargs: Unpack[AgentRunParams]) -> Optional[AgentRunResult]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L818)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L829)
 
 Hook called after running the agent for result transformation.
 
@@ -399,7 +404,7 @@ Hook called after running the agent for result transformation.
 def run(*args: Any, **kwargs: Unpack[AgentRunParams]) -> AgentRunResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L921)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L932)
 
 Run the agent with optional progress display.
 
@@ -434,7 +439,7 @@ Run the agent with optional progress display.
 def run_async(*args: Any, **kwargs: Unpack[AgentRunParams]) -> AgentRunResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L956)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L967)
 
 Run the agent asynchronously.
 
@@ -459,7 +464,7 @@ Run the agent asynchronously.
 def poll(poll_url: str) -> AgentRunResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1003)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1014)
 
 Poll for the result of an asynchronous agent execution.
 
@@ -486,7 +491,7 @@ def sync_poll(poll_url: str,
               **kwargs: Unpack[AgentRunParams]) -> AgentRunResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1021)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1032)
 
 Poll until an asynchronous agent execution completes.
 
@@ -509,7 +514,7 @@ Accepts either a full URL or a bare execution ID (see
 def save(*args: Any, **kwargs: Any) -> "Agent"
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1068)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1079)
 
 Save the agent with dependency management.
 
@@ -539,7 +544,7 @@ child components before the agent itself is saved.
 def before_save(*args: Any, **kwargs: Any) -> Optional[dict]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1270)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1281)
 
 Callback to be called before the resource is saved.
 
@@ -552,7 +557,7 @@ def after_duplicate(result: Union["Agent", Exception],
                     **kwargs: Any) -> Optional["Agent"]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1285)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1296)
 
 Callback called after the agent is duplicated.
 
@@ -566,7 +571,7 @@ def duplicate(duplicate_subagents: bool = False,
               name: Optional[str] = None) -> "Agent"
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1295)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1306)
 
 Duplicate this agent on the aiXplain platform (server-side).
 
@@ -601,7 +606,7 @@ def search(cls: type["Agent"],
            **kwargs: Unpack[BaseSearchParams]) -> "Page[Agent]"
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1334)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1345)
 
 Search agents with optional query and filtering.
 
@@ -622,7 +627,7 @@ Search agents with optional query and filtering.
 def llm_id() -> str
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1722)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1733)
 
 Return main LLM id whether llm is a string or Model.
 
@@ -632,7 +637,7 @@ Return main LLM id whether llm is a string or Model.
 def build_save_payload(**kwargs: Any) -> dict
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1730)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1741)
 
 Build the payload for the save action.
 
@@ -642,7 +647,7 @@ Build the payload for the save action.
 def build_run_payload(**kwargs: Unpack[AgentRunParams]) -> dict
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L1847)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L1858)
 
 Build the payload for the run action.
 

--- a/docs/api-reference/python/aixplain/v2/meta_agents.md
+++ b/docs/api-reference/python/aixplain/v2/meta_agents.md
@@ -27,6 +27,10 @@ Example usage:
     debug_result = response.debug()  # Uses default prompt
     debug_result = response.debug(&quot;Why did it take so long?&quot;)  # Custom prompt
 
+The debugger agent can be overridden per call with ``debugger_agent_id`` or by
+setting ``AIXPLAIN_DEBUGGER_AGENT_ID``. The explicit argument takes precedence,
+followed by the environment variable and then the default agent ID.
+
 ### DebugResult Objects
 
 ```python
@@ -36,7 +40,7 @@ Example usage:
 class DebugResult(Result)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L42)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L62)
 
 Result from running the Debugger meta-agent.
 
@@ -56,7 +60,7 @@ Result from running the Debugger meta-agent.
 def analysis() -> Optional[str]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L61)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L81)
 
 Extract the debugging analysis text from the result data.
 
@@ -70,12 +74,15 @@ Extract the debugging analysis text from the result data.
 class Debugger()
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L82)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L102)
 
 Meta-agent for debugging and analyzing agent responses.
 
 The Debugger uses a pre-configured aiXplain agent to provide insights into
 agent runs, errors, and potential improvements.
+
+The debugger agent can be overridden per call with ``debugger_agent_id`` or
+by setting ``AIXPLAIN_DEBUGGER_AGENT_ID``.
 
 **Attributes**:
 
@@ -101,7 +108,7 @@ agent runs, errors, and potential improvements.
 def __init__() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L106)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L129)
 
 Initialize the Debugger.
 
@@ -113,10 +120,11 @@ when creating the Debugger class dynamically.
 ```python
 def run(content: Optional[str] = None,
         prompt: Optional[str] = None,
+        debugger_agent_id: Optional[str] = None,
         **kwargs: Any) -> DebugResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L130)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L156)
 
 Run the debugger on provided content.
 
@@ -129,6 +137,9 @@ or agent output directly.
   error messages, or any text requiring analysis.
 - `prompt` - Optional custom prompt to guide the debugging analysis.
   If not provided, uses a default debugging prompt.
+- `debugger_agent_id` - Optional debugger agent ID override. If not provided,
+  uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+  default debugger agent ID.
 - `**kwargs` - Additional parameters to pass to the underlying agent.
   
 
@@ -149,10 +160,11 @@ or agent output directly.
 def debug_response(response: "AgentRunResult",
                    prompt: Optional[str] = None,
                    execution_id: Optional[str] = None,
+                   debugger_agent_id: Optional[str] = None,
                    **kwargs: Any) -> DebugResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L167)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L197)
 
 Debug an agent response.
 
@@ -167,6 +179,9 @@ insights into what happened during the agent execution.
   extracted from the response&#x27;s request_id or poll URL.
   The execution_id allows the debugger to fetch additional
   information like logs from the backend.
+- `debugger_agent_id` - Optional debugger agent ID override. If not provided,
+  uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+  default debugger agent ID.
 - `**kwargs` - Additional parameters to pass to the underlying agent.
   
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -729,10 +729,11 @@ without persisting the full URL.
 ```python
 def debug(prompt: Optional[str] = None,
           execution_id: Optional[str] = None,
+          debugger_agent_id: Optional[str] = None,
           **kwargs: Any) -> "DebugResult"
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/agent.py#L209)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/agent.py#L421)
 
 Debug this agent response using the Debugger meta-agent.
 
@@ -750,6 +751,9 @@ use the Debugger directly: aix.Debugger().debug_response(result)
 - `execution_id` - Optional execution ID (poll ID) for the run. If not provided,
   it will be extracted from the response's request_id or poll URL.
   This allows the debugger to fetch additional logs and information.
+- `debugger_agent_id` - Optional debugger agent ID override. If not provided,
+  uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+  default debugger agent ID.
 - `**kwargs` - Additional parameters to pass to the debugger.
   
 
@@ -770,6 +774,7 @@ use the Debugger directly: aix.Debugger().debug_response(result)
   debug_result = response.debug()  # Uses default prompt
   debug_result = response.debug("Why did it take so long?")  # Custom prompt
   debug_result = response.debug(execution_id="abc-123")  # With explicit ID
+  debug_result = response.debug(debugger_agent_id="my-debugger-id")  # With explicit debugger
   print(debug_result.analysis)
 
 ### Task Objects
@@ -2966,6 +2971,10 @@ Example usage:
     debug_result = response.debug()  # Uses default prompt
     debug_result = response.debug("Why did it take so long?")  # Custom prompt
 
+The debugger agent can be overridden per call with ``debugger_agent_id`` or by
+setting ``AIXPLAIN_DEBUGGER_AGENT_ID``. The explicit argument takes precedence,
+followed by the environment variable and then the default agent ID.
+
 ### DebugResult Objects
 
 ```python
@@ -2975,7 +2984,7 @@ Example usage:
 class DebugResult(Result)
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L42)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L62)
 
 Result from running the Debugger meta-agent.
 
@@ -2995,7 +3004,7 @@ Result from running the Debugger meta-agent.
 def analysis() -> Optional[str]
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L61)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L81)
 
 Extract the debugging analysis text from the result data.
 
@@ -3009,12 +3018,15 @@ Extract the debugging analysis text from the result data.
 class Debugger()
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L82)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L102)
 
 Meta-agent for debugging and analyzing agent responses.
 
 The Debugger uses a pre-configured aiXplain agent to provide insights into
 agent runs, errors, and potential improvements.
+
+The debugger agent can be overridden per call with ``debugger_agent_id`` or
+by setting ``AIXPLAIN_DEBUGGER_AGENT_ID``.
 
 **Attributes**:
 
@@ -3040,7 +3052,7 @@ agent runs, errors, and potential improvements.
 def __init__() -> None
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L106)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L129)
 
 Initialize the Debugger.
 
@@ -3052,10 +3064,11 @@ when creating the Debugger class dynamically.
 ```python
 def run(content: Optional[str] = None,
         prompt: Optional[str] = None,
+        debugger_agent_id: Optional[str] = None,
         **kwargs: Any) -> DebugResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L130)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L156)
 
 Run the debugger on provided content.
 
@@ -3068,6 +3081,9 @@ or agent output directly.
   error messages, or any text requiring analysis.
 - `prompt` - Optional custom prompt to guide the debugging analysis.
   If not provided, uses a default debugging prompt.
+- `debugger_agent_id` - Optional debugger agent ID override. If not provided,
+  uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+  default debugger agent ID.
 - `**kwargs` - Additional parameters to pass to the underlying agent.
   
 
@@ -3088,10 +3104,11 @@ or agent output directly.
 def debug_response(response: "AgentRunResult",
                    prompt: Optional[str] = None,
                    execution_id: Optional[str] = None,
+                   debugger_agent_id: Optional[str] = None,
                    **kwargs: Any) -> DebugResult
 ```
 
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/meta_agents.py#L167)
+[[view_source]](https://github.com/aixplain/aiXplain/blob/fm/sdk-debugger-agent-id-e5/aixplain/v2/meta_agents.py#L197)
 
 Debug an agent response.
 
@@ -3106,6 +3123,9 @@ insights into what happened during the agent execution.
   extracted from the response's request_id or poll URL.
   The execution_id allows the debugger to fetch additional
   information like logs from the backend.
+- `debugger_agent_id` - Optional debugger agent ID override. If not provided,
+  uses AIXPLAIN_DEBUGGER_AGENT_ID at call time, then the
+  default debugger agent ID.
 - `**kwargs` - Additional parameters to pass to the underlying agent.
   
 

--- a/tests/unit/v2/test_meta_agents.py
+++ b/tests/unit/v2/test_meta_agents.py
@@ -674,6 +674,18 @@ class TestDebuggerRun:
         assert call_kwargs.get("timeout") == 60
         assert call_kwargs.get("custom_param") == "value"
 
+    def test_run_passes_debugger_agent_id(self):
+        """Should pass the debugger agent ID to the agent resolver."""
+        debugger = self._create_debugger()
+
+        mock_agent = Mock()
+        mock_agent.run.return_value = AgentRunResult(status="SUCCESS", completed=True)
+
+        with patch.object(debugger, "_get_debugger_agent", return_value=mock_agent) as mock_get:
+            debugger.run(content="Content", debugger_agent_id="custom-debugger-id")
+
+        mock_get.assert_called_once_with(debugger_agent_id="custom-debugger-id")
+
 
 # =============================================================================
 # Debugger.debug_response Tests
@@ -767,6 +779,16 @@ class TestDebuggerDebugResponse:
         assert call_kwargs.get("timeout") == 120
         assert call_kwargs.get("custom") == "value"
 
+    def test_debug_response_passes_debugger_agent_id(self):
+        """Should pass the debugger agent ID to run method."""
+        debugger = self._create_debugger()
+        response = AgentRunResult(status="SUCCESS", completed=True)
+
+        with patch.object(debugger, "run", return_value=DebugResult(status="SUCCESS", completed=True)) as mock_run:
+            debugger.debug_response(response, debugger_agent_id="custom-debugger-id")
+
+        assert mock_run.call_args.kwargs["debugger_agent_id"] == "custom-debugger-id"
+
 
 # =============================================================================
 # Debugger._get_debugger_agent Tests
@@ -776,8 +798,9 @@ class TestDebuggerDebugResponse:
 class TestDebuggerGetDebuggerAgent:
     """Tests for Debugger._get_debugger_agent method."""
 
-    def test_get_debugger_agent_uses_correct_id(self):
+    def test_get_debugger_agent_uses_correct_id(self, monkeypatch):
         """Should call Agent.get with DEBUGGER_AGENT_ID."""
+        monkeypatch.delenv("AIXPLAIN_DEBUGGER_AGENT_ID", raising=False)
         mock_context = Mock()
         BoundDebugger = type("Debugger", (Debugger,), {"context": mock_context})
         debugger = BoundDebugger()
@@ -795,9 +818,51 @@ class TestDebuggerGetDebuggerAgent:
             mock_get.assert_called_once_with(DEBUGGER_AGENT_ID)
             assert agent is mock_agent
 
+    def test_get_debugger_agent_uses_environment_override(self, monkeypatch):
+        """Should use the environment override when no explicit ID is provided."""
+        mock_context = Mock()
+        BoundDebugger = type("Debugger", (Debugger,), {"context": mock_context})
+        debugger = BoundDebugger()
+
+        from aixplain.v2.agent import Agent
+
+        with patch.object(Agent, "get", return_value=Mock()) as mock_get:
+            monkeypatch.setenv("AIXPLAIN_DEBUGGER_AGENT_ID", "environment-debugger-id")
+            debugger._get_debugger_agent()
+
+        mock_get.assert_called_once_with("environment-debugger-id")
+
+    def test_get_debugger_agent_reads_environment_at_call_time(self, monkeypatch):
+        """Should honor an environment override set after module import."""
+        mock_context = Mock()
+        BoundDebugger = type("Debugger", (Debugger,), {"context": mock_context})
+        debugger = BoundDebugger()
+
+        from aixplain.v2.agent import Agent
+
+        with patch.object(Agent, "get", return_value=Mock()) as mock_get:
+            monkeypatch.setenv("AIXPLAIN_DEBUGGER_AGENT_ID", "late-environment-debugger-id")
+            debugger._get_debugger_agent()
+
+        mock_get.assert_called_once_with("late-environment-debugger-id")
+
+    def test_get_debugger_agent_explicit_id_overrides_environment(self, monkeypatch):
+        """Should prefer an explicit debugger agent ID over the environment."""
+        mock_context = Mock()
+        BoundDebugger = type("Debugger", (Debugger,), {"context": mock_context})
+        debugger = BoundDebugger()
+
+        from aixplain.v2.agent import Agent
+
+        with patch.object(Agent, "get", return_value=Mock()) as mock_get:
+            monkeypatch.setenv("AIXPLAIN_DEBUGGER_AGENT_ID", "environment-debugger-id")
+            debugger._get_debugger_agent("explicit-debugger-id")
+
+        mock_get.assert_called_once_with("explicit-debugger-id")
+
     def test_debugger_agent_id_constant(self):
         """DEBUGGER_AGENT_ID should have expected value."""
-        assert DEBUGGER_AGENT_ID == "696fdccad63e898317c097a0"
+        assert DEBUGGER_AGENT_ID == "6a83989b20d5ce8082cdc775"
 
 
 # =============================================================================
@@ -879,6 +944,19 @@ class TestAgentRunResultDebug:
 
         call_kwargs = mock_debug_response.call_args.kwargs
         assert call_kwargs.get("execution_id") == "exec-123"
+
+    def test_debug_passes_debugger_agent_id(self):
+        """Should forward debugger_agent_id to debugger."""
+        result = AgentRunResult(status="SUCCESS", completed=True)
+        result._context = Mock()
+
+        mock_debug_result = DebugResult(status="SUCCESS", completed=True)
+
+        with patch.object(Debugger, "debug_response", return_value=mock_debug_result) as mock_debug_response:
+            with patch.object(Debugger, "__init__", return_value=None):
+                result.debug(debugger_agent_id="custom-debugger-id")
+
+        assert mock_debug_response.call_args.kwargs["debugger_agent_id"] == "custom-debugger-id"
 
     def test_debug_passes_kwargs(self):
         """Should forward additional kwargs to debugger."""


### PR DESCRIPTION
## Summary

The debugger previously resolved every request through one hardcoded agent ID. That permanently pinned `aix.Debugger().run(...)`, `Debugger.debug_response(...)`, and `response.debug()` to a single shared agent, so teams running their own debugger agent could not use these SDK entry points.

This change makes the target configurable through the new `debugger_agent_id` argument on all three entry points and changes the default to `6a83989b20d5ce8082cdc775` (aiXplain Debugger Agent c3).

Resolution precedence is:

1. Explicit `debugger_agent_id` argument.
2. `AIXPLAIN_DEBUGGER_AGENT_ID` environment variable.
3. The module-level `DEBUGGER_AGENT_ID` default.

The environment variable is read at call time, so changes made after importing the SDK are honored. `DEBUGGER_AGENT_ID` remains importable with the same name, making this non-breaking apart from the requested default-value change.

## Merge precondition

**The new default agent is currently deployed on dev only. It must be deployed to production before this PR merges.** Until then, production users can select an available agent with the explicit argument or environment override.

## Validation

- `.venv/bin/python -m pytest tests/unit/v2/test_meta_agents.py` — 61 passed.
- `ruff check aixplain/v2/meta_agents.py aixplain/v2/agent.py tests/unit/v2/test_meta_agents.py` — all checks passed.
- `ruff format --check aixplain/v2/meta_agents.py aixplain/v2/agent.py tests/unit/v2/test_meta_agents.py` — 3 files already formatted.
- Regenerated the committed debugger API references and LLM documentation sections.
