### PR TITLE
fix(v2): persist updated agent skills on save

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -820,6 +820,39 @@ class Agent(
             ]
             self.files = current_ids
 
+    @staticmethod
+    def _skill_reference_id(skill: Optional[Union[str, Dict[str, Any], "Skill"]]) -> Optional[str]:
+        """Return the backend ID represented by one Skill reference."""
+        if skill is None:
+            return None
+        if isinstance(skill, str):
+            return skill
+        if isinstance(skill, dict):
+            return skill.get("id") or skill.get("asset_id") or skill.get("assetId")
+        return skill.id
+
+    def _sync_skill_references(self) -> None:
+        """Capture direct mutations to ``agent.skills`` before validation or save."""
+        current = list(self.skills or [])
+        original = list(getattr(self, "_original_skills", []) or [])
+        # A None slot is a still-unsaved placeholder; only safe to refresh by position if lengths match.
+        same_length = len(current) == len(original)
+        effective_current = [
+            original[index] if skill is None and same_length else skill for index, skill in enumerate(current)
+        ]
+        current_ids = [self._skill_reference_id(skill) for skill in effective_current]
+        original_ids = [self._skill_reference_id(skill) for skill in original]
+        if current_ids != original_ids or any(not isinstance(skill, str) for skill in effective_current):
+            original_by_id = {
+                self._skill_reference_id(skill): skill
+                for skill in original
+                if self._skill_reference_id(skill) is not None
+            }
+            self._original_skills = [
+                original_by_id.get(skill, skill) if isinstance(skill, str) else skill for skill in effective_current
+            ]
+            self.skills = current_ids
+
         # TODO: Re-enable this validation after backend data consistency is fixed
         # if self.agents and (self.tasks or self.tools):
         #     raise ValueError(
