### PR TITLE
fix(trigger): hydrate flat schedule attributes

### DIFF
--- a/aixplain/v2/trigger.py
+++ b/aixplain/v2/trigger.py
@@ -114,7 +114,7 @@ class TriggerConfiguration:
     days_of_month: Optional[List[int]] = field(default=None, metadata=dj_config(field_name="daysOfMonth"))
     run_at: Optional[str] = field(default=None, metadata=dj_config(field_name="runAt"))
     start_at: Optional[str] = field(default=None, metadata=dj_config(field_name="startAt"))
-    next_run_at: Optional[str] = field(default=None, metadata=dj_config(field_name="nextRunAt"))
+    next_run_at: Optional[str] = field(default=None, metadata=dj_config(field_name="nextRunAt", exclude=lambda x: True))
     repeat: Optional[TriggerRepeatRule] = None
 
 
@@ -399,8 +399,11 @@ class Trigger(
         if trigger_type == "external":
             payload["triggerId"] = self.trigger_id
         elif self.configuration is not None:
+            if self.id and (self.run_at is not None or self.every is not None or self.start_at is not None):
+                # Hydrated flat schedule fields (at/every/on/...) are the editable
+                # surface; rebuild so an edit made after fetch is actually sent.
+                self.configuration = self._build_configuration()
             configuration = self.configuration.to_dict()
-            configuration.pop("nextRunAt", None)
             payload["configuration"] = _strip_none(configuration)
         else:
             raise ValueError(

--- a/aixplain/v2/trigger.py
+++ b/aixplain/v2/trigger.py
@@ -114,6 +114,7 @@ class TriggerConfiguration:
     days_of_month: Optional[List[int]] = field(default=None, metadata=dj_config(field_name="daysOfMonth"))
     run_at: Optional[str] = field(default=None, metadata=dj_config(field_name="runAt"))
     start_at: Optional[str] = field(default=None, metadata=dj_config(field_name="startAt"))
+    next_run_at: Optional[str] = field(default=None, metadata=dj_config(field_name="nextRunAt"))
     repeat: Optional[TriggerRepeatRule] = None
 
 
@@ -218,11 +219,12 @@ class Trigger(
     def __post_init__(self) -> None:
         """Translate friendly construction kwargs into backend-shaped fields.
 
-        Skipped when rehydrating from the backend (``id`` already set), so that
-        ``from_dict`` in get/search/create is left untouched.
+        When rehydrating from the backend (``id`` already set), populate the
+        friendly schedule fields from ``configuration`` without rebuilding it.
         """
         if self.id is not None:
-            return  # rehydration path — nothing to translate
+            self._hydrate_schedule_fields()
+            return
 
         # Resolve the target agent -> assetId.
         if self.agent is not None and not self.asset_id:
@@ -240,6 +242,34 @@ class Trigger(
         elif self.run_at is not None or self.every is not None or self.start_at is not None:
             self.trigger_type = "time"
             self.configuration = self._build_configuration()
+
+    def _hydrate_schedule_fields(self) -> None:
+        """Populate friendly schedule attributes from a fetched configuration."""
+        config = self.configuration
+        if config is None:
+            return
+
+        self.timezone = config.timezone
+        self.run_at = config.run_at
+        self.at = config.time
+        self.start_at = config.start_at
+        if self.next_run_at is None:
+            self.next_run_at = config.next_run_at
+
+        if config.type == "daily":
+            self.every = "day"
+            self.interval = 1
+        elif config.type == "weekly":
+            self.every = "week"
+            self.interval = 1
+            self.on = config.days_of_week
+        elif config.type == "monthly":
+            self.every = "month"
+            self.interval = 1
+            self.on = config.days_of_month
+        elif config.type == "recurring" and config.repeat is not None:
+            self.every = config.repeat.unit
+            self.interval = 1 if config.repeat.every is None else config.repeat.every
 
     # ------------------------------------------------------------------
     # Event configuration
@@ -369,7 +399,9 @@ class Trigger(
         if trigger_type == "external":
             payload["triggerId"] = self.trigger_id
         elif self.configuration is not None:
-            payload["configuration"] = _strip_none(self.configuration.to_dict())
+            configuration = self.configuration.to_dict()
+            configuration.pop("nextRunAt", None)
+            payload["configuration"] = _strip_none(configuration)
         else:
             raise ValueError(
                 "A time trigger needs a schedule. Pass run_at=... (one-off) or "

--- a/tests/unit/v2/test_trigger.py
+++ b/tests/unit/v2/test_trigger.py
@@ -167,6 +167,23 @@ class TestBuildSavePayload:
         with pytest.raises(ValueError):
             t.build_save_payload()
 
+    def test_update_payload_excludes_nested_next_run_at(self):
+        t = Trigger.from_dict(
+            {
+                "id": "trig1",
+                "name": "Hourly",
+                "triggerType": "time",
+                "configuration": {
+                    "type": "recurring",
+                    "nextRunAt": "2026-01-01T02:00:00Z",
+                    "repeat": {"every": 2, "unit": "hour"},
+                },
+            }
+        )
+
+        assert t.next_run_at == "2026-01-01T02:00:00Z"
+        assert "nextRunAt" not in t.build_save_payload()["configuration"]
+
 
 # =============================================================================
 # Rehydration (get/search deserialization)
@@ -190,10 +207,50 @@ class TestRehydration:
         t = Trigger.from_dict(self._dto())
         assert t.id == "trig1" and t.asset_id == AGENT_ID and t.trigger_type == "time"
         assert t.schedule_type == "daily" and t.configuration.time == "09:00"
+        assert t.timezone == "Europe/London" and t.at == "09:00"
+        assert t.every == "day" and t.interval == 1
         assert t.next_run_at == "2026-07-14T09:00:00Z"
 
-    def test_post_init_not_run_on_rehydration(self):
-        # id present -> friendly translation skipped, enabled preserved from DTO (not forced True)
+    @pytest.mark.parametrize(
+        ("configuration", "expected"),
+        [
+            (
+                {"type": "once", "runAt": "2026-01-01T00:00:00Z", "timezone": "UTC"},
+                {"run_at": "2026-01-01T00:00:00Z", "timezone": "UTC"},
+            ),
+            (
+                {"type": "weekly", "time": "17:00", "daysOfWeek": ["mon", "thu"]},
+                {"every": "week", "at": "17:00", "on": ["mon", "thu"]},
+            ),
+            (
+                {"type": "monthly", "time": "09:00", "daysOfMonth": [1, 15]},
+                {"every": "month", "at": "09:00", "on": [1, 15]},
+            ),
+            (
+                {
+                    "type": "recurring",
+                    "startAt": "2026-01-01T00:00:00Z",
+                    "nextRunAt": "2026-01-01T02:00:00Z",
+                    "repeat": {"every": 2, "unit": "hour"},
+                },
+                {
+                    "every": "hour",
+                    "interval": 2,
+                    "start_at": "2026-01-01T00:00:00Z",
+                    "next_run_at": "2026-01-01T02:00:00Z",
+                },
+            ),
+        ],
+    )
+    def test_from_dict_hydrates_flat_schedule_fields(self, configuration, expected):
+        t = Trigger.from_dict(self._dto(configuration=configuration, nextRunAt=None))
+
+        assert t.schedule_type == configuration["type"]
+        for attribute, value in expected.items():
+            assert getattr(t, attribute) == value
+
+    def test_rehydration_preserves_backend_enabled_value(self):
+        # Rehydration must not apply the defaults used for locally constructed triggers.
         t = Trigger.from_dict(self._dto(enabled=False))
         assert t.enabled is False
 


### PR DESCRIPTION
Populate friendly Trigger schedule fields from backend configuration during rehydration, including recurrence and day mappings. Preserve top-level nextRunAt precedence while supporting a nested fallback, and exclude the nested read-only value from save payloads. Add focused coverage for once, daily, weekly, monthly, and recurring response shapes.