### PR TITLE
fix(v2): drop duplicated agent files init block introduced by merge

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -778,13 +778,6 @@ class Agent(
             file if isinstance(file, str) else (self._file_reference_id(file) or file) for file in (self.files or [])
         ]
 
-        # Unsaved files keep the object itself, not None, so list edits never lose track of which is which.
-        self._files_ever_configured = bool(self.files)
-        self._original_files = list(self.files or [])
-        self.files = [
-            file if isinstance(file, str) else (self._file_reference_id(file) or file) for file in (self.files or [])
-        ]
-
         if isinstance(self.output_format, OutputFormat):
             self.output_format = self.output_format.value
 


### PR DESCRIPTION
## Summary

The `Merge branch 'test' into development` commit (b9decea) duplicated the persistent-files initialization block in `Agent.__post_init__` — both merge parents carry it exactly once, the merge result twice.

The first pass snapshots the real `File` objects into `_original_files` and rewrites `self.files` to id strings. The duplicated second pass then re-snapshots `_original_files` from the already-stringified list, clobbering the `File` objects. As a result `build_save_payload` emitted bare `{id}` file references with `name`/`description` dropped.

This breaks 4 tests in `tests/unit/v2/test_agent_files.py` on `development` itself, which currently fails pre-commit CI on every PR targeting it (e.g. #1056).

## Fix

Remove the duplicate block, restoring the single-pass behavior both parents had. 7 deleted lines, no other changes.

## Testing

- `tests/unit/v2/test_agent_files.py`: 11 passed (was 4 failed, 7 passed)
- Full `tests/unit/v2` suite: 1286 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)