@@ -1301,6 +1334,7 @@ class Agent(
     def _save_subcomponents(self) -> None:
         """Recursively save all unsaved child components."""
         self._sync_file_references()
+        self._sync_skill_references()
         failed_components = []
 
         # Save tools
@@ -1359,6 +1393,7 @@ class Agent(
     def _validate_run_dependencies(self) -> None:
         """Validate that all child components are saved before running."""
         self._sync_file_references()
+        self._sync_skill_references()
         unsaved_components = []
 
         # Check tools
@@ -1404,6 +1439,7 @@ class Agent(
     def _validate_dependencies(self) -> None:
         """Validate that all child components are saved."""
         self._sync_file_references()
+        self._sync_skill_references()
         unsaved_components = []
 
         # Check tools
@@ -1909,6 +1945,7 @@ class Agent(
     def build_save_payload(self, **kwargs: Any) -> dict:
         """Build the payload for the save action."""
         self._sync_file_references()
+        self._sync_skill_references()
         # Import Inspector from v2 module
         from .inspector import Inspector
 
@@ -1993,23 +2030,20 @@ class Agent(
 
         # Convert skills to API format. Skills follow the same wire design as
         # tools: each is sent as an object (via as_tool()), never a bare id.
-        if getattr(self, "_original_skills", None):
-            converted_skills = []
-            for skill in self._original_skills:
-                if isinstance(skill, ToolableMixin):
-                    skill_dict = skill.as_tool()
-                elif isinstance(skill, dict):
-                    skill_dict = skill
-                elif isinstance(skill, str):
-                    skill_dict = {"id": skill, "type": "skill", "asset_id": skill}
-                else:
-                    raise ValueError("A skill must be a Skill instance, a dict, or a skill id string.")
-                if not skill_dict.get("id"):
-                    raise ValueError("All skills must be saved before saving the agent.")
-                converted_skills.append(self._normalize_tool_dict_for_api(skill_dict))
-            payload["skills"] = converted_skills
-        else:
-            payload.pop("skills", None)
+        converted_skills = []
+        for skill in getattr(self, "_original_skills", []) or []:
+            if isinstance(skill, ToolableMixin):
+                skill_dict = skill.as_tool()
+            elif isinstance(skill, dict):
+                skill_dict = skill
+            elif isinstance(skill, str):
+                skill_dict = {"id": skill, "type": "skill", "asset_id": skill}
+            else:
+                raise ValueError("A skill must be a Skill instance, a dict, or a skill id string.")
+            if not skill_dict.get("id"):
+                raise ValueError("All skills must be saved before saving the agent.")
+            converted_skills.append(self._normalize_tool_dict_for_api(skill_dict))
+        payload["skills"] = converted_skills
 
         # Persistent Agent files are references to already-saved File assets.
         # Never upload them here and never reinterpret them as run attachments.

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -749,11 +749,13 @@ class Agent(
         # Convert to IDs for serialization (to_dict), using None as placeholder for unsaved agents
         self.agents = [a if isinstance(a, str) else a.get("id") if isinstance(a, dict) else a.id for a in self.agents]
 
-        # Skills behave exactly like agents: keep the originals to resolve ids
-        # at save time, and serialize as a list of ids.
+        # Keep originals to resolve ids at save time. Unsaved skills remain as
+        # objects in the public list so later list edits cannot lose them.
+        self._skills_ever_configured = bool(self.skills)
         self._original_skills = list(self.skills or [])
         self.skills = [
-            s if isinstance(s, str) else s.get("id") if isinstance(s, dict) else s.id for s in (self.skills or [])
+            skill if isinstance(skill, str) else (self._skill_reference_id(skill) or skill)
+            for skill in (self.skills or [])
         ]
 
         # Unsaved files keep the object itself, not None, so list edits never lose track of which is which.
@@ -820,6 +822,12 @@ class Agent(
             ]
             self.files = current_ids
 
+        # TODO: Re-enable this validation after backend data consistency is fixed
+        # if self.agents and (self.tasks or self.tools):
+        #     raise ValueError(
+        #         "Team agents cannot have tasks or tools. Please remove the tasks or tools and try again."
+        #     )
+
     @staticmethod
     def _skill_reference_id(skill: Optional[Union[str, Dict[str, Any], "Skill"]]) -> Optional[str]:
         """Return the backend ID represented by one Skill reference."""
@@ -842,7 +850,9 @@ class Agent(
         ]
         current_ids = [self._skill_reference_id(skill) for skill in effective_current]
         original_ids = [self._skill_reference_id(skill) for skill in original]
-        if current_ids != original_ids or any(not isinstance(skill, str) for skill in effective_current):
+        if current_ids != original_ids or any(isinstance(skill, (Skill, dict)) for skill in effective_current):
+            if current_ids != original_ids:
+                self._skills_ever_configured = True
             original_by_id = {
                 self._skill_reference_id(skill): skill
                 for skill in original
@@ -851,13 +861,7 @@ class Agent(
             self._original_skills = [
                 original_by_id.get(skill, skill) if isinstance(skill, str) else skill for skill in effective_current
             ]
-            self.skills = current_ids
-
-        # TODO: Re-enable this validation after backend data consistency is fixed
-        # if self.agents and (self.tasks or self.tools):
-        #     raise ValueError(
-        #         "Team agents cannot have tasks or tools. Please remove the tasks or tools and try again."
-        #     )
+            self.skills = [self._skill_reference_id(skill) or skill for skill in self._original_skills]
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Keep ``self.budget`` a (never-None) ``Budget`` instance.
@@ -2030,20 +2034,23 @@ class Agent(
 
         # Convert skills to API format. Skills follow the same wire design as
         # tools: each is sent as an object (via as_tool()), never a bare id.
-        converted_skills = []
-        for skill in getattr(self, "_original_skills", []) or []:
-            if isinstance(skill, ToolableMixin):
-                skill_dict = skill.as_tool()
-            elif isinstance(skill, dict):
-                skill_dict = skill
-            elif isinstance(skill, str):
-                skill_dict = {"id": skill, "type": "skill", "asset_id": skill}
-            else:
-                raise ValueError("A skill must be a Skill instance, a dict, or a skill id string.")
-            if not skill_dict.get("id"):
-                raise ValueError("All skills must be saved before saving the agent.")
-            converted_skills.append(self._normalize_tool_dict_for_api(skill_dict))
-        payload["skills"] = converted_skills
+        if getattr(self, "_skills_ever_configured", False):
+            converted_skills = []
+            for skill in getattr(self, "_original_skills", []) or []:
+                if isinstance(skill, ToolableMixin):
+                    skill_dict = skill.as_tool()
+                elif isinstance(skill, dict):
+                    skill_dict = skill
+                elif isinstance(skill, str):
+                    skill_dict = {"id": skill, "type": "skill", "asset_id": skill}
+                else:
+                    raise ValueError("A skill must be a Skill instance, a dict, or a skill id string.")
+                if not skill_dict.get("id"):
+                    raise ValueError("All skills must be saved before saving the agent.")
+                converted_skills.append(self._normalize_tool_dict_for_api(skill_dict))
+            payload["skills"] = converted_skills
+        else:
+            payload.pop("skills", None)
 
         # Persistent Agent files are references to already-saved File assets.
         # Never upload them here and never reinterpret them as run attachments.

--- a/tests/unit/v2/test_agent_skills.py
+++ b/tests/unit/v2/test_agent_skills.py
@@ -49,6 +49,29 @@ def test_clearing_agent_skills_emits_empty_list(aix):
     assert agent.build_save_payload()["skills"] == []
 
 
+def test_agent_never_configured_with_skills_omits_the_key(aix):
+    """An agent that never touched skills must not start sending skills=[]."""
+    agent = aix.Agent(name="plain-agent", instructions="hi")
+
+    assert "skills" not in agent.build_save_payload()
+
+
+def test_unsaved_skill_survives_validation_then_list_append(aix):
+    """Keep an unsaved Skill attached when the public list later changes length."""
+    unsaved = aix.Skill(name="Unsaved One")
+    saved = aix.Skill(id="saved-2", name="Two")
+    agent = aix.Agent(name="skill-agent", instructions="hi", skills=[unsaved])
+
+    with pytest.raises(ValueError, match="skill 'Unsaved One'.*saved before saving"):
+        agent._validate_dependencies()
+
+    agent.skills.append(saved)
+
+    with pytest.raises(ValueError, match="All skills must be saved before saving the agent"):
+        agent.build_save_payload()
+    assert agent._original_skills == [unsaved, saved]
+
+
 def test_save_subcomponents_uses_newly_assigned_skill(aix):
     """Recursively save an unsaved Skill assigned after Agent construction."""
     skill = aix.Skill(name="New Skill")

--- a/tests/unit/v2/test_agent_skills.py
+++ b/tests/unit/v2/test_agent_skills.py
@@ -1,0 +1,64 @@
+"""Tests for Skill references on v2 Agents."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from aixplain import Aixplain
+
+
+@pytest.fixture
+def aix() -> Aixplain:
+    """Return an isolated client."""
+    return Aixplain(api_key="test-key", backend_url="https://example.test")
+
+
+def test_replacing_fetched_agent_skills_changes_save_payload(aix):
+    """Use the current public skills list instead of its construction-time snapshot."""
+    agent = aix.Agent(
+        id="agent-id",
+        name="skill-agent",
+        skills=[{"id": "original-id", "name": "Original", "type": "skill"}],
+    )
+
+    agent.skills = ["replacement-id"]
+
+    assert agent.build_save_payload()["skills"] == [
+        {"id": "replacement-id", "type": "skill", "assetId": "replacement-id"}
+    ]
+
+
+def test_appending_skill_object_changes_save_payload(aix):
+    """Honor in-place additions to the public skills list."""
+    original = aix.Skill(id="original-id", name="Original")
+    added = aix.Skill(id="added-id", name="Added")
+    agent = aix.Agent(id="agent-id", name="skill-agent", skills=[original])
+
+    agent.skills.append(added)
+
+    assert [skill["id"] for skill in agent.build_save_payload()["skills"]] == ["original-id", "added-id"]
+    assert agent.skills == ["original-id", "added-id"]
+
+
+def test_clearing_agent_skills_emits_empty_list(aix):
+    """Allow callers to detach all skills on save."""
+    agent = aix.Agent(id="agent-id", name="skill-agent", skills=["original-id"])
+
+    agent.skills.clear()
+
+    assert agent.build_save_payload()["skills"] == []
+
+
+def test_save_subcomponents_uses_newly_assigned_skill(aix):
+    """Recursively save an unsaved Skill assigned after Agent construction."""
+    skill = aix.Skill(name="New Skill")
+    skill.save = Mock(side_effect=lambda: setattr(skill, "id", "new-skill-id") or skill)
+    aix.client.request = Mock(return_value={"id": "agent-id", "name": "skill-agent", "skills": []})
+    agent = aix.Agent(name="skill-agent")
+    agent.skills = [skill]
+
+    agent.save(save_subcomponents=True)
+
+    skill.save.assert_called_once_with()
+    request_payload = aix.client.request.call_args.kwargs["json"]
+    assert request_payload["skills"][0]["id"] == "new-skill-id"


### PR DESCRIPTION
Synchronize the public Agent.skills collection before validation and payload construction so replacements, mutations, and explicit clearing round-trip correctly. Add regression coverage for skill IDs, objects, clearing, and recursive saves.\n\nBUG-1166