### PR TITLE
fix(v2): SEV2 correctness fixes for search filters, results, save() and run kwargs (BUG-1092, BUG-1094, BUG-1093, BUG-1091)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -350,6 +350,30 @@ Beyond the factories, three more legacy prefixes redirect into v1:
 | `from aixplain.modules import Agent, Model, ...` | `aix.Agent`, `aix.Model`, … — v2 resources replace the v1 domain objects |
 | `from aixplain.decorators import ...`, `aixplain.base`, `aixplain.processes` | Internal helpers with no public v2 counterpart |
 
+## v2 behavior notes
+
+### `search()` is strict about records it cannot parse
+
+`search()` (and the `list()` wrappers built on it) raises `ResourceError` if the
+API returns a record the SDK cannot deserialize, matching the long-standing
+contract of `get()`. Previously such records were logged and dropped while
+`Page.total` still counted them, so `len(page.results) < page.total` was a
+normal state and bulk loops skipped rows with no error.
+
+If you prefer to skip the bad records, opt in per call:
+
+```python
+page = aix.Model.search(strict=False)
+
+page.total    # never counts the records that were skipped
+page.skipped  # how many were skipped on this page
+```
+
+`strict=False` is a client-side option and is never sent to the backend. A
+resource class whose records are known to be heterogeneous can set
+`PAGINATE_STRICT = False` to make lenient listing its default; a per-call
+`strict=` always wins.
+
 ## Getting help
 
 - Open an issue at <https://github.com/aixplain/aiXplain/issues> — especially if a gap above blocks you; that feedback shapes the removal timeline.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -374,6 +374,37 @@ resource class whose records are known to be heterogeneous can set
 `PAGINATE_STRICT = False` to make lenient listing its default; a per-call
 `strict=` always wins.
 
+### A streamed run only reports `SUCCESS` when it finished
+
+`ModelResponseStreamer.status` used to become `SUCCESS` as soon as the
+connection ended, so an error event mid-generation, or a stream cut before its
+`[DONE]` marker, handed you a truncated answer that claimed to be complete. It
+now stays `FAILED` unless the stream terminated cleanly (a `[DONE]` marker, a
+terminal `finish_reason`, or a terminal `status` envelope), and an error event
+yields one final chunk carrying the reason:
+
+```python
+with model.run_stream(text="Explain LLMs") as stream:
+    for chunk in stream:
+        print(chunk.data, end="", flush=True)
+
+if stream.status != aix.ResponseStatus.SUCCESS:
+    ...  # the text above is partial
+```
+
+Iteration itself does not raise, so existing `for chunk in stream` loops keep
+working — but check `stream.status` (or `chunk.error_message`) before treating
+the concatenated text as a full answer.
+
+### A polled falsy result keeps its value and type
+
+`poll()` coerced any falsy `data` to `{}`, so a classifier that legitimately
+answers `0`, or a model whose correct answer is `""`, came back as `{}` — and
+`result.data.strip()` raised `AttributeError`. Falsy-but-present payloads
+(`""`, `0`, `False`, `[]`) now pass through unchanged, matching what the same
+model returns on the synchronous path. A genuinely absent (or `null`) `data`
+still arrives as `{}`.
+
 ## Getting help
 
 - Open an issue at <https://github.com/aixplain/aiXplain/issues> — especially if a gap above blocks you; that feedback shapes the removal timeline.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -352,27 +352,43 @@ Beyond the factories, three more legacy prefixes redirect into v1:
 
 ## v2 behavior notes
 
-### `search()` is strict about records it cannot parse
+### `search()` never reports more records than it returns
 
-`search()` (and the `list()` wrappers built on it) raises `ResourceError` if the
-API returns a record the SDK cannot deserialize, matching the long-standing
-contract of `get()`. Previously such records were logged and dropped while
-`Page.total` still counted them, so `len(page.results) < page.total` was a
-normal state and bulk loops skipped rows with no error.
+`search()` (and the `list()` wrappers built on it) used to log and drop any
+record the SDK could not deserialize while `Page.total` still counted it, so
+`len(page.results) < page.total` was a normal state and bulk loops skipped rows
+with no error.
 
-If you prefer to skip the bad records, opt in per call:
+Records the SDK cannot model — a new backend enum value, say — are still
+skipped rather than failing the whole listing, but the count no longer lies:
 
 ```python
-page = aix.Model.search(strict=False)
+page = aix.Model.search()
 
 page.total    # never counts the records that were skipped
 page.skipped  # how many were skipped on this page
 ```
 
-`strict=False` is a client-side option and is never sent to the backend. A
-resource class whose records are known to be heterogeneous can set
-`PAGINATE_STRICT = False` to make lenient listing its default; a per-call
-`strict=` always wins.
+Every skip is logged at `WARNING` with the reason. If you want the
+`get()`-like contract instead, where any unparseable record raises
+`ResourceError`, opt in per call with `aix.Model.search(strict=True)`, or set
+`PAGINATE_STRICT = True` on a resource class whose records must all parse; a
+per-call `strict=` always wins. `strict` is a client-side option and is never
+sent to the backend.
+
+A response that carries no readable item list at all — a renamed envelope, or
+an error body served with HTTP 200 — always raises `ResourceError`, because
+returning it as an empty page would be indistinguishable from a search that
+genuinely matched nothing. A present-but-empty (or `null`) item list is still a
+normal empty page.
+
+### `save()` on a deleted resource always raises `ResourceError`
+
+The guard that stops a deleted resource from being re-created raised
+`ValidationError` from `Agent.save()` and `File.save()` but `ResourceError`
+from every other resource's `save()`. Both derive from `AixplainV2Error`, so
+`except ResourceError` around a save caught only some of the paths. All of them
+now raise `ResourceError`.
 
 ### A streamed run only reports `SUCCESS` when it finished
 
@@ -395,6 +411,15 @@ if stream.status != aix.ResponseStatus.SUCCESS:
 Iteration itself does not raise, so existing `for chunk in stream` loops keep
 working — but check `stream.status` (or `chunk.error_message`) before treating
 the concatenated text as a full answer.
+
+### `run(stream=True)` works even when the model record omits the flag
+
+A backend record that does not report `supportsStreaming` leaves
+`model.supports_streaming` at `None`, and such a model still takes the
+streaming path. If it answers with a complete JSON body rather than an SSE
+stream, the streamer detects that and yields the response as a single
+`SUCCESS` chunk, instead of feeding the JSON text to the SSE parser and ending
+at `FAILED`. Only an explicit `supports_streaming is False` refuses to stream.
 
 ### A polled falsy result keeps its value and type
 

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -240,6 +240,10 @@ _ROLES: List[_RoleSpec] = [
     _RoleSpec("response_generator", "responder", "responder"),
 ]
 
+# Attributes that hold a role ref, for the explicit-assignment tracking in
+# ``Agent.__setattr__``.
+_ROLE_ATTRS = frozenset(spec.attr for spec in _ROLES)
+
 
 class AgentRunParams(BaseRunParams):
     """Parameters for running an agent.
@@ -877,7 +881,7 @@ class Agent(
             self.skills = [self._skill_reference_id(skill) or skill for skill in self._original_skills]
 
     def __setattr__(self, name: str, value: Any) -> None:
-        """Keep ``self.budget`` a (never-None) ``Budget`` instance.
+        """Keep ``self.budget`` a (never-None) ``Budget`` instance, and note role assignments.
 
         Assigning ``agent.budget`` a dict / ``Budget`` / ``None`` is coerced into
         a ``Budget`` so attribute access (``agent.budget.max_cost = ...``) always
@@ -885,11 +889,27 @@ class Agent(
         ``Model.__setattr__`` coerces bulk ``inputs`` assignment). This runs for
         the generated ``__init__`` assignment too, so the field is a ``Budget``
         by the time ``__post_init__`` executes.
+
+        A role ref assigned *after* hydration is the caller's intent and must
+        always be sent on save, even when it happens to equal the class default
+        (BUG-1093). Assignments made by the generated ``__init__`` are not
+        recorded — ``_explicit_roles`` does not exist yet at that point — but
+        such an object also has no recorded server fields, so suppression is off
+        for it anyway. Hydration resets the set (see ``_record_server_fields``).
         """
         if name == "budget":
             coerced = self._coerce_budget(value)
             value = coerced if coerced is not None else Budget()
+        if name in _ROLE_ATTRS:
+            explicit = getattr(self, "_explicit_roles", None)
+            if explicit is not None:
+                explicit.add(name)
         super().__setattr__(name, value)
+
+    def _record_server_fields(self, data: Any) -> None:
+        """Reset explicit-role tracking: post-hydration role values came from the server."""
+        super()._record_server_fields(data)
+        self._explicit_roles = set()
 
     @classmethod
     def _fold_legacy_max_iterations(cls, kvs: Any) -> Any:
@@ -1278,8 +1298,15 @@ class Agent(
             Agent: The saved agent instance
 
         Raises:
+            ValidationError: If the agent has been deleted.
             ValueError: If child components are not saved and save_subcomponents is False
         """
+        # Guard before any child component is saved and before before_save()
+        # flips status DELETED -> ONBOARDED: a deleted agent must not touch the
+        # backend at all (BUG-1093).
+        if self.id or self.is_deleted:
+            self._ensure_valid_state()
+
         save_subcomponents = kwargs.pop("save_subcomponents", False)
 
         # Save all child components recursively if requested
@@ -1916,13 +1943,28 @@ class Agent(
 
         Each entry is ``{id, parameters?: [{name, value}]}`` (matches backend
         ``AgentModelInput``). Driven by the module-level ``_ROLES`` table.
+
+        A role whose value is still the SDK class default is omitted when the
+        response that hydrated this agent did not carry that key and the caller
+        never assigned it: sending it would write an SDK default (e.g.
+        ``DEFAULT_LLM``) over whatever the platform actually has (BUG-1093).
+        Creates are unaffected — a locally built Agent has no recorded server
+        fields, so nothing is suppressed.
         """
+        explicit = getattr(self, "_explicit_roles", None) or frozenset()
         for spec in _ROLES:
             ref = getattr(self, spec.attr, None)
-            if ref is not None:
-                payload[spec.save_key] = self._role_ref_to_save_manifest(ref)
-            else:
+            if ref is None:
                 payload.pop(spec.save_key, None)
+                continue
+            if (
+                spec.attr not in explicit
+                and self._is_at_field_default(spec.attr)
+                and self._server_omitted(spec.save_key)
+            ):
+                payload.pop(spec.save_key, None)
+                continue
+            payload[spec.save_key] = self._role_ref_to_save_manifest(ref)
         for k in self._LEGACY_ROLE_KEYS:
             payload.pop(k, None)
 

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1298,14 +1298,14 @@ class Agent(
             Agent: The saved agent instance
 
         Raises:
-            ValidationError: If the agent has been deleted.
+            ResourceError: If the agent has been deleted.
             ValueError: If child components are not saved and save_subcomponents is False
         """
         # Guard before any child component is saved and before before_save()
         # flips status DELETED -> ONBOARDED: a deleted agent must not touch the
         # backend at all (BUG-1093).
         if self.id or self.is_deleted:
-            self._ensure_valid_state()
+            self._ensure_saveable()
 
         save_subcomponents = kwargs.pop("save_subcomponents", False)
 

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1585,6 +1585,11 @@ class Agent(
 
         duplicated = Agent.from_dict(response_data)
         duplicated.context = self.context
+        # Record which keys the duplicate response carried, like get()/search()
+        # do: without this the duplicate has no provenance and a later save()
+        # would PUT the SDK default model over whatever the platform gave the
+        # copy (BUG-1093).
+        duplicated._record_server_fields(response_data)
         duplicated._update_saved_state()
 
         return duplicated

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -2402,7 +2402,11 @@ class Agent(
         fields = ("max_cost", "max_duration_seconds", "max_iterations")
         if session_budget is None:
             has_cap = any(getattr(agent_budget, name, None) is not None for name in fields)
-            return agent_budget if has_cap else None
+            # Copy, never alias: ``agent.budget`` is documented as mutated in
+            # place (``agent.budget.max_cost = ...``), so handing the same object
+            # to the session would let a later agent-side edit silently rewrite
+            # the session's persisted cap.
+            return replace(agent_budget) if has_cap else None
         filled = {
             name: getattr(agent_budget, name, None)
             for name in fields

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from datetime import datetime
 from enum import Enum
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Any, Dict, Tuple, Union, Text
 from typing_extensions import Unpack, NotRequired, TypedDict, Literal
 from dataclasses_json import dataclass_json, config
@@ -2158,7 +2158,17 @@ class Agent(
         return payload
 
     def build_run_payload(self, **kwargs: Unpack[AgentRunParams]) -> dict:
-        """Build the payload for the run action."""
+        """Build the payload for the run action.
+
+        SDK-control kwargs (``_RUN_CONTROL_KEYS``: retries/timeouts, the
+        ``progress_*`` display trio, ``api_key`` / ``resource_path``, and the
+        header-only run metadata) are dropped up front. The run path already
+        filters them via ``_payload_kwargs_for_run``; repeating it here means the
+        catch-all snake_case→camelCase forwarder below cannot put them on the
+        wire even when this builder is called directly (BUG-1091).
+        """
+        kwargs = {k: v for k, v in kwargs.items() if k not in self._RUN_CONTROL_KEYS}
+
         # Extract execution_params if provided, otherwise use defaults
         execution_params = kwargs.pop("execution_params", {})
 
@@ -2365,8 +2375,42 @@ class Agent(
                         values[name] = value
         return values
 
-    @staticmethod
-    def _apply_run_overrides_to_session(session: "Session", kwargs: Dict[str, Any]) -> None:
+    # Per-run kwargs that map onto ``ExecutionConfig`` fields. ``budget`` is
+    # intentionally absent: it is not a run kwarg (``build_run_payload`` pops any
+    # stray one) and reaches the session via the agent's own budget instead.
+    _SESSION_EXECUTION_OVERRIDES: ClassVar[tuple] = (
+        "execution_params",
+        "criteria",
+        "evolve",
+        "identifier",
+        "run_response_generation",
+    )
+
+    def _budget_for_session(self, session_budget: Optional["Budget"]) -> Optional["Budget"]:
+        """Fill unset session budget caps from ``self.budget``; session values win.
+
+        A session's stored cap is an explicit, persisted ceiling: the agent's own
+        budget may only fill slots the session leaves unset, never widen or
+        replace one.
+
+        Returns *session_budget* itself (identity, so the caller can tell nothing
+        changed) when the agent has no budget or contributes no new cap.
+        """
+        agent_budget = getattr(self, "budget", None)
+        if agent_budget is None:
+            return session_budget
+        fields = ("max_cost", "max_duration_seconds", "max_iterations")
+        if session_budget is None:
+            has_cap = any(getattr(agent_budget, name, None) is not None for name in fields)
+            return agent_budget if has_cap else None
+        filled = {
+            name: getattr(agent_budget, name, None)
+            for name in fields
+            if getattr(session_budget, name, None) is None and getattr(agent_budget, name, None) is not None
+        }
+        return replace(session_budget, **filled) if filled else session_budget
+
+    def _apply_run_overrides_to_session(self, session: "Session", kwargs: Dict[str, Any]) -> None:
         """Apply per-run execution overrides onto a session.
 
         When a caller runs within a ``session`` but also passes
@@ -2379,37 +2423,40 @@ class Agent(
         result differs from what's stored, persist it so the overrides
         take effect.
 
+        The agent's own ``budget`` applies on this path too (it already does on
+        the direct run path), but only fills caps the session leaves unset.
+
         We warn because this mutates the session's ``executionConfig`` for
         every subsequent message in the session, not just this run.
         """
         from .session import ExecutionConfig
 
-        overrides = {
-            "execution_params": kwargs.get("execution_params"),
-            "criteria": kwargs.get("criteria"),
-            "evolve": kwargs.get("evolve"),
-            "identifier": kwargs.get("identifier"),
-            "run_response_generation": kwargs.get("run_response_generation"),
-        }
-        provided = {key: value for key, value in overrides.items() if value is not None}
-        if not provided:
+        provided = {key: kwargs[key] for key in self._SESSION_EXECUTION_OVERRIDES if kwargs.get(key) is not None}
+
+        current = ExecutionConfig.coerce(session.execution_config)
+
+        # Rebuild *from the stored config*, never from an enumerated field list:
+        # a hardcoded ``base`` dict omitted ``budget``, so every session run with
+        # any override silently deleted the session's persisted spend cap — and
+        # the same trap would reopen for any field added to ExecutionConfig
+        # (BUG-1091).
+        merged = replace(current, **provided) if current is not None else ExecutionConfig(**provided)
+
+        seeded = self._budget_for_session(merged.budget)
+        budget_seeded = seeded is not merged.budget
+        if budget_seeded:
+            merged = replace(merged, budget=seeded)
+
+        # Nothing to apply: keep today's semantics that a plain session run (no
+        # overrides, no cap the agent can contribute) performs no write.
+        if not provided and not budget_seeded:
             return
-
-        current = session.execution_config
-        base = {
-            "execution_params": getattr(current, "execution_params", None),
-            "criteria": getattr(current, "criteria", None),
-            "evolve": getattr(current, "evolve", None),
-            "identifier": getattr(current, "identifier", None),
-            "run_response_generation": getattr(current, "run_response_generation", None),
-        }
-        merged = ExecutionConfig(**{**base, **provided})
-
         if current is not None and merged.to_api_dict() == current.to_api_dict():
             return
 
+        changed = sorted(provided) + (["budget (from agent.budget)"] if budget_seeded else [])
         warnings.warn(
-            f"Per-run execution overrides ({', '.join(sorted(provided))}) were "
+            f"Per-run execution overrides ({', '.join(changed)}) were "
             f"passed alongside session '{session.id}'. Updating the session's "
             f"stored executionConfig so the overrides take effect; this also "
             f"applies to every subsequent message in this session.",

--- a/aixplain/v2/agent_evaluator.py
+++ b/aixplain/v2/agent_evaluator.py
@@ -1306,9 +1306,7 @@ class AgentEvaluationRun:
         except Exception:
             pass
         try:
-            # Best-effort discovery: one unparseable row in the page must not
-            # cost us the default insight model, so opt out of strict listing.
-            page = model_cls.search(path=path, page_size=50, strict=False)
+            page = model_cls.search(path=path, page_size=50)
         except Exception:
             return None
         results = list(getattr(page, "results", []) or [])

--- a/aixplain/v2/agent_evaluator.py
+++ b/aixplain/v2/agent_evaluator.py
@@ -1306,7 +1306,9 @@ class AgentEvaluationRun:
         except Exception:
             pass
         try:
-            page = model_cls.search(path=path, page_size=50)
+            # Best-effort discovery: one unparseable row in the page must not
+            # cost us the default insight model, so opt out of strict listing.
+            page = model_cls.search(path=path, page_size=50, strict=False)
         except Exception:
             return None
         results = list(getattr(page, "results", []) or [])

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -288,7 +288,16 @@ class File(BaseResource):
         self._apply_data(root_data)
 
     def save(self, **_: Any) -> "File":
-        """Upload the source and persist it as a backend File asset."""
+        """Upload the source and persist it as a backend File asset.
+
+        Raises:
+            ValidationError: If the file has been deleted.
+        """
+        # File.save() never reaches BaseResource.save(), so it needs its own
+        # deleted-state guard (BUG-1093).
+        if self.id or self.is_deleted:
+            self._ensure_valid_state()
+
         if self.context is None:
             self.context = type(self).context
         if not self.source:

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -291,12 +291,12 @@ class File(BaseResource):
         """Upload the source and persist it as a backend File asset.
 
         Raises:
-            ValidationError: If the file has been deleted.
+            ResourceError: If the file has been deleted.
         """
         # File.save() never reaches BaseResource.save(), so it needs its own
         # deleted-state guard (BUG-1093).
         if self.id or self.is_deleted:
-            self._ensure_valid_state()
+            self._ensure_saveable()
 
         if self.context is None:
             self.context = type(self).context

--- a/aixplain/v2/inspector.py
+++ b/aixplain/v2/inspector.py
@@ -12,7 +12,7 @@ plain strings for ``action`` / ``targets`` / ``severity`` and an ``aix.Metric``
 import inspect
 import logging
 import textwrap
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
 
 from .enums import Function
@@ -509,21 +509,29 @@ class Inspector(
         return filters
 
     @classmethod
-    def _build_resources(cls, items: List[dict], context: Any) -> List["Inspector"]:
-        """Adapt each guard-model item into a configured Inspector."""
+    def _deserialize_items(cls, items: List[dict], context: Any) -> Tuple[List["Inspector"], List[str]]:
+        """Adapt each guard-model item into a configured Inspector.
+
+        Records that cannot be adapted are reported as errors rather than
+        silently dropped, so ``search()`` can raise (strict, the default) or
+        correct ``Page.total`` instead of over-reporting.
+        """
         resources: List["Inspector"] = []
-        for item in items:
+        errors: List[str] = []
+        for index, item in enumerate(items):
             if not isinstance(item, dict):
+                errors.append(f"item[{index}]: expected a guard object, got {type(item).__name__}")
                 continue
             try:
                 inspector = cls.from_guard_model(item)
             except Exception as e:  # pragma: no cover - defensive
                 logger.warning("Skipping guard during Inspector deserialization: %s", e)
+                errors.append(f"item[{index}]: {e}")
                 continue
             setattr(inspector, "context", context)
             inspector._update_saved_state()
             resources.append(inspector)
-        return resources
+        return resources, errors
 
 
 __all__ = [

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -21,6 +21,9 @@ from .resource import (
     RunnableResourceMixin,
     BaseRunParams,
     Result,
+    _filter_value,
+    _filter_values,
+    _sort_direction,
 )
 from .enums import Function, Supplier, Language, AssetStatus, ResponseStatus
 from .mixins import ToolableMixin, ToolDict
@@ -392,15 +395,6 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
 
 
 InputsProxy = Inputs
-
-
-def find_supplier_by_id(supplier_id: Union[str, int]) -> Optional[Supplier]:
-    """Find supplier enum by ID."""
-    supplier_id_str = str(supplier_id)
-    return next(
-        (supplier for supplier in Supplier if supplier.value.get("id") == supplier_id_str),
-        None,
-    )
 
 
 def find_function_by_id(function_id: str) -> Optional[Function]:
@@ -1157,97 +1151,37 @@ class Model(
 
         # functions - backend validates "each value in functions must be a string"
         if params.get("functions") is not None:
-            functions_param = params["functions"]
-            if isinstance(functions_param, list):
-                filters["functions"] = [(f.value if hasattr(f, "value") else str(f)) for f in functions_param]
-            else:
-                filters["functions"] = [
-                    functions_param.value if hasattr(functions_param, "value") else str(functions_param)
-                ]
+            filters["functions"] = _filter_values(params["functions"])
 
         # suppliers - should be array of strings
         if params.get("vendors") is not None:
-            suppliers = params["vendors"]
-            if isinstance(suppliers, list):
-                filters["suppliers"] = [
-                    (s.value["code"] if hasattr(s, "value") and isinstance(s.value, dict) else str(s))
-                    for s in suppliers
-                ]
-            else:
-                supplier_value = (
-                    suppliers.value["code"]
-                    if (hasattr(suppliers, "value") and isinstance(suppliers.value, dict))
-                    else str(suppliers)
-                )
-                filters["suppliers"] = [supplier_value]
+            filters["suppliers"] = _filter_values(params["vendors"])
 
         # status - should be array of strings
         if params.get("status") is not None:
-            status = params["status"]
-            if isinstance(status, list):
-                filters["status"] = [
-                    (s.value if (hasattr(s, "value") and isinstance(s.value, str)) else str(s)) for s in status
-                ]
-            else:
-                if hasattr(status, "value") and isinstance(status.value, str):
-                    status_value = status.value
-                else:
-                    status_value = str(status)
-                filters["status"] = [status_value]
+            filters["status"] = _filter_values(params["status"])
 
         # source_languages - should be array of language codes
         if params.get("source_languages") is not None:
-            source_langs = params["source_languages"]
-            if isinstance(source_langs, list):
-                filters["sourceLanguages"] = [
-                    (lang.value if hasattr(lang, "value") and isinstance(lang.value, str) else str(lang))
-                    for lang in source_langs
-                ]
-            else:
-                lang_value = (
-                    source_langs.value
-                    if hasattr(source_langs, "value") and isinstance(source_langs.value, str)
-                    else str(source_langs)
-                )
-                filters["sourceLanguages"] = [lang_value]
+            filters["sourceLanguages"] = _filter_values(params["source_languages"])
 
         # target_languages - should be array of language codes
         if params.get("target_languages") is not None:
-            target_langs = params["target_languages"]
-            if isinstance(target_langs, list):
-                filters["targetLanguages"] = [
-                    (lang.value if hasattr(lang, "value") and isinstance(lang.value, str) else str(lang))
-                    for lang in target_langs
-                ]
-            else:
-                lang_value = (
-                    target_langs.value
-                    if hasattr(target_langs, "value") and isinstance(target_langs.value, str)
-                    else str(target_langs)
-                )
-                filters["targetLanguages"] = [lang_value]
+            filters["targetLanguages"] = _filter_values(params["target_languages"])
 
         # is_finetunable - boolean filter
         # Note: v1 API uses "isFineTunable" (capital T), v2 API uses "isFinetunable" (lowercase t)
         if params.get("is_finetunable") is not None:
             filters["isFineTunable"] = params["is_finetunable"]
 
-        # sort - should be array of objects with field and dir
+        # sort - array of {field, dir}; ``dir`` is +/-1 per the backend contract
         if params.get("sort_by") is not None or params.get("sort_order") is not None:
-            sort_field = params.get("sort_by", "name")
-            sort_order = params.get("sort_order", "asc")
-
-            # Convert enum to string if needed
-            if hasattr(sort_field, "value"):
-                sort_field = sort_field.value
-
-            # Convert sort order to integer
-            if hasattr(sort_order, "value"):
-                sort_dir = sort_order.value
-            else:
-                sort_dir = 1 if str(sort_order).lower() == "asc" else -1
-
-            filters["sort"] = [{"field": str(sort_field), "dir": sort_dir}]
+            filters["sort"] = [
+                {
+                    "field": _filter_value(params.get("sort_by", "name")),
+                    "dir": _sort_direction(params.get("sort_order", "asc")),
+                }
+            ]
         else:
             # Always include empty sort array as backend requires it
             filters["sort"] = [{}]

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -1175,11 +1175,15 @@ class Model(
             filters["isFineTunable"] = params["is_finetunable"]
 
         # sort - array of {field, dir}; ``dir`` is +/-1 per the backend contract
-        if params.get("sort_by") is not None or params.get("sort_order") is not None:
+        sort_by = params.get("sort_by")
+        sort_order = params.get("sort_order")
+        if sort_by is not None or sort_order is not None:
+            # Either half may be omitted (or explicitly ``None``); fall back to
+            # the documented defaults rather than serializing ``None``.
             filters["sort"] = [
                 {
-                    "field": _filter_value(params.get("sort_by", "name")),
-                    "dir": _sort_direction(params.get("sort_order", "asc")),
+                    "field": _filter_value("name" if sort_by is None else sort_by),
+                    "dir": _sort_direction("ASC" if sort_order is None else sort_order),
                 }
             ]
         else:

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Mapping
+from itertools import chain
 from typing import Dict, Union, List, Optional, Any, TYPE_CHECKING, Iterator
 from urllib.parse import urlparse
 from typing_extensions import NotRequired, Unpack
@@ -251,12 +253,59 @@ def _extract_stream_error(data: Any) -> Optional[str]:
     return None
 
 
+#: Line prefixes defined by the SSE wire format (WHATWG HTML §9.2). A body whose
+#: first non-empty line starts with one of these is a stream even when the
+#: server forgot the ``text/event-stream`` content type.
+_SSE_LINE_PREFIXES = ("data:", "event:", "id:", "retry:", ":")
+
+
+def _content_from_document(data: Any) -> str:
+    """Return the text payload of a complete (non-streamed) run response.
+
+    Args:
+        data: The decoded JSON document returned by the run endpoint.
+
+    Returns:
+        str: The model's text output. A structured payload that has no text
+        field is serialized rather than dropped, so the caller still gets the
+        data it asked for.
+    """
+    if isinstance(data, str):
+        return data
+
+    if isinstance(data, dict):
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+            message = choices[0].get("message")
+            if not isinstance(message, dict):
+                message = choices[0].get("delta")
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str):
+                    return content
+
+        content = data.get("data")
+        if isinstance(content, str):
+            return content
+        if content is not None:
+            return json.dumps(content)
+
+    return json.dumps(data)
+
+
 class ModelResponseStreamer(Iterator[StreamChunk]):
     """A streamer for model responses that yields chunks as they arrive.
 
     This class provides an iterator interface for streaming model responses.
     It handles the conversion of Server-Sent Events (SSE) into StreamChunk objects
     and manages the response status.
+
+    A backend that answers a streaming request with a plain JSON document
+    instead of an SSE body (a model whose record omits ``supportsStreaming``
+    may simply not stream) is detected on the first ``next()`` and yielded as a
+    single complete ``StreamChunk`` with ``status=SUCCESS``, rather than being
+    fed line by line to the SSE parser — which used to surface the raw JSON
+    text as ``chunk.data`` and end at ``status=FAILED``.
 
     ``status`` only becomes ``SUCCESS`` once the stream terminates cleanly — a
     ``[DONE]`` marker, a terminal ``finish_reason`` or a terminal ``status``
@@ -295,10 +344,75 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
         self._done = False
         self._buffered_line: Optional[str] = None
         self._saw_terminal_event = False
+        self._sniffed = False
 
     def __iter__(self) -> Iterator[StreamChunk]:
         """Return the iterator for the ModelResponseStreamer."""
         return self
+
+    def _non_streaming_chunk(self) -> Optional[StreamChunk]:
+        """Return the whole body as one chunk when it is not an SSE stream.
+
+        The decision is made on the actual response rather than on the model's
+        ``supports_streaming`` flag, which the backend record may omit: a
+        ``text/event-stream`` content type, or a first line in SSE field form,
+        keeps the streaming parser; anything that parses as a single JSON
+        document is returned complete. A body that is neither is replayed
+        unchanged to the SSE parser, so nothing is consumed on its behalf.
+
+        Returns:
+            Optional[StreamChunk]: The complete response as a single chunk, or
+            None when the body should be parsed as SSE.
+        """
+        headers = getattr(self._response, "headers", None)
+        content_type = ""
+        if isinstance(headers, Mapping):
+            content_type = str(headers.get("Content-Type") or "").lower()
+        if "event-stream" in content_type:
+            return None
+
+        collected: List[str] = []
+        for line in self._iterator:
+            collected.append(line)
+            if not line or not line.strip():
+                continue
+            if "json" not in content_type and line.lstrip().startswith(_SSE_LINE_PREFIXES):
+                self._iterator = chain(iter(collected), self._iterator)
+                return None
+            break
+
+        collected.extend(self._iterator)
+        try:
+            data = json.loads("\n".join(collected))
+        except (json.JSONDecodeError, ValueError):
+            self._iterator = iter(collected)
+            return None
+
+        self._done = True
+        error_message = _extract_stream_error(data)
+        if error_message is not None:
+            self.status = ResponseStatus.FAILED
+            logger.warning("Model run reported an error on the streaming path: %s", error_message)
+            return StreamChunk(status=ResponseStatus.FAILED, data="", error_message=error_message)
+
+        logger.warning(
+            "Model responded to a streaming request with a complete %s body; yielding it as a single chunk.",
+            content_type or "non-SSE",
+        )
+        self.status = ResponseStatus.SUCCESS
+        usage = data.get("usage") if isinstance(data, dict) else None
+        finish_reason = None
+        if isinstance(data, dict):
+            choices = data.get("choices")
+            if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+                raw_finish_reason = choices[0].get("finish_reason")
+                finish_reason = raw_finish_reason if isinstance(raw_finish_reason, str) else None
+        return StreamChunk(
+            status=ResponseStatus.SUCCESS,
+            data=_content_from_document(data),
+            usage=usage if isinstance(usage, dict) else None,
+            finish_reason=finish_reason,
+        )
 
     def __next__(self) -> StreamChunk:
         """Return the next chunk of the response.
@@ -311,6 +425,12 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
         """
         if self._done:
             raise StopIteration
+
+        if not self._sniffed:
+            self._sniffed = True
+            complete_chunk = self._non_streaming_chunk()
+            if complete_chunk is not None:
+                return complete_chunk
 
         while True:
             try:
@@ -834,7 +954,10 @@ class Model(
         Returns:
             ModelResult, or a :class:`ModelResponseStreamer` when ``stream=True``
             — the flag selects the streaming path rather than being silently
-            dropped (BUG-1091).
+            dropped (BUG-1091). A model whose backend record omits
+            ``supportsStreaming`` still takes the streaming path; if it answers
+            with a complete JSON body instead of an SSE stream, the streamer
+            yields that body as a single successful chunk.
         """
         # ``stream`` selects the path, so it is consumed here rather than
         # forwarded: run_stream sets ``options.stream`` on the wire itself and
@@ -999,7 +1122,10 @@ class Model(
 
         Returns:
             ModelResponseStreamer: A streamer that yields StreamChunk objects. Can be
-                iterated directly or used as a context manager.
+                iterated directly or used as a context manager. When the model
+                answers with a complete JSON body rather than an SSE stream —
+                which a model whose record omits ``supportsStreaming`` may well
+                do — the streamer yields that response as a single chunk.
 
         Raises:
             ValidationError: If the model explicitly does not support streaming

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -220,9 +220,6 @@ class StreamChunk:
             self.data = ""
 
 
-_TERMINAL_FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter", "function_call"})
-
-
 def _extract_stream_error(data: Any) -> Optional[str]:
     """Return an error message if an SSE payload represents a failure.
 
@@ -262,12 +259,12 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
     and manages the response status.
 
     ``status`` only becomes ``SUCCESS`` once the stream terminates cleanly — a
-    ``[DONE]`` marker or a terminal ``finish_reason``. An error event, or a
-    stream cut before either of those, leaves ``status`` at ``FAILED``, so a
-    truncated generation is never reported as a complete one. Error events also
-    yield a final ``StreamChunk`` with ``status=FAILED`` and ``error_message``
-    set, rather than raising, so existing ``for chunk in stream`` loops keep
-    working.
+    ``[DONE]`` marker, a terminal ``finish_reason`` or a terminal ``status``
+    envelope. An error event, or a stream cut before any of those, leaves
+    ``status`` at ``FAILED``, so a truncated generation is never reported as a
+    complete one. Error events also yield a final ``StreamChunk`` with
+    ``status=FAILED`` and ``error_message`` set, rather than raising, so
+    existing ``for chunk in stream`` loops keep working.
 
     The streamer can be used directly in a for loop or as a context manager
     for proper resource cleanup.
@@ -297,7 +294,7 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
         self.status = ResponseStatus.IN_PROGRESS
         self._done = False
         self._buffered_line: Optional[str] = None
-        self._saw_terminal_finish_reason = False
+        self._saw_terminal_event = False
 
     def __iter__(self) -> Iterator[StreamChunk]:
         """Return the iterator for the ModelResponseStreamer."""
@@ -324,9 +321,10 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                     line = next(self._iterator)
             except StopIteration:
                 self._done = True
-                if self._saw_terminal_finish_reason:
-                    # The server closed cleanly after a terminal finish_reason
-                    # but without a [DONE] marker; that is a complete stream.
+                if self._saw_terminal_event:
+                    # The server closed cleanly after a terminal event (a
+                    # finish_reason or a SUCCESS envelope) but without a [DONE]
+                    # marker; that is a complete stream, not a truncated one.
                     self.status = ResponseStatus.SUCCESS
                 else:
                     self.status = ResponseStatus.FAILED
@@ -390,6 +388,14 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                 logger.warning("Model stream reported an error: %s", error_message)
                 return StreamChunk(status=ResponseStatus.FAILED, data="", error_message=error_message)
 
+            # The aiXplain envelope announces a clean end with a terminal status
+            # rather than a finish_reason; that closes the stream as cleanly as
+            # a [DONE] marker would.
+            if isinstance(data, dict):
+                status_value = data.get("status")
+                if isinstance(status_value, str) and status_value.upper() in {"SUCCESS", "COMPLETED"}:
+                    self._saw_terminal_event = True
+
             # OpenAI-style stream chunk format:
             # {"choices":[{"delta":{"content":"...", "tool_calls":[...]},"finish_reason":...}],"usage":...}
             if isinstance(data, dict) and "choices" in data:
@@ -418,8 +424,13 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
 
                 finish_reason = choice.get("finish_reason")
                 finish_reason = finish_reason if isinstance(finish_reason, str) else None
-                if finish_reason in _TERMINAL_FINISH_REASONS:
-                    self._saw_terminal_finish_reason = True
+                if finish_reason:
+                    # Any non-null finish_reason terminates the choice. Suppliers
+                    # emit values well beyond OpenAI's own set ("end_turn",
+                    # "max_tokens", "guardrail_intervened", ...), so accept them
+                    # all instead of allowlisting and calling a complete stream
+                    # truncated; "error" never reaches here (handled above).
+                    self._saw_terminal_event = True
 
                 usage = data.get("usage")
                 usage = usage if isinstance(usage, dict) else None

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -746,41 +746,37 @@ class Model(
         else:
             super().__setattr__(name, value)
 
-    # Orchestration params the SDK consumes itself, plus every per-run header
-    # kwarg. The header half is derived from RunnableResourceMixin._RUN_HEADER_KEYS
-    # rather than re-listed, so a new header can't be added to the wire while
-    # still leaking into the v1/URL payloads (a merge once silently dropped such a
-    # duplicated entry — see the _RUN_HEADER_KEYS note).
-    _SDK_ONLY_PARAMS = frozenset(
-        {
-            "timeout",
-            "wait_time",
-            "show_progress",
-            "stream",
-            "run_retries",
-            "run_retry_wait",
-        }
-    ) | {key for key, _ in RunnableResourceMixin._RUN_HEADER_KEYS}
-
     # ``identifier`` is a per-run caller identity emitted as the ``x-user-id``
     # header (RunnableResourceMixin._headers_for_run), never a model/action
-    # input. Exclude it from the v2 payload builder here (and from the v1/URL
-    # builders via _SDK_ONLY_PARAMS above) so it cannot leak into model inputs
-    # or supplier-facing logs. Agent keeps it in the body by NOT overriding this.
+    # input. Exclude it from the payload builders here so it cannot leak into
+    # model inputs or supplier-facing logs. Agent keeps it in the body by NOT
+    # overriding this.
     #
     # ``session_id`` (→ ``x-session-id``) and ``agent_name`` (→ ``x-agent``) are
     # the same kind of per-run metadata but header-only for every runnable, so the
-    # base _RUN_CONTROL_KEYS already excludes them; _SDK_ONLY_PARAMS above covers
-    # them again for the v1/URL builder paths.
-    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier"}
+    # base _RUN_CONTROL_KEYS already excludes them.
+    #
+    # ``stream`` selects the streaming *path* (see ``run``) and is expressed on
+    # the wire as ``options.stream`` by ``run_stream`` — never as a top-level
+    # body field.
+    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier", "stream"}
+
+    # The v1/URL builder path (``_run_async_v1``) and ``build_run_payload`` filter
+    # with the *same* set rather than a second hand-maintained literal: a merge
+    # once dropped a duplicated entry and silently put ``session_id`` back on the
+    # wire (BUG-1091). Kept as a distinct name because it is referenced by
+    # existing tests and by ``build_run_payload``'s docstring.
+    _SDK_ONLY_PARAMS = _RUN_CONTROL_KEYS
 
     def build_run_payload(self, **kwargs: Unpack[ModelRunParams]) -> dict:
         """Build the JSON payload for a model execution request.
 
         Strips SDK-only orchestration params (``timeout``, ``wait_time``,
-        ``show_progress``, ``stream``, ``run_retries``, ``run_retry_wait``) and
-        the header-only run metadata (``identifier``, ``session_id``,
-        ``agent_name``) so they are never forwarded to the backend API.
+        ``show_progress``, ``progress_*``, ``stream``, ``run_retries``,
+        ``run_retry_wait``), the request-dispatch params (``api_key``,
+        ``resource_path``) and the header-only run metadata (``identifier``,
+        ``session_id``, ``agent_name``) so they are never forwarded to the
+        backend API.
         """
         filtered = {k: v for k, v in kwargs.items() if k not in self._SDK_ONLY_PARAMS}
         return super().build_run_payload(**filtered)
@@ -828,13 +824,24 @@ class Model(
         # Use v2 endpoint - it uses "results" as the items key (default)
         return super().search(**kwargs)
 
-    def run(self, **kwargs: Unpack[ModelRunParams]) -> ModelResult:
+    def run(self, **kwargs: Unpack[ModelRunParams]) -> Union[ModelResult, "ModelResponseStreamer"]:
         """Run the model with dynamic parameter validation and default handling.
 
         This method routes the execution based on the model's connection type:
         - Sync models: Uses V2 endpoint directly (returns result immediately)
         - Async models: Uses V2 endpoint and polls until completion
+
+        Returns:
+            ModelResult, or a :class:`ModelResponseStreamer` when ``stream=True``
+            — the flag selects the streaming path rather than being silently
+            dropped (BUG-1091).
         """
+        # ``stream`` selects the path, so it is consumed here rather than
+        # forwarded: run_stream sets ``options.stream`` on the wire itself and
+        # runs its own merge/validation, so passing it on would be redundant.
+        if kwargs.pop("stream", None):
+            return self.run_stream(**kwargs)
+
         # Merge dynamic attributes with provided kwargs
         effective_params = self._merge_with_dynamic_attrs(**kwargs)
 
@@ -929,9 +936,16 @@ class Model(
         v1_base_url = self.context.model_url.replace("/api/v2/", "/api/v1/")
         url = f"{v1_base_url}/{self.id}"
 
+        # Same identity headers as the sync path: this fallback is still a run,
+        # so its caller must stay attributable downstream (BUG-1091).
+        request_kwargs: dict = {"data": json_payload}
+        headers = self._headers_for_run(kwargs)
+        if headers:
+            request_kwargs["headers"] = headers
+
         # Use the v2 client's raw request method (raises APIError on non-2xx)
         try:
-            r = self.context.client.request_raw("post", url, data=json_payload)
+            r = self.context.client.request_raw("post", url, **request_kwargs)
             resp = r.json()
         except Exception as e:
             logger.error(f"Error in V1 async request: {e}")
@@ -1017,7 +1031,12 @@ class Model(
 
         self._ensure_valid_state()
 
-        payload = self.build_run_payload(**effective_params)
+        # Same body filter and identity headers as the sync path: a stream is
+        # still a run, so ``api_key`` must not reach the model input and the
+        # caller must stay attributable downstream (BUG-1091).
+        payload_input = self._payload_kwargs_for_run(effective_params)
+
+        payload = self.build_run_payload(**payload_input)
 
         if "options" not in payload:
             payload["options"] = {}
@@ -1025,11 +1044,15 @@ class Model(
         if payload.get("tools") is not None:
             payload["options"]["raw"] = True
 
-        run_url = self.build_run_url(**effective_params)
+        run_url = self.build_run_url(**payload_input)
 
         logger.debug(f"Model Run Stream: Start service for {run_url}")
 
-        response = self.context.client.request_stream("POST", run_url, json=payload)
+        request_kwargs: dict = {"json": payload}
+        headers = self._headers_for_run(effective_params)
+        if headers:
+            request_kwargs["headers"] = headers
+        response = self.context.client.request_stream("POST", run_url, **request_kwargs)
 
         return ModelResponseStreamer(response)
 

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -196,12 +196,14 @@ class StreamChunk:
     """A chunk of streamed response data.
 
     Attributes:
-        status: The current status of the streaming operation (IN_PROGRESS or SUCCESS)
+        status: The current status of the streaming operation (IN_PROGRESS,
+            SUCCESS, or FAILED when the stream reported an error)
         data: The content/token of this chunk
         reasoning_content: Reasoning-model chain-of-thought text delta, when provided
         tool_calls: Tool call deltas when stream uses OpenAI-style chunk format
         usage: Usage payload when provided in a stream chunk
         finish_reason: Completion reason for the current choice, when provided
+        error_message: The error reported by the stream, when status is FAILED
     """
 
     status: ResponseStatus
@@ -210,11 +212,46 @@ class StreamChunk:
     tool_calls: Optional[List[dict[str, Any]]] = None
     usage: Optional[dict[str, Any]] = None
     finish_reason: Optional[str] = None
+    error_message: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Ensure data remains a text chunk."""
         if not isinstance(self.data, str):
             self.data = ""
+
+
+_TERMINAL_FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter", "function_call"})
+
+
+def _extract_stream_error(data: Any) -> Optional[str]:
+    """Return an error message if an SSE payload represents a failure.
+
+    Args:
+        data: The decoded JSON payload of a single SSE event.
+
+    Returns:
+        Optional[str]: The reported error message, or None if the payload does
+        not represent a failure.
+    """
+    if not isinstance(data, dict):
+        return None
+
+    error = data.get("error")
+    if error:
+        if isinstance(error, dict):
+            return str(error.get("message") or error)
+        return str(error)
+
+    status = data.get("status")
+    if isinstance(status, str) and status.upper() in {"FAILED", "ERROR"}:
+        return str(data.get("errorMessage") or data.get("message") or f"stream reported status={status}")
+
+    choices = data.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else None
+    if isinstance(choice, dict) and choice.get("finish_reason") == "error":
+        return str(choice.get("error") or "stream finished with finish_reason='error'")
+
+    return None
 
 
 class ModelResponseStreamer(Iterator[StreamChunk]):
@@ -223,6 +260,14 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
     This class provides an iterator interface for streaming model responses.
     It handles the conversion of Server-Sent Events (SSE) into StreamChunk objects
     and manages the response status.
+
+    ``status`` only becomes ``SUCCESS`` once the stream terminates cleanly — a
+    ``[DONE]`` marker or a terminal ``finish_reason``. An error event, or a
+    stream cut before either of those, leaves ``status`` at ``FAILED``, so a
+    truncated generation is never reported as a complete one. Error events also
+    yield a final ``StreamChunk`` with ``status=FAILED`` and ``error_message``
+    set, rather than raising, so existing ``for chunk in stream`` loops keep
+    working.
 
     The streamer can be used directly in a for loop or as a context manager
     for proper resource cleanup.
@@ -252,6 +297,7 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
         self.status = ResponseStatus.IN_PROGRESS
         self._done = False
         self._buffered_line: Optional[str] = None
+        self._saw_terminal_finish_reason = False
 
     def __iter__(self) -> Iterator[StreamChunk]:
         """Return the iterator for the ModelResponseStreamer."""
@@ -278,7 +324,13 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                     line = next(self._iterator)
             except StopIteration:
                 self._done = True
-                self.status = ResponseStatus.SUCCESS
+                if self._saw_terminal_finish_reason:
+                    # The server closed cleanly after a terminal finish_reason
+                    # but without a [DONE] marker; that is a complete stream.
+                    self.status = ResponseStatus.SUCCESS
+                else:
+                    self.status = ResponseStatus.FAILED
+                    logger.warning("Model stream ended without a [DONE] marker; treating it as truncated.")
                 raise
 
             # Skip empty lines (SSE uses blank lines as separators)
@@ -328,6 +380,16 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
                     return StreamChunk(status=self.status, data=buffered_payload)
                 continue
 
+            # A failure event carries no choices, so it would otherwise fall
+            # through as an empty content chunk and the stream would still be
+            # reported as a success.
+            error_message = _extract_stream_error(data)
+            if error_message is not None:
+                self._done = True
+                self.status = ResponseStatus.FAILED
+                logger.warning("Model stream reported an error: %s", error_message)
+                return StreamChunk(status=ResponseStatus.FAILED, data="", error_message=error_message)
+
             # OpenAI-style stream chunk format:
             # {"choices":[{"delta":{"content":"...", "tool_calls":[...]},"finish_reason":...}],"usage":...}
             if isinstance(data, dict) and "choices" in data:
@@ -356,6 +418,8 @@ class ModelResponseStreamer(Iterator[StreamChunk]):
 
                 finish_reason = choice.get("finish_reason")
                 finish_reason = finish_reason if isinstance(finish_reason, str) else None
+                if finish_reason in _TERMINAL_FINISH_REASONS:
+                    self._saw_terminal_finish_reason = True
 
                 usage = data.get("usage")
                 usage = usage if isinstance(usage, dict) else None

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -5,7 +5,7 @@ import logging
 import time
 import reprlib
 from datetime import datetime
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field
 from dataclasses_json import dataclass_json, config
 from urllib.parse import quote
 from typing import (
@@ -375,6 +375,45 @@ class BaseResource:
         """
         return getattr(self, "_deleted", False)
 
+    # -- hydration provenance -------------------------------------------------
+    #
+    # Stored as plain instance attributes (like ``_deleted``), never dataclass
+    # fields, so they stay invisible to ``to_dict``/``from_dict``, the
+    # ``__dataclass_fields__`` copy loop in ``_create`` and
+    # ``_get_serializable_state``.
+
+    @property
+    def _server_fields(self) -> Optional[frozenset]:
+        """Wire keys present in the response that last hydrated this instance.
+
+        ``None`` means "never hydrated from a server response" (a locally
+        constructed object): nothing is known to be absent, so no save-payload
+        key may be suppressed. A ``frozenset`` means the instance mirrors a
+        server record, and any key *not* in it was genuinely not reported by
+        the backend.
+        """
+        return getattr(self, "_server_field_names", None)
+
+    @_server_fields.setter
+    def _server_fields(self, value: Optional[frozenset]) -> None:
+        self._server_field_names = value
+
+    def _record_server_fields(self, data: Any) -> None:
+        """Remember which top-level wire keys the hydrating response carried."""
+        self._server_fields = frozenset(data.keys()) if isinstance(data, dict) else None
+
+    def _server_omitted(self, wire_key: str) -> bool:
+        """Return True when this instance came from the server and *wire_key* was absent."""
+        server_fields = self._server_fields
+        return server_fields is not None and wire_key not in server_fields
+
+    def _is_at_field_default(self, attr: str) -> bool:
+        """Return True when *attr* still holds its declared dataclass default."""
+        field_def = self.__dataclass_fields__.get(attr)
+        if field_def is None or field_def.default is MISSING:
+            return False
+        return getattr(self, attr, None) == field_def.default
+
     def _update_saved_state(self) -> None:
         """Update the saved state to match the current state.
 
@@ -428,9 +467,28 @@ class BaseResource:
         result = self.context.client.request("post", f"{resource_path}", json=payload)
         # Flatten assetInfo structure before deserialization
         result = _flatten_asset_info(dict(result)) if isinstance(result, dict) else result
+
+        # Record the server id BEFORE hydrating. The POST already succeeded, so
+        # the resource exists remotely; if from_dict() below fails (an
+        # unmodelled enum value, a new nested shape) the caller must still be
+        # able to reach it. Without this the object is left with id=None and
+        # the obvious reaction — retrying save() — creates a second resource
+        # and orphans the first (BUG-1093).
+        created_id = result.get("id") if isinstance(result, dict) else None
+        if created_id is not None:
+            self.id = created_id
+
         # Update the object from the full response
         if isinstance(self, HasFromDict):
-            updated = self.from_dict(result)
+            try:
+                updated = self.from_dict(result)
+            except Exception as e:
+                raise ResourceError(
+                    f"{type(self).__name__} was created (id={self.id!r}) but its response could not be "
+                    f"deserialized: {e}. The resource exists on the platform — do NOT retry save(), which "
+                    f"would create a duplicate. Re-fetch it with {type(self).__name__}.get({self.id!r}), "
+                    f"or delete it."
+                ) from e
             # Copy each field from the freshly-parsed ``updated`` onto self.
             # A field that is excluded from serialization is normally
             # authoritative locally (we never sent it, the response can't
@@ -439,8 +497,15 @@ class BaseResource:
             for field_name, field_def in self.__dataclass_fields__.items():
                 if _is_excluded_from_serialization(field_def) and not _is_auto_deserialize_only(field_def):
                     continue
-                if hasattr(updated, field_name):
-                    setattr(self, field_name, getattr(updated, field_name))
+                if not hasattr(updated, field_name):
+                    continue
+                value = getattr(updated, field_name)
+                # Never let a response the parser could not map back to "id"
+                # un-record the id we just captured.
+                if field_name == "id" and value is None and created_id is not None:
+                    continue
+                setattr(self, field_name, value)
+            self._record_server_fields(result)
         else:
             # Fallback: just set the ID
             self.id = result["id"]
@@ -469,8 +534,17 @@ class BaseResource:
             BaseResource: The saved resource instance
 
         Raises:
+            ValidationError: If the resource has been deleted.
             Backend validation errors as appropriate
         """
+        # save() is the only mutating path that may legitimately run without an
+        # id (the create branch below), so the state check is conditional. A
+        # deleted resource has id=None *and* _deleted=True, and must never fall
+        # through to _create(): that POSTs a duplicate and rebinds self.id to
+        # the new server id (BUG-1093).
+        if self.id or self.is_deleted:
+            self._ensure_valid_state()
+
         resource_path = kwargs.pop("resource_path", self.RESOURCE_PATH)
 
         # Set attributes from kwargs before saving
@@ -514,6 +588,11 @@ class BaseResource:
         # Reset ID and saved state for new asset
         cloned.id = None
         cloned._saved_state = None
+        # A clone is a brand-new resource: it is not the deleted original (so
+        # save() must not refuse it), and none of its field values came from a
+        # server response for *it*, so save() must send them all (BUG-1093).
+        cloned._deleted = False
+        cloned._server_fields = None
 
         # Set attributes from kwargs
         for key, value in kwargs.items():
@@ -920,6 +999,13 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
                     errors.append(f"item[{index}]: {e}")
                     continue
             setattr(obj, "context", context)
+            # Remember which keys the backend actually reported, so save() can
+            # tell "server said null" from "server never mentioned it". The
+            # fallback branch above accepts any resource-shaped class, so this
+            # stays optional.
+            record_server_fields = getattr(obj, "_record_server_fields", None)
+            if callable(record_server_fields):
+                record_server_fields(item)
             # Set the saved state to match the loaded state
             obj._update_saved_state()
             resources.append(obj)
@@ -1162,6 +1248,12 @@ class GetResourceMixin(BaseMixin, Generic[GetParamsT, ResourceT]):
         else:
             instance = cls(**obj)  # type: ignore[call-arg]
         setattr(instance, "context", context)
+        # Remember which keys the backend actually reported, so save() can tell
+        # "server said null" from "server never mentioned it". The ``cls(**obj)``
+        # fallback above accepts any resource-shaped class, so this stays optional.
+        record_server_fields = getattr(instance, "_record_server_fields", None)
+        if callable(record_server_fields):
+            record_server_fields(obj)
         # Set the saved state to match the loaded state
         instance._update_saved_state()
         return instance

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -483,11 +483,19 @@ class BaseResource:
             try:
                 updated = self.from_dict(result)
             except Exception as e:
+                name = type(self).__name__
+                if created_id is not None:
+                    hint = (
+                        f"The resource exists on the platform — do NOT retry save(), which would create a "
+                        f"duplicate. Re-fetch it with {name}.get({created_id!r}), or delete it."
+                    )
+                else:
+                    hint = (
+                        "The resource may exist on the platform even though the response carried no id — "
+                        "check before retrying save(), which would create a duplicate."
+                    )
                 raise ResourceError(
-                    f"{type(self).__name__} was created (id={self.id!r}) but its response could not be "
-                    f"deserialized: {e}. The resource exists on the platform — do NOT retry save(), which "
-                    f"would create a duplicate. Re-fetch it with {type(self).__name__}.get({self.id!r}), "
-                    f"or delete it."
+                    f"{name} was created (id={created_id!r}) but its response could not be deserialized: {e}. {hint}"
                 ) from e
             # Copy each field from the freshly-parsed ``updated`` onto self.
             # A field that is excluded from serialization is normally
@@ -534,7 +542,10 @@ class BaseResource:
             BaseResource: The saved resource instance
 
         Raises:
-            ValidationError: If the resource has been deleted.
+            ResourceError: If the resource has been deleted. The guard raises
+                ``ValidationError``, which the ``@with_hooks`` wrapper re-raises
+                as ``ResourceError`` — the same shape ``delete()`` already had.
+                Both derive from ``AixplainV2Error``.
             Backend validation errors as appropriate
         """
         # save() is the only mutating path that may legitimately run without an

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -909,8 +909,16 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
                     errors.append(f"item[{index}]: {e}")
                     continue
             else:
-                # Fallback for classes without from_dict
-                obj = cls(**item)  # type: ignore[call-arg]
+                # Fallback for classes without from_dict. It fails the same way
+                # from_dict does (a non-mapping record, an unexpected field), so
+                # report it rather than letting a raw TypeError escape a call the
+                # caller asked to be lenient.
+                try:
+                    obj = cls(**item)  # type: ignore[call-arg]
+                except Exception as e:
+                    logger.warning("Skipping item during %s deserialization: %s", cls.__name__, e)
+                    errors.append(f"item[{index}]: {e}")
+                    continue
             setattr(obj, "context", context)
             # Set the saved state to match the loaded state
             obj._update_saved_state()
@@ -1062,14 +1070,13 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
             # rather than collapsing it to ``len(results)``.
             total = max(total - skipped, len(results))
 
-        page = Page(
+        return Page(
             results=results,
             total=total,
             page_number=kwargs["page_number"],
             page_total=page_total,
+            skipped=skipped,
         )
-        page.skipped = skipped
-        return page
 
     @classmethod
     def _populate_path(cls, path: str, custom_path: Optional[str] = None) -> str:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -715,7 +715,8 @@ class BaseSearchParams(BaseParams):
         paginate_items_key: str: Optional key name for items in paginated
                                 response (overrides PAGINATE_ITEMS_KEY).
         strict: bool: Whether a record that cannot be deserialized raises
-                     (default) or is skipped. Overrides PAGINATE_STRICT.
+                     instead of being skipped (default: skip, correcting
+                     ``Page.total``). Overrides PAGINATE_STRICT.
     """
 
     query: NotRequired[str]
@@ -896,8 +897,8 @@ class Page(Generic[ResourceT]):
         total: Total number of resources across all pages. Never counts a
             record that was returned by the API but skipped by this page.
         skipped: Number of records the API returned for this page that could
-            not be deserialized and were skipped. Always ``0`` in strict mode
-            (the default), where such records raise instead.
+            not be deserialized and were skipped. Always ``0`` under
+            ``strict=True``, where such records raise instead.
     """
 
     results: List[ResourceT]
@@ -956,8 +957,10 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
         PAGINATE_DEFAULT_PAGE_NUMBER: int: The default page number.
         PAGINATE_DEFAULT_PAGE_SIZE: int: The default page size.
         PAGINATE_STRICT: bool: Whether a record that cannot be deserialized
-            raises instead of being skipped. A per-call ``strict=`` keyword
-            takes precedence over this class-level default.
+            raises instead of being skipped and subtracted from ``Page.total``.
+            Defaults to False: discovery listings must survive a record the
+            client cannot model yet (a new backend enum value, say). A per-call
+            ``strict=`` keyword takes precedence over this class-level default.
     """
 
     PAGINATE_PATH: str = "paginate"
@@ -968,7 +971,7 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
     PAGINATE_PAGE_NUMBER_KEY: str = "pageNumber"
     PAGINATE_DEFAULT_PAGE_NUMBER: int = 0
     PAGINATE_DEFAULT_PAGE_SIZE: int = 20
-    PAGINATE_STRICT: bool = True
+    PAGINATE_STRICT: bool = False
 
     @classmethod
     def _get_context_and_path(cls: type, **kwargs: Any) -> Tuple["Aixplain", str, Optional[str]]:
@@ -991,8 +994,8 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
 
         Errors are returned alongside the successfully built resources instead of
         being swallowed, so that :meth:`_build_page` can decide whether to raise
-        (strict, the default) or to correct ``Page.total`` so it never counts a
-        record the page does not contain.
+        (under ``strict``) or to correct ``Page.total`` so it never counts a
+        record the page does not contain (the default).
 
         Args:
             items: The raw records from the paginated response.
@@ -1045,10 +1048,12 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
     def _build_resources(cls: type, items: List[dict], context: "Aixplain") -> List[ResourceT]:
         """Build resource instances from response items.
 
-        Backward-compatible wrapper around :meth:`_deserialize_items`. It
-        discards deserialization errors, so internal callers should prefer
-        :meth:`_deserialize_items`; subclasses customising deserialization
-        should override that hook instead of this one.
+        .. deprecated::
+            :meth:`_build_page` no longer calls this method, so overriding it
+            no longer customises listings. It is kept only for callers that
+            build resources directly. Override :meth:`_deserialize_items`
+            instead — that is the hook listings use, and it reports the
+            deserialization errors this wrapper discards.
         """
         resources, _ = cls._deserialize_items(items, context)
         return resources
@@ -1080,12 +1085,16 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
     def search(cls: type, **kwargs: Unpack[SearchParamsT]) -> Page[ResourceT]:
         """Search resources across the first n pages with optional filtering.
 
-        If any record returned by the API cannot be deserialized, this raises
-        :class:`ResourceError`, matching the contract of ``get()``. Pass
-        ``strict=False`` to skip such records instead; in that mode
-        ``Page.total`` is reduced by the number skipped and ``Page.skipped``
-        reports the count, so ``page.total`` never counts a record the page
-        does not contain.
+        A record the API returns but this client cannot deserialize is logged
+        and skipped rather than failing the whole listing; ``Page.total`` is
+        reduced by the number skipped and ``Page.skipped`` reports the count,
+        so ``page.total`` never counts a record the page does not contain.
+        Pass ``strict=True`` (or set ``PAGINATE_STRICT``) to raise
+        :class:`ResourceError` on such a record instead.
+
+        A response that carries no readable item list at all always raises:
+        there is nothing to count, and an empty page would be
+        indistinguishable from a search that genuinely matched nothing.
 
         Args:
             kwargs: The keyword arguments.
@@ -1094,8 +1103,8 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
             Page[ResourceT]: Page of BaseResource instances
 
         Raises:
-            ResourceError: If a returned record cannot be deserialized and
-                ``strict`` is enabled (the default).
+            ResourceError: If the response envelope carries no item list, or if
+                a returned record cannot be deserialized and ``strict`` is on.
         """
         # Set default pagination values
         default_page_number = getattr(cls, "PAGINATE_DEFAULT_PAGE_NUMBER", 0)
@@ -1119,39 +1128,87 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
         return cls._build_page(response, context, **kwargs)
 
     @classmethod
+    def _extract_page_items(cls: type, json_data: Any, paginate_items_key: Optional[str]) -> List[Any]:
+        """Return the record list carried by a paginated response envelope.
+
+        An envelope the client cannot read is a failure, not an empty page: a
+        renamed items key, or a 200 body that is actually an error report,
+        would otherwise be indistinguishable from "this search matched
+        nothing". A present item list — including an empty one, or an explicit
+        ``null`` — is passed through as the empty page it genuinely is.
+
+        Args:
+            json_data: The decoded response body.
+            paginate_items_key: The envelope key holding the records, or None
+                for endpoints that answer with a bare array.
+
+        Returns:
+            List[Any]: The raw records to deserialize.
+
+        Raises:
+            ResourceError: If the response carries no usable item list.
+        """
+        # A bare array is usable whatever the configured key: some list
+        # endpoints (API keys) answer that way while inheriting the default.
+        if isinstance(json_data, list):
+            return json_data
+
+        if not isinstance(json_data, dict):
+            raise ResourceError(
+                f"{cls.__name__}: paginated response is a {type(json_data).__name__}, "
+                "not a list of records or an envelope containing one."
+            )
+
+        if not paginate_items_key:
+            raise ResourceError(
+                f"{cls.__name__}: paginated response is an object, but this resource expects a bare array. "
+                f"Keys returned: {sorted(json_data)}."
+            )
+
+        if paginate_items_key not in json_data:
+            raise ResourceError(
+                f"{cls.__name__}: paginated response is missing the {paginate_items_key!r} key, "
+                f"so it carries no results to read. Keys returned: {sorted(json_data)}."
+            )
+
+        items = json_data[paginate_items_key]
+        # An explicit null is how some endpoints spell "no results".
+        if items is None:
+            return []
+        if not isinstance(items, list):
+            raise ResourceError(
+                f"{cls.__name__}: paginated response {paginate_items_key!r} is a "
+                f"{type(items).__name__}, not a list of records."
+            )
+        return items
+
+    @classmethod
     def _build_page(cls: type, response: "Any", context: "Aixplain", **kwargs: Any) -> Page[ResourceT]:
         """Build a page of resources from the response.
 
         Accepts either a requests.Response or already-decoded dict/list. A
-        missing envelope key falls back to the computed default (an empty item
-        list, or ``len(items)`` for the counts) and logs a warning rather than
-        raising.
+        missing ``total`` / ``pageTotal`` falls back to the computed default,
+        but an envelope that carries no usable item list at all is reported:
+        a renamed envelope, or a 200 error body, must not be indistinguishable
+        from "no results". A present-but-empty (or explicitly ``null``) item
+        list is a genuinely empty page and stays one.
+
+        Records inside a usable envelope are treated leniently by default: each
+        one that cannot be deserialized is logged and skipped, and ``total`` is
+        corrected so it never counts a record the page does not contain.
 
         Raises:
-            ResourceError: If a returned record cannot be deserialized and
-                ``strict`` is enabled (the default).
+            ResourceError: If the response carries no usable item list, or if a
+                returned record cannot be deserialized and ``strict`` is on.
         """
         if hasattr(response, "json"):
             json_data = response.json()
         else:
             json_data = response
 
-        items = json_data
         # Check for override in kwargs first, then fall back to class attribute
         paginate_items_key = kwargs.get("paginate_items_key") or getattr(cls, "PAGINATE_ITEMS_KEY", "items")
-        if paginate_items_key and isinstance(json_data, dict):
-            if paginate_items_key not in json_data:
-                logger.warning(
-                    "%s: paginated response is missing the %r key; treating the page as empty",
-                    cls.__name__,
-                    paginate_items_key,
-                )
-            # The honest default for a missing items key is an empty page: falling
-            # back to ``json_data`` itself would iterate the envelope's keys and
-            # build garbage resources out of strings.
-            items = json_data.get(paginate_items_key) or []
-        if not isinstance(items, list):
-            items = []
+        items = cls._extract_page_items(json_data, paginate_items_key)
 
         total = len(items)
         paginate_total_key = getattr(cls, "PAGINATE_TOTAL_KEY", "total")
@@ -1174,16 +1231,26 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
         if skipped:
             strict = kwargs.get("strict")
             if strict is None:
-                strict = getattr(cls, "PAGINATE_STRICT", True)
+                strict = getattr(cls, "PAGINATE_STRICT", False)
             if strict:
                 raise ResourceError(
                     f"Failed to deserialize {skipped} of {len(items)} {cls.__name__} record(s) "
                     f"returned by the API; pass strict=False to skip them. "
                     f"Details: {'; '.join(errors[:3])}"
                 )
-            # Lenient mode: never report a total that counts records we did not
-            # return. ``total`` spans every page, so subtract this page's drops
-            # rather than collapsing it to ``len(results)``.
+            # Lenient default: one record the client cannot model — a new enum
+            # value, say — must not cost the caller the whole listing. The
+            # drops are logged per record by _deserialize_items and summarised
+            # here, and ``total`` never counts a record we did not return:
+            # ``total`` spans every page, so subtract this page's drops rather
+            # than collapsing it to ``len(results)``.
+            logger.warning(
+                "%s: skipped %d of %d record(s) returned by the API; pass strict=True to raise instead. Details: %s",
+                cls.__name__,
+                skipped,
+                len(items),
+                "; ".join(errors[:3]),
+            )
             total = max(total - skipped, len(results))
 
         return Page(

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -605,6 +605,8 @@ class BaseSearchParams(BaseParams):
                           RESOURCE_PATH.
         paginate_items_key: str: Optional key name for items in paginated
                                 response (overrides PAGINATE_ITEMS_KEY).
+        strict: bool: Whether a record that cannot be deserialized raises
+                     (default) or is skipped. Overrides PAGINATE_STRICT.
     """
 
     query: NotRequired[str]
@@ -615,6 +617,7 @@ class BaseSearchParams(BaseParams):
     page_size: NotRequired[int]
     resource_path: NotRequired[str]
     paginate_items_key: NotRequired[str]
+    strict: NotRequired[bool]
 
 
 class BaseGetParams(BaseParams):
@@ -781,15 +784,27 @@ class Page(Generic[ResourceT]):
         results: The list of resources in this page.
         page_number: Current page number (0-indexed).
         page_total: Total number of pages.
-        total: Total number of resources across all pages.
+        total: Total number of resources across all pages. Never counts a
+            record that was returned by the API but skipped by this page.
+        skipped: Number of records the API returned for this page that could
+            not be deserialized and were skipped. Always ``0`` in strict mode
+            (the default), where such records raise instead.
     """
 
     results: List[ResourceT]
     page_number: int
     page_total: int
     total: int
+    skipped: int
 
-    def __init__(self, results: List[ResourceT], page_number: int, page_total: int, total: int):
+    def __init__(
+        self,
+        results: List[ResourceT],
+        page_number: int,
+        page_total: int,
+        total: int,
+        skipped: int = 0,
+    ):
         """Initialize a Page instance.
 
         Args:
@@ -797,11 +812,13 @@ class Page(Generic[ResourceT]):
             page_number: Current page number (0-indexed)
             page_total: Total number of pages
             total: Total number of resources across all pages
+            skipped: Number of returned records that could not be deserialized
         """
         self.results = results
         self.page_number = page_number
         self.page_total = page_total
         self.total = total
+        self.skipped = skipped
 
     def __repr__(self) -> str:
         """Return JSON representation of the page."""
@@ -829,6 +846,9 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
         PAGINATE_PAGE_TOTAL_KEY: str: The key for the total number of pages.
         PAGINATE_DEFAULT_PAGE_NUMBER: int: The default page number.
         PAGINATE_DEFAULT_PAGE_SIZE: int: The default page size.
+        PAGINATE_STRICT: bool: Whether a record that cannot be deserialized
+            raises instead of being skipped. A per-call ``strict=`` keyword
+            takes precedence over this class-level default.
     """
 
     PAGINATE_PATH: str = "paginate"
@@ -839,6 +859,7 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
     PAGINATE_PAGE_NUMBER_KEY: str = "pageNumber"
     PAGINATE_DEFAULT_PAGE_NUMBER: int = 0
     PAGINATE_DEFAULT_PAGE_SIZE: int = 20
+    PAGINATE_STRICT: bool = True
 
     @classmethod
     def _get_context_and_path(cls: type, **kwargs: Any) -> Tuple["Aixplain", str, Optional[str]]:
@@ -856,10 +877,25 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
         return context, resource_path, custom_path
 
     @classmethod
-    def _build_resources(cls: type, items: List[dict], context: "Aixplain") -> List[ResourceT]:
-        """Build resource instances from response items."""
-        resources = []
-        for item in items:
+    def _deserialize_items(cls: type, items: List[dict], context: "Aixplain") -> Tuple[List[ResourceT], List[str]]:
+        """Build resource instances from response items, reporting failures.
+
+        Errors are returned alongside the successfully built resources instead of
+        being swallowed, so that :meth:`_build_page` can decide whether to raise
+        (strict, the default) or to correct ``Page.total`` so it never counts a
+        record the page does not contain.
+
+        Args:
+            items: The raw records from the paginated response.
+            context: The Aixplain context to attach to each resource.
+
+        Returns:
+            Tuple[List[ResourceT], List[str]]: The resources that were built and
+            a message per record that could not be deserialized.
+        """
+        resources: List[ResourceT] = []
+        errors: List[str] = []
+        for index, item in enumerate(items):
             # Flatten assetInfo structure before deserialization
             item = _flatten_asset_info(dict(item)) if isinstance(item, dict) else item
             # Use dataclasses_json's from_dict to handle field aliasing
@@ -870,6 +906,7 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
                     obj = cls.from_dict(item)
                 except Exception as e:
                     logger.warning("Skipping item during %s deserialization: %s", cls.__name__, e)
+                    errors.append(f"item[{index}]: {e}")
                     continue
             else:
                 # Fallback for classes without from_dict
@@ -878,6 +915,18 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
             # Set the saved state to match the loaded state
             obj._update_saved_state()
             resources.append(obj)
+        return resources, errors
+
+    @classmethod
+    def _build_resources(cls: type, items: List[dict], context: "Aixplain") -> List[ResourceT]:
+        """Build resource instances from response items.
+
+        Backward-compatible wrapper around :meth:`_deserialize_items`. It
+        discards deserialization errors, so internal callers should prefer
+        :meth:`_deserialize_items`; subclasses customising deserialization
+        should override that hook instead of this one.
+        """
+        resources, _ = cls._deserialize_items(items, context)
         return resources
 
     @classmethod
@@ -907,11 +956,22 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
     def search(cls: type, **kwargs: Unpack[SearchParamsT]) -> Page[ResourceT]:
         """Search resources across the first n pages with optional filtering.
 
+        If any record returned by the API cannot be deserialized, this raises
+        :class:`ResourceError`, matching the contract of ``get()``. Pass
+        ``strict=False`` to skip such records instead; in that mode
+        ``Page.total`` is reduced by the number skipped and ``Page.skipped``
+        reports the count, so ``page.total`` never counts a record the page
+        does not contain.
+
         Args:
             kwargs: The keyword arguments.
 
         Returns:
             Page[ResourceT]: Page of BaseResource instances
+
+        Raises:
+            ResourceError: If a returned record cannot be deserialized and
+                ``strict`` is enabled (the default).
         """
         # Set default pagination values
         default_page_number = getattr(cls, "PAGINATE_DEFAULT_PAGE_NUMBER", 0)
@@ -938,7 +998,14 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
     def _build_page(cls: type, response: "Any", context: "Aixplain", **kwargs: Any) -> Page[ResourceT]:
         """Build a page of resources from the response.
 
-        Accepts either a requests.Response or already-decoded dict/list.
+        Accepts either a requests.Response or already-decoded dict/list. A
+        missing envelope key falls back to the computed default (an empty item
+        list, or ``len(items)`` for the counts) and logs a warning rather than
+        raising.
+
+        Raises:
+            ResourceError: If a returned record cannot be deserialized and
+                ``strict`` is enabled (the default).
         """
         if hasattr(response, "json"):
             json_data = response.json()
@@ -949,27 +1016,60 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
         # Check for override in kwargs first, then fall back to class attribute
         paginate_items_key = kwargs.get("paginate_items_key") or getattr(cls, "PAGINATE_ITEMS_KEY", "items")
         if paginate_items_key and isinstance(json_data, dict):
-            items = json_data[paginate_items_key]
+            if paginate_items_key not in json_data:
+                logger.warning(
+                    "%s: paginated response is missing the %r key; treating the page as empty",
+                    cls.__name__,
+                    paginate_items_key,
+                )
+            # The honest default for a missing items key is an empty page: falling
+            # back to ``json_data`` itself would iterate the envelope's keys and
+            # build garbage resources out of strings.
+            items = json_data.get(paginate_items_key) or []
+        if not isinstance(items, list):
+            items = []
 
         total = len(items)
         paginate_total_key = getattr(cls, "PAGINATE_TOTAL_KEY", "total")
         if paginate_total_key and isinstance(json_data, dict):
-            total = json_data[paginate_total_key]
+            total = json_data.get(paginate_total_key, total)
+        if not isinstance(total, int) or isinstance(total, bool):
+            total = len(items)
 
         page_total = len(items)
         paginate_page_total_key = getattr(cls, "PAGINATE_PAGE_TOTAL_KEY", "pageTotal")
         if paginate_page_total_key and isinstance(json_data, dict):
-            page_total = json_data[paginate_page_total_key]
+            page_total = json_data.get(paginate_page_total_key, page_total)
+        if not isinstance(page_total, int) or isinstance(page_total, bool):
+            page_total = len(items)
 
         # Build resources using shared method
-        results = cls._build_resources(items, context)
+        results, errors = cls._deserialize_items(items, context)
 
-        return Page(
+        skipped = len(errors)
+        if skipped:
+            strict = kwargs.get("strict")
+            if strict is None:
+                strict = getattr(cls, "PAGINATE_STRICT", True)
+            if strict:
+                raise ResourceError(
+                    f"Failed to deserialize {skipped} of {len(items)} {cls.__name__} record(s) "
+                    f"returned by the API; pass strict=False to skip them. "
+                    f"Details: {'; '.join(errors[:3])}"
+                )
+            # Lenient mode: never report a total that counts records we did not
+            # return. ``total`` spans every page, so subtract this page's drops
+            # rather than collapsing it to ``len(results)``.
+            total = max(total - skipped, len(results))
+
+        page = Page(
             results=results,
             total=total,
             page_number=kwargs["page_number"],
             page_total=page_total,
         )
+        page.skipped = skipped
+        return page
 
     @classmethod
     def _populate_path(cls, path: str, custom_path: Optional[str] = None) -> str:
@@ -1663,7 +1763,13 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         # Handle polling response - use camelCase keys (what backend sends)
         # dataclass_json with config(field_name=...) handles mapping to snake_case
         run_time, used_credits = _extract_run_time_and_used_credits(response)
-        data = response.get("data") or {}
+        data = response.get("data")
+        if data is None:
+            # Absent data keeps the historical {} shape, but a falsy-but-present
+            # value ("", 0, False, []) is passed through unchanged so that a poll
+            # returns the same value and type as the synchronous path in
+            # handle_run_response.
+            data = {}
         data_error = data.get("error") if isinstance(data, dict) else None
         error_message = response.get("errorMessage") or data_error
         filtered_response = {
@@ -1697,11 +1803,12 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                     "Poll response deserialization failed for a completed response. "
                     "Building fallback result from raw data."
                 )
+                fallback_data = filtered_response.get("data")
                 result = response_class.from_dict(
                     {
                         "status": filtered_response["status"],
                         "completed": True,
-                        "data": filtered_response.get("data") or {},
+                        "data": {} if fallback_data is None else fallback_data,
                     }
                 )
             else:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -90,13 +90,21 @@ def _filter_values(value: Any) -> List[str]:
 def _sort_direction(sort_order: Any) -> int:
     """Return the backend's sort direction for a sort order argument.
 
+    Handles v2's string-valued ``SortOrder`` (``"ASC"``/``"DESC"``), the
+    longer ``"ASCENDING"``/``"DESCENDING"`` spellings, and already-numeric
+    inputs (v1's ``SortOrder`` is valued ``1``/``-1``), which are mapped by
+    sign so that a caller migrating from v1 keeps the direction they asked for.
+
     Args:
-        sort_order: ``SortOrder`` member or equivalent string.
+        sort_order: ``SortOrder`` member, equivalent string, or +/-1.
 
     Returns:
         int: ``-1`` for descending, ``1`` for ascending (the default).
     """
-    return -1 if _filter_value(sort_order).upper() == _DESCENDING else 1
+    raw = getattr(sort_order, "value", sort_order)
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return -1 if raw < 0 else 1
+    return -1 if _filter_value(raw).upper().startswith(_DESCENDING) else 1
 
 
 # Hook decorator system
@@ -882,8 +890,8 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
 
         if params.get("ownership") is not None:
             ownership = params["ownership"]
-            if isinstance(ownership, (list, tuple)):
-                filters["ownership"] = [_filter_value(o) for o in ownership]
+            if isinstance(ownership, (list, tuple, set)):
+                filters["ownership"] = _filter_values(ownership)
             else:
                 filters["ownership"] = _filter_value(ownership)
 

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -668,12 +668,31 @@ class BaseResource:
         return encode_resource_id(self.id)
 
 
+# Keys the SDK consumes itself when *dispatching* a request (choosing the path,
+# authenticating). They are declared on ``BaseParams`` for every operation, so
+# they can arrive on any call — and must never be forwarded to a backend body or
+# to ``requests.Session.request``, which would raise ``TypeError``.
+#
+# ``api_key`` authenticates nothing: ``Client.request_raw`` always overlays
+# ``_auth_headers()`` from the Aixplain context, so a per-call ``api_key``'s only
+# observable effect was riding into the model input body (BUG-1091).
+_SDK_REQUEST_KEYS: frozenset[str] = frozenset({"api_key", "resource_path"})
+
+
 class BaseParams(TypedDict):
     """Base class for parameters that include API key and resource path.
 
     Attributes:
-        api_key: str: The API key for authentication.
-        resource_path: str: Custom resource path for actions (optional).
+        api_key: Accepted for backward compatibility and **ignored**.
+            Authentication always comes from the ``Aixplain`` context
+            (``Client._auth_headers``), which overrides any per-call value. It is
+            stripped from every request so it can never reach a model input body
+            or a supplier's prompt logs. Configure credentials via
+            ``Aixplain(api_key=...)`` or ``TEAM_API_KEY`` / ``AIXPLAIN_API_KEY``
+            instead.
+        resource_path: Custom resource path for actions (optional). Consumed by
+            the URL builders; never forwarded to the backend body or to
+            ``requests``.
     """
 
     api_key: NotRequired[str]
@@ -1246,6 +1265,11 @@ class GetResourceMixin(BaseMixin, Generic[GetParamsT, ResourceT]):
         if host is not None:
             kwargs["params"] = {"host": host}
 
+        # ``api_key`` is inert (the client supplies auth) and is not a ``requests``
+        # kwarg; ``resource_path`` was already popped above. Same root cause as
+        # ``delete`` (BUG-1091).
+        kwargs = {k: v for k, v in kwargs.items() if k not in _SDK_REQUEST_KEYS}
+
         obj = context.client.get(path, **kwargs)
 
         # Flatten assetInfo structure before deserialization
@@ -1389,8 +1413,14 @@ class DeleteResourceMixin(BaseMixin, Generic[DeleteParamsT, DeleteResultT]):
         # Build the delete URL
         delete_url = self.build_delete_url(**kwargs)
 
+        # ``resource_path`` was consumed by build_delete_url and ``api_key`` is
+        # inert (the client supplies auth); neither is a ``requests`` kwarg.
+        # Forwarding them made ``delete(resource_path=…)`` raise TypeError deep
+        # inside requests (BUG-1091).
+        request_kwargs = {k: v for k, v in kwargs.items() if k not in _SDK_REQUEST_KEYS}
+
         # Execute the delete operation (delete endpoints don't return JSON)
-        response = self.context.client.request_raw("delete", delete_url, **kwargs)
+        response = self.context.client.request_raw("delete", delete_url, **request_kwargs)
 
         # Handle the response using the extensible response handler
         return self.handle_delete_response(response, **kwargs)
@@ -1530,16 +1560,34 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     # top-level ``session_id`` kwarg is purely the per-run correlation channel
     # emitted as ``x-session-id``; ``agent_name`` is likewise only the calling
     # agent's name, emitted as ``x-agent``.
-    _RUN_CONTROL_KEYS: frozenset[str] = frozenset(
-        {
-            "run_retries",
-            "run_retry_wait",
-            "timeout",
-            "wait_time",
-            "show_progress",
-            "session_id",
-            "agent_name",
-        }
+    #
+    # ``api_key`` / ``resource_path`` (``_SDK_REQUEST_KEYS``) are excluded for a
+    # different reason: they are declared on ``BaseParams`` for *every* operation,
+    # so they can arrive on a run call, and neither is a backend body field.
+    # ``api_key`` in particular authenticated nothing — its only observable effect
+    # was riding into the model input body and the supplier's prompt logs
+    # (BUG-1091).
+    #
+    # The ``progress_*`` trio configures the client-side progress display (the
+    # ``show_progress`` toggle already lived here). ``before_run`` / ``after_run``
+    # still receive the *unfiltered* kwargs, so the tracker keeps seeing them —
+    # only the payload/URL builders are filtered.
+    _RUN_CONTROL_KEYS: frozenset[str] = (
+        frozenset(
+            {
+                "run_retries",
+                "run_retry_wait",
+                "timeout",
+                "wait_time",
+                "show_progress",
+                "progress_format",
+                "progress_verbosity",
+                "progress_truncate",
+                "session_id",
+                "agent_name",
+            }
+        )
+        | _SDK_REQUEST_KEYS
     )
 
     @staticmethod

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -2046,12 +2046,13 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                     "Poll response deserialization failed for a completed response. "
                     "Building fallback result from raw data."
                 )
-                fallback_data = filtered_response.get("data")
+                # ``data`` was already defaulted to {} above when the response
+                # omitted it, so it is never None here.
                 result = response_class.from_dict(
                     {
                         "status": filtered_response["status"],
                         "completed": True,
-                        "data": {} if fallback_data is None else fallback_data,
+                        "data": filtered_response["data"],
                     }
                 )
             else:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -45,6 +45,60 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_DESCENDING = "DESC"
+
+
+def _filter_value(value: Any) -> str:
+    """Return the wire value for a search filter argument.
+
+    Accepts a plain string, a string-valued enum member (v2) or a dict-valued
+    enum member exposing a ``code``/``id`` key (the legacy v1 ``Supplier``
+    shape). ``str(member)`` is deliberately avoided: for a
+    ``class X(str, Enum)`` it returns the member repr
+    (``"OwnershipType.PRIVATE"``) rather than the value (``"PRIVATE"``), which
+    the backend silently fails to match.
+
+    Args:
+        value: The filter argument as supplied by the caller.
+
+    Returns:
+        str: The value to place in the request body.
+    """
+    raw = getattr(value, "value", value)
+    if isinstance(raw, dict):
+        raw = raw.get("code") or raw.get("id") or ""
+    return str(raw)
+
+
+def _filter_values(value: Any) -> List[str]:
+    """Return the wire values for a filter that the backend expects as an array.
+
+    A scalar argument is wrapped in a single-element list, so callers may pass
+    either ``Supplier.OPENAI`` or ``[Supplier.OPENAI, "cohere"]``.
+
+    Args:
+        value: A single filter argument or a sequence of them.
+
+    Returns:
+        List[str]: The values to place in the request body.
+    """
+    if isinstance(value, (list, tuple, set)):
+        return [_filter_value(item) for item in value]
+    return [_filter_value(value)]
+
+
+def _sort_direction(sort_order: Any) -> int:
+    """Return the backend's sort direction for a sort order argument.
+
+    Args:
+        sort_order: ``SortOrder`` member or equivalent string.
+
+    Returns:
+        int: ``-1`` for descending, ``1`` for ascending (the default).
+    """
+    return -1 if _filter_value(sort_order).upper() == _DESCENDING else 1
+
+
 # Hook decorator system
 def with_hooks(func: Callable) -> Callable:
     """Generic decorator to add before/after hooks to resource operations.
@@ -827,13 +881,17 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
             filters["q"] = params["query"]
 
         if params.get("ownership") is not None:
-            filters["ownership"] = str(params["ownership"])
+            ownership = params["ownership"]
+            if isinstance(ownership, (list, tuple)):
+                filters["ownership"] = [_filter_value(o) for o in ownership]
+            else:
+                filters["ownership"] = _filter_value(ownership)
 
         if params.get("sort_by") is not None:
-            filters["sortBy"] = str(params["sort_by"])
+            filters["sortBy"] = _filter_value(params["sort_by"])
 
         if params.get("sort_order") is not None:
-            filters["sortOrder"] = str(params["sort_order"])
+            filters["sortOrder"] = _filter_value(params["sort_order"])
 
         return filters
 

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -332,6 +332,25 @@ class BaseResource:
             else:
                 raise ValidationError(f"{resource_name} has been deleted or is invalid. {resource_name} ID is missing.")
 
+    def _ensure_saveable(self) -> None:
+        """Guard ``save()`` on a resource that is deleted or otherwise unusable.
+
+        ``BaseResource.save`` runs inside :func:`with_hooks`, which re-raises
+        anything that is not a ``ResourceError`` as one, while the sibling
+        guards in ``Agent.save`` and ``File.save`` run outside it. Raising
+        ``ValidationError`` from the guard therefore split one rule across two
+        exception types, and ``except ResourceError`` around ``agent.save()``
+        caught only some of the paths. Every deleted-save guard raises
+        ``ResourceError`` through this helper (BUG-1093).
+
+        Raises:
+            ResourceError: If the resource is deleted or has no usable id.
+        """
+        try:
+            self._ensure_valid_state()
+        except ValidationError as exc:
+            raise ResourceError(str(exc)) from exc
+
     def _get_serializable_state(self) -> dict:
         """Get the current state of the resource as a serializable dictionary.
 
@@ -542,10 +561,9 @@ class BaseResource:
             BaseResource: The saved resource instance
 
         Raises:
-            ResourceError: If the resource has been deleted. The guard raises
-                ``ValidationError``, which the ``@with_hooks`` wrapper re-raises
-                as ``ResourceError`` — the same shape ``delete()`` already had.
-                Both derive from ``AixplainV2Error``.
+            ResourceError: If the resource has been deleted — the same type
+                every other deleted-save guard raises, so one ``except`` clause
+                covers ``BaseResource.save``, ``Agent.save`` and ``File.save``.
             Backend validation errors as appropriate
         """
         # save() is the only mutating path that may legitimately run without an
@@ -554,7 +572,7 @@ class BaseResource:
         # through to _create(): that POSTs a duplicate and rebinds self.id to
         # the new server id (BUG-1093).
         if self.id or self.is_deleted:
-            self._ensure_valid_state()
+            self._ensure_saveable()
 
         resource_path = kwargs.pop("resource_path", self.RESOURCE_PATH)
 

--- a/aixplain/v2/session.py
+++ b/aixplain/v2/session.py
@@ -423,6 +423,36 @@ class ExecutionConfig:
         return out
 
     @classmethod
+    def _lift_wire_budget(cls, kvs: Any) -> Any:
+        """Lift a wire ``executionParams.budget`` back into the ``budget`` slot.
+
+        ``to_api_dict`` serializes ``budget`` *into* ``executionParams.budget``,
+        but nothing decoded it back out — so a session loaded from the backend
+        came back with ``budget=None`` and the real cap buried inside
+        ``execution_params``. Anything that then set ``budget`` (e.g. the run
+        path seeding it from ``agent.budget``) would silently overwrite that
+        persisted cap on the next ``to_api_dict``. Decoding is now symmetric with
+        encoding, so there is exactly one representation of the cap in memory.
+
+        An explicit top-level ``budget`` wins; the standalone nested key is
+        always dropped so it cannot be emitted twice. Returns a copy; the
+        caller's dict is untouched.
+        """
+        if not isinstance(kvs, dict):
+            return kvs
+        key = "executionParams" if "executionParams" in kvs else "execution_params"
+        ep = kvs.get(key)
+        if not isinstance(ep, dict) or ep.get("budget") is None:
+            return kvs
+        kvs = dict(kvs)  # shallow copy; never mutate the caller's dict
+        ep = dict(ep)
+        nested = ep.pop("budget")
+        if kvs.get("budget") is None:
+            kvs["budget"] = nested
+        kvs[key] = ep
+        return kvs
+
+    @classmethod
     def _fold_legacy_max_iterations(cls, kvs: Any) -> Any:
         """Fold a legacy ``executionParams.maxIterations`` into ``budget`` silently.
 
@@ -476,7 +506,7 @@ _dataclass_json_execution_config_from_dict = ExecutionConfig.from_dict.__func__
 
 
 def _execution_config_from_dict(cls, kvs: Any, *, infer_missing: bool = False) -> "ExecutionConfig":
-    kvs = cls._fold_legacy_max_iterations(kvs)
+    kvs = cls._fold_legacy_max_iterations(cls._lift_wire_budget(kvs))
     return _dataclass_json_execution_config_from_dict(cls, kvs, infer_missing=infer_missing)
 
 
@@ -548,7 +578,7 @@ class Session(
         if isinstance(kvs, dict):
             ec = kvs.get("executionConfig") or kvs.get("execution_config")
             if isinstance(ec, dict):
-                folded = ExecutionConfig._fold_legacy_max_iterations(ec)
+                folded = ExecutionConfig._fold_legacy_max_iterations(ExecutionConfig._lift_wire_budget(ec))
                 if folded is not ec:  # only copy when a fold actually happened
                     kvs = dict(kvs)
                     if "executionConfig" in kvs:

--- a/aixplain/v2/skill.py
+++ b/aixplain/v2/skill.py
@@ -40,6 +40,7 @@ from .resource import (
     GetResourceMixin,
     DeleteResourceMixin,
     Page,
+    _filter_values,
 )
 from .enums import Privacy
 from .mixins import ToolableMixin
@@ -193,7 +194,7 @@ class Skill(
         if params.get("tags") is not None:
             filters["tags"] = params["tags"]
         if params.get("suppliers") is not None:
-            filters["suppliers"] = params["suppliers"]
+            filters["suppliers"] = _filter_values(params["suppliers"])
         if params.get("saved") is not None:
             filters["saved"] = params["saved"]
         return filters

--- a/docs/api-reference/python/aixplain/v2/model.md
+++ b/docs/api-reference/python/aixplain/v2/model.md
@@ -205,16 +205,6 @@ def __exit__(exc_type, exc_val, exc_tb) -> None
 
 Context manager exit - ensures response is closed.
 
-#### find\_supplier\_by\_id
-
-```python
-def find_supplier_by_id(supplier_id: Union[str, int]) -> Optional[Supplier]
-```
-
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/model.py#L398)
-
-Find supplier enum by ID.
-
 #### find\_function\_by\_id
 
 ```python

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3400,16 +3400,6 @@ def __exit__(exc_type, exc_val, exc_tb) -> None
 
 Context manager exit - ensures response is closed.
 
-#### find_supplier_by_id
-
-```python
-def find_supplier_by_id(supplier_id: Union[str, int]) -> Optional[Supplier]
-```
-
-[[view_source]](https://github.com/aixplain/aiXplain/blob/main/aixplain/v2/model.py#L315)
-
-Find supplier enum by ID.
-
 #### find_function_by_id
 
 ```python

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -479,3 +479,159 @@ class TestRunPathWarningStacklevel:
         conflict = [w for w in caught if w.category is UserWarning and "precedence" in str(w.message)]
         assert conflict, "expected a run-path conflict UserWarning"
         assert conflict[0].filename == __file__, conflict[0].filename
+
+
+class TestSessionBudgetPreservation:
+    """A per-run override must never delete a session's persisted spend cap.
+
+    ``_apply_run_overrides_to_session`` used to rebuild ``ExecutionConfig`` from a
+    hardcoded five-field ``base`` dict that omitted ``budget``, then ``save()``
+    the loss — so the session (and every later message in it) ran uncapped
+    (BUG-1091). The merge now rebuilds from the stored config object, and the
+    agent's own budget may only *fill* caps the session leaves unset.
+    """
+
+    @staticmethod
+    def _session(execution_config=None):
+        from aixplain.v2.session import Session
+
+        session = MagicMock(spec=Session)
+        session.id = "sess_abc"
+        session.execution_config = execution_config
+        session.save = MagicMock()
+        return session
+
+    @staticmethod
+    def _apply(agent, session, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            agent._apply_run_overrides_to_session(session, kwargs)
+
+    def test_override_preserves_session_budget(self):
+        """Row 1: session cap, no agent cap → the cap survives the override."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        session = self._session(ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0, max_iterations=7)))
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.criteria == "be terse"
+        assert session.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert session.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 7,
+        }
+        assert session.save.call_count == 1
+
+    def test_preserves_every_other_execution_config_field(self):
+        """The same trap would reopen for any other field, so pin them all."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        stored = ExecutionConfig(
+            execution_params={"maxTokens": 64},
+            criteria="old",
+            evolve="{}",
+            identifier="corr-1",
+            run_response_generation=True,
+            budget=Budget(max_cost=5.0),
+        )
+        session = self._session(stored)
+
+        self._apply(agent, session, criteria="be terse")
+
+        merged = session.execution_config
+        assert merged.execution_params == {"maxTokens": 64}
+        assert merged.evolve == "{}"
+        assert merged.identifier == "corr-1"
+        assert merged.run_response_generation is True
+        assert merged.budget == Budget(max_cost=5.0)
+
+    def test_session_cap_wins_over_agent_cap(self):
+        """Row 2: a persisted session cap is never widened or replaced."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0)))
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget == Budget(max_cost=5.0)
+
+    def test_agent_cap_fills_unset_session_slot(self):
+        """Row 3: the agent's budget only fills caps the session leaves unset."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_iterations=7)
+        session = self._session(ExecutionConfig(budget=Budget(max_cost=5.0)))
+
+        self._apply(agent, session)
+
+        assert session.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert session.save.call_count == 1
+
+    def test_agent_budget_applies_when_session_has_none(self):
+        """Row 4: ``agent.budget`` was applied on the direct run path only."""
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(None)
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget == Budget(max_cost=1.0)
+        assert session.execution_config.criteria == "be terse"
+        assert session.save.call_count == 1
+
+    def test_empty_agent_budget_contributes_nothing(self):
+        """Row 5: the default empty ``Budget()`` must stay inert."""
+        agent = _create_agent()
+        session = self._session(None)
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget is None
+
+    def test_no_overrides_and_no_new_cap_does_not_save(self):
+        """Row 6: a plain session run must still perform no write."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        session = self._session(ExecutionConfig(criteria="be brief", budget=Budget(max_cost=5.0)))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            agent._apply_run_overrides_to_session(session, {})
+
+        session.save.assert_not_called()
+
+    def test_no_overrides_and_no_config_does_not_save(self):
+        agent = _create_agent()
+        session = self._session(None)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            agent._apply_run_overrides_to_session(session, {})
+
+        session.save.assert_not_called()
+        assert session.execution_config is None
+
+    def test_warning_names_the_seeded_budget(self):
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(None)
+
+        with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
+            agent._apply_run_overrides_to_session(session, {"criteria": "be terse"})
+
+    def test_accepts_a_dict_execution_config(self):
+        """Sessions hydrated from the backend may carry a raw dict."""
+        agent = _create_agent()
+        session = self._session({"criteria": "old", "budget": {"maxCost": 5.0}})
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.criteria == "be terse"
+        assert session.execution_config.budget == Budget(max_cost=5.0)

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -293,18 +293,14 @@ class TestDeprecatedRunTimeMaxIterations:
     def test_folds_into_execution_budget(self):
         agent = _create_agent()
         with pytest.warns(DeprecationWarning):
-            payload = agent.build_run_payload(
-                query="q", execution_params={"max_iterations": 7}
-            )
+            payload = agent.build_run_payload(query="q", execution_params={"max_iterations": 7})
         assert payload["executionParams"]["budget"] == {"maxIterations": 7}
         assert "maxIterations" not in payload["executionParams"]
 
     def test_camel_case_exec_param_also_folds(self):
         agent = _create_agent()
         with pytest.warns(DeprecationWarning):
-            payload = agent.build_run_payload(
-                query="q", execution_params={"maxIterations": 7}
-            )
+            payload = agent.build_run_payload(query="q", execution_params={"maxIterations": 7})
         assert payload["executionParams"]["budget"] == {"maxIterations": 7}
         assert "maxIterations" not in payload["executionParams"]
 
@@ -411,9 +407,7 @@ class TestFromDictLegacyMaxIterations:
                 "id": "a",
                 "name": "t",
                 "maxIterations": 3,
-                "tasks": [
-                    {"name": "task1", "description": "desc", "expectedOutput": "o"}
-                ],
+                "tasks": [{"name": "task1", "description": "desc", "expectedOutput": "o"}],
             }
         )
         assert agent.budget.max_iterations == 3
@@ -625,6 +619,30 @@ class TestSessionBudgetPreservation:
 
         with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
             agent._apply_run_overrides_to_session(session, {"criteria": "be terse"})
+
+    def test_backend_hydrated_session_cap_still_wins(self):
+        """The session's cap must win even when it arrives in the wire shape.
+
+        ``to_api_dict`` nests the cap inside ``executionParams.budget``. If the
+        decoder leaves it there, ``execution_config.budget`` reads as ``None``,
+        the agent's budget looks like it is filling an unset slot, and the next
+        ``to_api_dict`` overwrites the session's persisted cap wholesale
+        (BUG-1091).
+        """
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=0.01, max_iterations=3)
+        wire = ExecutionConfig(execution_params={"maxTokens": 64}, budget=Budget(max_cost=5.0)).to_api_dict()
+        session = self._session(ExecutionConfig.from_dict(wire))
+
+        self._apply(agent, session, criteria="be terse")
+
+        # Session's max_cost survives; the agent only fills the unset slot.
+        assert session.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 3,
+        }
 
     def test_accepts_a_dict_execution_config(self):
         """Sessions hydrated from the backend may carry a raw dict."""

--- a/tests/unit/v2/test_agent_progress.py
+++ b/tests/unit/v2/test_agent_progress.py
@@ -1,5 +1,8 @@
 """Unit tests for the v2 agent progress formatter."""
 
+from unittest.mock import MagicMock
+
+from aixplain.v2.agent import Agent
 from aixplain.v2.agent_progress import AgentProgressTracker
 
 
@@ -61,3 +64,71 @@ def test_completion_message_includes_arrow_style_totals(capsys):
 
     captured = capsys.readouterr().out
     assert "↓510 ↑536 (1046)" in captured
+
+
+class TestProgressKwargsStayOffTheWire:
+    """``progress_*`` configure the client-side display, never the run body.
+
+    They were in no filter, so ``build_run_payload``'s catch-all snake_case →
+    camelCase forwarder put them in the run POST — coupling the SDK's display
+    options to the backend's input contract (BUG-1091). The tracker must keep
+    receiving them: ``before_run`` sees the *unfiltered* kwargs.
+    """
+
+    PROGRESS_KWARGS = {"progress_format": "logs", "progress_verbosity": 2, "progress_truncate": False}
+
+    @staticmethod
+    def _runnable_agent():
+        agent = Agent.from_dict({"id": "a1", "name": "t"})
+        agent.context = MagicMock()
+        agent.status = None
+        fake_result = MagicMock()
+        fake_result.url = None
+        fake_result.completed = True
+        agent.handle_run_response = lambda response, **kw: fake_result
+        return agent
+
+    def test_progress_kwargs_absent_from_build_run_payload(self):
+        agent = self._runnable_agent()
+        payload = agent.build_run_payload(query="hi", **self.PROGRESS_KWARGS)
+
+        for key in self.PROGRESS_KWARGS:
+            assert key not in payload
+
+    def test_progress_kwargs_absent_from_the_posted_body(self):
+        agent = self._runnable_agent()
+        agent.run(query="hi", **self.PROGRESS_KWARGS)
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        for key in self.PROGRESS_KWARGS:
+            assert key not in body
+        assert body["query"] == {"input": "hi"}
+
+    def test_tracker_still_receives_the_progress_kwargs(self):
+        agent = self._runnable_agent()
+        observed = {}
+
+        def capture(kwargs):
+            observed.update({k: kwargs.get(k) for k in self.PROGRESS_KWARGS})
+
+        agent._start_progress_tracker = capture
+        agent.run(query="hi", **self.PROGRESS_KWARGS)
+
+        assert observed == self.PROGRESS_KWARGS
+
+
+class TestSdkRequestKwargsStayOffTheAgentWire:
+    """``api_key`` / ``resource_path`` are dispatch params, never model input."""
+
+    @staticmethod
+    def _runnable_agent():
+        return TestProgressKwargsStayOffTheWire._runnable_agent()
+
+    def test_api_key_never_reaches_the_agent_run_body(self):
+        agent = self._runnable_agent()
+        agent.run(query="hi", api_key="SECRET", resource_path="sdk/agents")
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert "SECRET" not in str(body)

--- a/tests/unit/v2/test_agent_save_server_fields.py
+++ b/tests/unit/v2/test_agent_save_server_fields.py
@@ -1,0 +1,131 @@
+"""Tests that save() does not write SDK defaults over server state (BUG-1093).
+
+``Agent.llm`` carries a class default (``DEFAULT_LLM``). When the response that
+hydrated an agent omitted ``model``, ``build_save_payload`` used to emit that
+default, so an unrelated edit (``agent.name = ...; agent.save()``) silently
+replaced the platform's configured model.
+
+Suppression is gated on hydration provenance: it only applies to a value that
+came from a server response which did not mention the key, and never to a value
+the caller assigned or to a locally constructed agent being created.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aixplain.v2.agent import Agent
+
+
+@pytest.fixture
+def context() -> MagicMock:
+    """Bind a mock context to the Agent class for the duration of a test."""
+    original = Agent.context
+    mock = MagicMock()
+    Agent.context = mock
+    try:
+        yield mock
+    finally:
+        Agent.context = original
+
+
+def _fetch(context: MagicMock, payload: dict) -> Agent:
+    """Hydrate an Agent through GetResourceMixin.get from *payload*."""
+    context.client.get.return_value = payload
+    return Agent.get(payload["id"])
+
+
+def test_save_omits_model_when_get_response_omitted_it(context):
+    """A GET without "model" must not cause the SDK default to be PUT back."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+
+    assert agent.llm == Agent.DEFAULT_LLM  # read side is unchanged
+    assert "model" not in agent.build_save_payload()
+
+
+def test_save_sends_model_when_get_response_included_it(context):
+    """A server-reported model is echoed back unchanged."""
+    agent = _fetch(context, {"id": "A1", "name": "agent", "model": {"id": "SERVER-LLM"}})
+
+    assert agent.build_save_payload()["model"] == {"id": "SERVER-LLM"}
+
+
+def test_save_sends_model_when_assigned_after_fetch(context):
+    """An explicit assignment is the caller's intent and is always sent."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    agent.llm = "CHOSEN-LLM"
+
+    assert agent.build_save_payload()["model"] == {"id": "CHOSEN-LLM"}
+
+
+def test_save_sends_model_when_explicitly_assigned_the_default(context):
+    """Assigning the default explicitly is still an assignment, not a fallback."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    agent.llm = Agent.DEFAULT_LLM
+
+    assert agent.build_save_payload()["model"] == {"id": Agent.DEFAULT_LLM}
+
+
+def test_save_sends_model_when_passed_through_save_kwargs(context):
+    """save(llm=...) sets the attribute, which counts as explicit."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    context.client.request.return_value = {"id": "A1", "name": "agent"}
+
+    agent.save(llm="KWARG-LLM")
+
+    payload = context.client.request.call_args.kwargs["json"]
+    assert payload["model"] == {"id": "KWARG-LLM"}
+
+
+def test_create_still_sends_default_model(context):
+    """Non-regression: a locally built agent still creates with the default LLM."""
+    agent = Agent(name="new agent")
+
+    assert agent.build_save_payload()["model"] == {"id": Agent.DEFAULT_LLM}
+
+
+def test_search_hydrated_agent_does_not_clobber_model(context):
+    """List/search hydration records provenance too, not just get()."""
+    (agent,) = Agent._build_resources([{"id": "A1", "name": "agent"}], context)
+
+    assert "model" not in agent.build_save_payload()
+
+
+def test_absent_none_defaulted_roles_are_still_popped(context):
+    """Roles defaulting to None keep their existing "omit the key" behaviour."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    payload = agent.build_save_payload()
+
+    assert agent.supervisor is None
+    for key in ("supervisor", "planner", "responder"):
+        assert key not in payload
+
+
+def test_clone_of_fetched_agent_sends_model(context):
+    """A clone is a create: it forgets provenance and sends the full payload."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    cloned = agent.clone(name="copy")
+
+    assert cloned.build_save_payload()["model"] == {"id": Agent.DEFAULT_LLM}
+
+
+def test_update_payload_still_carries_server_model(context):
+    """End-to-end: the PUT for a model-bearing agent is unchanged."""
+    agent = _fetch(context, {"id": "A1", "name": "agent", "model": {"id": "SERVER-LLM"}})
+    context.client.request.return_value = {"id": "A1", "name": "renamed"}
+
+    agent.save(name="renamed")
+
+    payload = context.client.request.call_args.kwargs["json"]
+    assert payload["model"] == {"id": "SERVER-LLM"}
+
+
+def test_update_payload_omits_model_for_model_less_agent(context):
+    """End-to-end: renaming an agent fetched without "model" leaves it alone."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    context.client.request.return_value = {"id": "A1", "name": "renamed"}
+
+    agent.save(name="renamed")
+
+    payload = context.client.request.call_args.kwargs["json"]
+    assert "model" not in payload

--- a/tests/unit/v2/test_agent_save_server_fields.py
+++ b/tests/unit/v2/test_agent_save_server_fields.py
@@ -129,3 +129,28 @@ def test_update_payload_omits_model_for_model_less_agent(context):
 
     payload = context.client.request.call_args.kwargs["json"]
     assert "model" not in payload
+
+
+def test_duplicate_response_records_provenance(context):
+    """duplicate() hydrates like get() does, so it must record provenance too."""
+    agent = _fetch(context, {"id": "A1", "name": "agent", "model": {"id": "SERVER-LLM"}})
+    context.client.request.return_value = {"id": "A2", "name": "agent (copy)"}
+
+    duplicated = agent.duplicate()
+
+    assert duplicated.id == "A2"
+    assert "model" not in duplicated.build_save_payload()
+
+
+def test_duplicate_keeps_model_reported_by_the_copy(context):
+    """A duplicate whose response carries "model" still echoes it back."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    context.client.request.return_value = {
+        "id": "A2",
+        "name": "agent (copy)",
+        "model": {"id": "COPY-LLM"},
+    }
+
+    duplicated = agent.duplicate()
+
+    assert duplicated.build_save_payload()["model"] == {"id": "COPY-LLM"}

--- a/tests/unit/v2/test_agent_via_session.py
+++ b/tests/unit/v2/test_agent_via_session.py
@@ -259,6 +259,71 @@ class TestRunWithSessionOverrides:
             agent.run("hi again", session="sess_abc", criteria="be brief")
         existing.save.assert_not_called()
 
+    def test_override_does_not_delete_the_session_budget(self):
+        """A per-run override must not silently drop the session's spend cap.
+
+        The merge used to rebuild ExecutionConfig from a hardcoded field list
+        that omitted ``budget`` and then ``save()`` the loss, so the session ran
+        uncapped from that point on (BUG-1091).
+        """
+        from aixplain.v2.agent import Budget
+
+        ctx = _make_mock_context()
+
+        existing = Mock(spec=Session)
+        existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0, max_iterations=7))
+        existing.save = Mock()
+        existing.add_message = Mock(return_value=_user_message(request_id="req_budget"))
+
+        ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_budget")
+
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        with pytest.warns(UserWarning, match="session 'sess_abc'"):
+            agent.run("hi again", session="sess_abc", criteria="be brief")
+
+        existing.save.assert_called_once()
+        assert existing.execution_config.criteria == "be brief"
+        assert existing.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert existing.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 7,
+        }
+
+    def test_agent_budget_seeds_a_session_without_one(self):
+        """``agent.budget`` applied on the direct run path only; now on both."""
+        from aixplain.v2.agent import Budget
+
+        ctx = _make_mock_context()
+
+        existing = Mock(spec=Session)
+        existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = None
+        existing.save = Mock()
+        existing.add_message = Mock(return_value=_user_message(request_id="req_seed"))
+
+        ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_seed")
+
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent.budget = Budget(max_cost=1.0)
+        agent._update_saved_state()
+
+        with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
+            agent.run("hi again", session="sess_abc")
+
+        existing.save.assert_called_once()
+        assert existing.execution_config.budget == Budget(max_cost=1.0)
+
 
 # ---------------------------------------------------------------------------
 # 4. Attachments / files / audio-as-prompt

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from aixplain.v2.enums import Function, ResponseStatus
-from aixplain.v2.exceptions import APIError, create_operation_failed_error
+from aixplain.v2.exceptions import APIError, ValidationError, create_operation_failed_error
 from aixplain.v2.model import (
     Message,
     Model,
@@ -1780,3 +1780,139 @@ class TestModelStreamerFailureReporting:
         assert chunk.data == "Ship aiX"
         list(streamer)
         assert streamer.status == ResponseStatus.SUCCESS
+
+
+class TestStreamingWithUnknownStreamingSupport:
+    """``supports_streaming`` is ``None`` for any record that omits the flag.
+
+    ``run(stream=True)`` must still stream such a model (BUG-1091), so the
+    decision about how to parse the body cannot be taken from the flag: it is
+    taken from the response itself. A model that answers a streaming request
+    with a plain JSON document used to have that document fed to the SSE
+    parser, which surfaced the raw JSON text as ``chunk.data`` and ended the
+    iteration at ``status=FAILED``.
+    """
+
+    @staticmethod
+    def _response(lines, content_type=None):
+        """Build a mock response whose headers behave like a real mapping."""
+        response = Mock()
+        response.headers = {"Content-Type": content_type} if content_type else {}
+        response.iter_lines.return_value = iter(lines)
+        return response
+
+    @staticmethod
+    def _model_with_response(response, supports_streaming=None):
+        """A model whose streaming request returns *response*."""
+        model = _model_with_mock_client()
+        model.supports_streaming = supports_streaming
+        model.context.client.request_stream.return_value = response
+        return model
+
+    def test_unknown_flag_with_sse_body_still_streams(self):
+        """The BUG-1091 fix stands: an unflagged model that streams, streams."""
+        response = self._response(
+            [
+                'data: {"choices":[{"delta":{"content":"Ship "}}]}',
+                'data: {"choices":[{"delta":{"content":"aiX"}}]}',
+                "data: [DONE]",
+            ],
+            content_type="text/event-stream",
+        )
+        model = self._model_with_response(response)
+
+        streamer = model.run(text="hello", stream=True)
+
+        assert isinstance(streamer, ModelResponseStreamer)
+        assert [chunk.data for chunk in streamer] == ["Ship ", "aiX"]
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_unknown_flag_with_untyped_sse_body_still_streams(self):
+        """A server that omits the content type is recognised by the SSE lines."""
+        streamer = ModelResponseStreamer(
+            self._response(['data: {"data":"Ship "}', 'data: {"data":"aiX"}', "data: [DONE]"])
+        )
+
+        assert [chunk.data for chunk in streamer] == ["Ship ", "aiX"]
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_unknown_flag_with_json_body_returns_usable_data(self):
+        """The defect: a plain JSON body must not decay into a failed stream."""
+        response = self._response(
+            ['{"status": "SUCCESS", "completed": true,', ' "data": "Ship aiX"}'],
+            content_type="application/json",
+        )
+        model = self._model_with_response(response)
+
+        streamer = model.run(text="hello", stream=True)
+        chunks = list(streamer)
+
+        assert [chunk.data for chunk in chunks] == ["Ship aiX"]
+        assert chunks[0].status == ResponseStatus.SUCCESS
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_untyped_json_body_returns_usable_data(self):
+        """The fallback does not depend on the server labelling the body."""
+        streamer = ModelResponseStreamer(self._response(['{"status":"SUCCESS","data":"Ship aiX"}']))
+
+        assert [chunk.data for chunk in streamer] == ["Ship aiX"]
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_openai_shaped_json_body_yields_the_message_content(self):
+        """A complete chat-completions body carries its text under ``message``."""
+        body = (
+            '{"choices":[{"message":{"role":"assistant","content":"Ship aiX"},"finish_reason":"stop"}],'
+            '"usage":{"total_tokens":7}}'
+        )
+        streamer = ModelResponseStreamer(self._response([body], content_type="application/json"))
+
+        chunks = list(streamer)
+
+        assert [chunk.data for chunk in chunks] == ["Ship aiX"]
+        assert chunks[0].finish_reason == "stop"
+        assert chunks[0].usage == {"total_tokens": 7}
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_structured_json_payload_is_serialized_rather_than_dropped(self):
+        """A non-text ``data`` payload still reaches the caller."""
+        streamer = ModelResponseStreamer(
+            self._response(['{"status":"SUCCESS","data":{"label":"positive"}}'], content_type="application/json")
+        )
+
+        chunks = list(streamer)
+
+        assert json.loads(chunks[0].data) == {"label": "positive"}
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_failed_json_body_reports_the_error(self):
+        """A complete body that reports a failure is still a failure."""
+        streamer = ModelResponseStreamer(
+            self._response(['{"status":"FAILED","errorMessage":"boom"}'], content_type="application/json")
+        )
+
+        chunks = list(streamer)
+
+        assert chunks[0].status == ResponseStatus.FAILED
+        assert chunks[0].error_message == "boom"
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_non_json_non_sse_body_falls_through_to_the_sse_parser(self):
+        """A body the fallback cannot parse is replayed, never swallowed."""
+        streamer = ModelResponseStreamer(self._response(["not json at all"]))
+
+        assert [chunk.data for chunk in streamer] == ["not json at all"]
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_empty_body_still_reports_a_truncated_stream(self):
+        """An empty response is a truncated stream, not a successful one."""
+        streamer = ModelResponseStreamer(self._response([]))
+
+        assert list(streamer) == []
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_flag_false_still_refuses_to_stream(self):
+        """An explicit ``supports_streaming=False`` is still an error."""
+        model = self._model_with_response(self._response([]), supports_streaming=False)
+
+        with pytest.raises(ValidationError, match="does not support streaming"):
+            model.run(text="hello", stream=True)

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -1546,7 +1546,12 @@ class TestModelStreamerFailureReporting:
         assert [chunk.data for chunk in streamer] == ["Ship aiX"]
         assert streamer.status == ResponseStatus.FAILED
 
-    @pytest.mark.parametrize("finish_reason", ["stop", "length", "tool_calls", "content_filter"])
+    @pytest.mark.parametrize(
+        "finish_reason",
+        # The last two are supplier-specific reasons outside OpenAI's own set:
+        # they still end the choice, so they must not be read as a truncation.
+        ["stop", "length", "tool_calls", "content_filter", "end_turn", "guardrail_intervened"],
+    )
     def test_terminal_finish_reason_without_done_reports_success(self, finish_reason):
         """A server that closes after a terminal finish_reason is not truncated."""
         streamer = self._create_streamer(
@@ -1558,6 +1563,14 @@ class TestModelStreamerFailureReporting:
 
         list(streamer)
 
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    @pytest.mark.parametrize("status", ["SUCCESS", "COMPLETED", "success"])
+    def test_terminal_status_envelope_without_done_reports_success(self, status):
+        """The aiXplain envelope ends with a status rather than a finish_reason."""
+        streamer = self._create_streamer(['data: {"status":"%s","data":"Ship aiX"}' % status])
+
+        assert [chunk.data for chunk in streamer] == ["Ship aiX"]
         assert streamer.status == ResponseStatus.SUCCESS
 
     def test_done_marker_still_reports_success(self):

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -6,6 +6,8 @@ This module tests Model-specific functionality including:
 - V1 payload conversion for sync-only models
 """
 
+import json
+
 import pytest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -341,8 +343,15 @@ class TestModelRunRouting:
         mock_super_run_async.assert_called_once()
         assert result.status == "IN_PROGRESS"
 
-    def test_build_run_payload_strips_sdk_params(self):
-        """build_run_payload should exclude timeout, wait_time, show_progress, stream."""
+    def test_build_run_payload_keeps_sdk_control_keys_out_of_the_body(self):
+        """SDK-control kwargs must not ride in the model *input body*.
+
+        ``stream`` in particular is a path selector expressed on the wire as
+        ``options.stream`` by ``run_stream`` — see
+        ``TestModelStreamDispatch`` for the dispatch half. Stripping it here is
+        correct but is *not* on its own evidence that ``run(stream=True)``
+        streams (BUG-1091).
+        """
         model = self._create_model_with_mocks(connection_type=["asynchronous"])
         payload = model.build_run_payload(
             text="hello",
@@ -506,6 +515,184 @@ class TestRunHeaderKeysAreSingleSourceOfTruth:
 
     def test_header_kwargs_covered_by_sdk_only_params(self):
         assert {key for key, _ in Model._RUN_HEADER_KEYS} <= Model._SDK_ONLY_PARAMS
+
+    def test_sdk_only_params_is_derived_not_duplicated(self):
+        """``_SDK_ONLY_PARAMS`` must *be* ``_RUN_CONTROL_KEYS``, not a copy of it.
+
+        Two hand-maintained literals is how ``session_id`` was once filtered on
+        one path and shipped on the other. Identity here makes that drift
+        impossible rather than merely absent (BUG-1091).
+        """
+        assert Model._SDK_ONLY_PARAMS == Model._RUN_CONTROL_KEYS
+
+    @pytest.mark.parametrize("path", ["run", "run_stream", "_run_async_v1"])
+    def test_every_header_kwarg_rides_as_header_on_every_request_path(self, path):
+        """Each ``_RUN_HEADER_KEYS`` entry must become a header — and stay out of
+        the body — on *all three* request-issuing model paths.
+
+        ``run_stream`` and ``_run_async_v1`` build their own requests, which is
+        exactly where the shared filters silently stopped applying (BUG-1091).
+        """
+        for key, header in Model._RUN_HEADER_KEYS:
+            model = _model_with_mock_client(sync_only=(path != "run"))
+            client = model.context.client
+            kwargs = {"text": "hi", key: "v"}
+
+            if path == "run":
+                model.run(**kwargs)
+                call = client.request.call_args
+                body = call.kwargs["json"]
+            elif path == "run_stream":
+                model.run_stream(**kwargs)
+                call = client.request_stream.call_args
+                body = call.kwargs["json"]
+            else:
+                model._run_async_v1(**kwargs)
+                call = client.request_raw.call_args
+                body = json.loads(call.kwargs["data"])
+
+            assert call.kwargs["headers"][header] == "v", f"{path} dropped {header}"
+            assert key not in body, f"{path} leaked {key} into the body"
+
+
+def _model_with_mock_client(sync_only: bool = True) -> Model:
+    """A Model wired to a mock client that answers every request-issuing path."""
+    model = Model.__new__(Model)
+    model.id = "test-model-id"
+    model.name = "Test Model"
+    model.connection_type = ["synchronous"] if sync_only else ["asynchronous"]
+    model.params = None
+    model.supports_streaming = True
+    model.__post_init__()
+    model.context = Mock()
+    model.context.model_url = "https://models.aixplain.com/api/v2/execute"
+    model.context.client.request.return_value = {"status": "SUCCESS", "completed": True, "data": "ok"}
+    model.context.client.request_raw.return_value.json.return_value = {
+        "status": "IN_PROGRESS",
+        "data": "https://models.aixplain.com/api/v1/data/poll-id",
+    }
+    return model
+
+
+class TestModelStreamDispatch:
+    """``run(stream=True)`` must actually stream (BUG-1091).
+
+    The flag was declared, documented in four shipped places (including the
+    ``Model`` docstring and the bundled skill), stripped from the payload — and
+    never read by ``run``, so callers silently got a blocking ``ModelResult``.
+    """
+
+    def test_stream_true_dispatches_to_run_stream(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello", stream=True)
+
+        assert isinstance(result, ModelResponseStreamer)
+        assert model.context.client.request_stream.call_count == 1
+        assert model.context.client.request.call_count == 0
+
+    def test_stream_true_sets_options_stream_on_the_wire(self):
+        """The flag is expressed as ``options.stream``, never as a body field."""
+        model = _model_with_mock_client()
+        model.run(text="hello", stream=True)
+
+        body = model.context.client.request_stream.call_args.kwargs["json"]
+        assert body["options"]["stream"] is True
+        assert "stream" not in body
+
+    def test_stream_false_runs_normally(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello", stream=False)
+
+        assert isinstance(result, ModelResult)
+        assert model.context.client.request_stream.call_count == 0
+        assert model.context.client.request.call_count == 1
+        assert "stream" not in model.context.client.request.call_args.kwargs["json"]
+
+    def test_run_without_stream_kwarg_unchanged(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello")
+
+        assert isinstance(result, ModelResult)
+        assert model.context.client.request_stream.call_count == 0
+        assert model.context.client.request.call_args.kwargs["json"] == {"text": "hello"}
+
+    def test_stream_dispatch_forwards_remaining_kwargs(self):
+        """Model params and identity metadata survive the hand-off to run_stream."""
+        model = _model_with_mock_client()
+        model.run(text="hello", temperature=0.7, stream=True, identifier="alice")
+
+        call = model.context.client.request_stream.call_args
+        assert call.kwargs["json"]["temperature"] == 0.7
+        assert call.kwargs["headers"] == {"x-user-id": "alice"}
+
+
+class TestModelStreamPathFilters:
+    """``run_stream`` is still a run: same body filter, same identity headers."""
+
+    def test_run_stream_sends_identity_headers(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi", identifier="alice", session_id="sess-1", agent_name="Researcher")
+
+        headers = model.context.client.request_stream.call_args.kwargs["headers"]
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
+    def test_run_stream_omits_headers_when_no_metadata(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi")
+
+        assert "headers" not in model.context.client.request_stream.call_args.kwargs
+
+    def test_run_stream_strips_api_key_from_body(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi", api_key="SECRET", resource_path="v2/models")
+
+        body = model.context.client.request_stream.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert body["text"] == "hi"
+
+
+class TestRunAsyncV1Headers:
+    """The sync-only async fallback builds its own request — it must still send
+    the identity headers the sync path sends (BUG-1091)."""
+
+    def test_run_async_v1_sends_identity_headers(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi", identifier="alice", session_id="sess-1", agent_name="Researcher")
+
+        headers = model.context.client.request_raw.call_args.kwargs["headers"]
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
+    def test_run_async_v1_omits_headers_when_no_metadata(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi")
+
+        assert "headers" not in model.context.client.request_raw.call_args.kwargs
+
+    def test_run_async_v1_strips_sdk_keys_from_body(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi", api_key="SECRET", resource_path="v2/models", temperature=0.7)
+
+        body = json.loads(model.context.client.request_raw.call_args.kwargs["data"])
+        assert body == {"data": "hi", "temperature": 0.7}
+
+
+class TestOpenEndedModelParamsStillPassThrough:
+    """Model parameters are declared per-model by the backend and ship without an
+    SDK release, so ``run()`` deliberately does **not** reject unknown kwargs —
+    only the known SDK-control keys are stripped.
+
+    Pinned so a later tidy-up cannot quietly close the open channel and break
+    ``temperature`` / ``max_tokens`` / every future backend parameter. See the
+    BUG-1091 PR body for the deviation rationale.
+    """
+
+    def test_known_and_unknown_model_params_are_both_forwarded(self):
+        model = _model_with_mock_client()
+        model.run(text="hi", temperature=0.7, maxTokns=100)
+
+        body = model.context.client.request.call_args.kwargs["json"]
+        assert body == {"text": "hi", "temperature": 0.7, "maxTokns": 100}
 
 
 class TestRunHeaderValuesMustBeAscii:

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -1449,3 +1449,134 @@ class TestModelStreamerSseEncoding:
         ModelResponseStreamer(response)
 
         assert response.encoding == "utf-16"
+
+
+# =============================================================================
+# BUG-1094: an errored or truncated stream must not report SUCCESS
+# =============================================================================
+
+
+class TestModelStreamerFailureReporting:
+    """A stream that errored or was cut short must report a non-SUCCESS status.
+
+    Before BUG-1094 the streamer never looked at ``error`` / ``status`` /
+    ``finish_reason == "error"`` events -- a JSON error event carries no
+    ``choices``, so it decayed into an empty content chunk -- and the
+    ``StopIteration`` handler set ``SUCCESS`` unconditionally, so a connection
+    cut mid-generation surfaced a truncated answer that claimed to be complete.
+    """
+
+    @staticmethod
+    def _create_streamer(lines):
+        """Create a response streamer from raw SSE lines."""
+        response = Mock()
+        response.iter_lines.return_value = iter(lines)
+        return ModelResponseStreamer(response)
+
+    def test_error_event_reports_failed(self):
+        """A ``{"error": {...}}`` event ends the stream at FAILED."""
+        streamer = self._create_streamer(
+            [
+                'data: {"choices":[{"delta":{"content":"Ship "}}]}',
+                'data: {"error":{"message":"context length exceeded"}}',
+                "data: [DONE]",
+            ]
+        )
+
+        first = next(streamer)
+        assert first.status == ResponseStatus.IN_PROGRESS
+        assert first.data == "Ship "
+
+        failure = next(streamer)
+        assert failure.status == ResponseStatus.FAILED
+        assert failure.error_message == "context length exceeded"
+        assert failure.data == ""
+
+        # The stream is over: a trailing [DONE] must not flip it back to SUCCESS.
+        with pytest.raises(StopIteration):
+            next(streamer)
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_string_error_event_reports_failed(self):
+        """An ``error`` given as a bare string is still a failure."""
+        streamer = self._create_streamer(['data: {"error":"upstream refused"}'])
+
+        failure = next(streamer)
+
+        assert failure.status == ResponseStatus.FAILED
+        assert failure.error_message == "upstream refused"
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_finish_reason_error_reports_failed(self):
+        """``finish_reason == "error"`` is a failure, not a terminal success."""
+        streamer = self._create_streamer(['data: {"choices":[{"delta":{},"finish_reason":"error"}]}', "data: [DONE]"])
+
+        failure = next(streamer)
+
+        assert failure.status == ResponseStatus.FAILED
+        assert failure.error_message == "stream finished with finish_reason='error'"
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_failed_status_event_reports_failed(self):
+        """A top-level ``status: FAILED`` event is a failure."""
+        streamer = self._create_streamer(['data: {"status":"FAILED","errorMessage":"boom"}'])
+
+        failure = next(streamer)
+
+        assert failure.status == ResponseStatus.FAILED
+        assert failure.error_message == "boom"
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_truncated_stream_reports_failed(self):
+        """A stream cut before ``[DONE]`` must not report SUCCESS."""
+        streamer = self._create_streamer(
+            [
+                'data: {"choices":[{"delta":{"content":"Ship "}}]}',
+                'data: {"choices":[{"delta":{"content":"aiX"}}]}',
+            ]
+        )
+
+        assert [chunk.data for chunk in streamer] == ["Ship ", "aiX"]
+        assert streamer.status == ResponseStatus.FAILED
+
+    def test_truncated_aixplain_style_stream_reports_failed(self):
+        """The aiXplain ``{"data": ...}`` chunk shape is guarded too."""
+        streamer = self._create_streamer(['data: {"data":"Ship aiX"}'])
+
+        assert [chunk.data for chunk in streamer] == ["Ship aiX"]
+        assert streamer.status == ResponseStatus.FAILED
+
+    @pytest.mark.parametrize("finish_reason", ["stop", "length", "tool_calls", "content_filter"])
+    def test_terminal_finish_reason_without_done_reports_success(self, finish_reason):
+        """A server that closes after a terminal finish_reason is not truncated."""
+        streamer = self._create_streamer(
+            [
+                'data: {"choices":[{"delta":{"content":"Ship aiX"}}]}',
+                'data: {"choices":[{"delta":{},"finish_reason":"%s"}]}' % finish_reason,
+            ]
+        )
+
+        list(streamer)
+
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_done_marker_still_reports_success(self):
+        """Regression guard: the happy path is untouched."""
+        streamer = self._create_streamer(['data: {"data":"Ship aiX"}', "data: [DONE]"])
+
+        list(streamer)
+
+        assert streamer.status == ResponseStatus.SUCCESS
+
+    def test_empty_error_field_is_not_a_failure(self):
+        """A falsy ``error`` key (``null``/``""``) is not an error event."""
+        streamer = self._create_streamer(
+            ['data: {"error":null,"choices":[{"delta":{"content":"Ship aiX"}}]}', "data: [DONE]"]
+        )
+
+        chunk = next(streamer)
+
+        assert chunk.status == ResponseStatus.IN_PROGRESS
+        assert chunk.data == "Ship aiX"
+        list(streamer)
+        assert streamer.status == ResponseStatus.SUCCESS

--- a/tests/unit/v2/test_partial_results.py
+++ b/tests/unit/v2/test_partial_results.py
@@ -1,0 +1,385 @@
+"""Guards against reporting partial results and failures as complete successes.
+
+BUG-1094. Three v2 paths used to present an incomplete operation to the caller
+as a complete one:
+
+* ``search()`` / ``list()`` logged a warning and dropped any record it could
+  not deserialize, while ``Page.total`` still came straight from the backend
+  envelope -- so ``len(page.results) != page.total`` was a normal state and a
+  bulk ``for x in page`` silently skipped rows. Its siblings
+  ``GetResourceMixin.get`` and ``Session.search`` both *raise* on the identical
+  failure.
+* ``_build_page`` computed three sensible fallbacks and then overwrote each one
+  with a raising ``json_data[key]`` lookup, so an envelope missing ``results``,
+  ``total`` or ``pageTotal`` turned every search into ``KeyError: 'total'``.
+* ``poll()`` did ``response.get("data") or {}``, so a classifier that
+  legitimately answers ``0`` -- or a model whose correct answer is ``""`` --
+  came back as ``{}``, and ``result.data.strip()`` then raised
+  ``AttributeError``. The synchronous path passes those values through
+  unchanged, so the *same model* returned ``""`` when run sync and ``{}`` when
+  polled.
+
+The tests are effect-based: they assert on ``page.total`` / ``page.skipped``
+and on the value *and type* of ``result.data``, because that is where each
+defect was observable.
+"""
+
+import logging
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+import pytest
+from dataclasses_json import dataclass_json
+
+from aixplain.v2.exceptions import ResourceError
+from aixplain.v2.inspector import Inspector
+from aixplain.v2.model import Model
+from aixplain.v2.resource import (
+    BaseResource,
+    BaseRunParams,
+    Page,
+    Result,
+    RunnableResourceMixin,
+)
+
+# A record the deserializer cannot handle at all: ``from_dict`` needs a mapping.
+BAD_RECORD = "not_a_dict"
+
+
+def _model_envelope(*items, **overrides):
+    """Build a models/paginate envelope around *items*."""
+    envelope = {"results": list(items), "total": len(items), "pageTotal": 1}
+    envelope.update(overrides)
+    return envelope
+
+
+def _bind(monkeypatch, cls, response):
+    """Bind *cls* to a mock context whose client returns *response*."""
+    context = Mock(client=Mock(), backend_url="https://platform-api.aixplain.com", api_key="test_key")
+    context.client.request.return_value = response
+    context.client.get.return_value = response
+    monkeypatch.setattr(cls, "context", context, raising=False)
+    return context
+
+
+# =============================================================================
+# Finding 1 -- unparseable records must not be dropped behind an inflated total
+# =============================================================================
+
+
+class TestStrictListing:
+    """``search()`` must not return a ``total`` that counts records it dropped."""
+
+    def test_unparseable_record_raises_by_default(self, monkeypatch):
+        """Strict is the default, matching ``get()`` and ``Session.search``."""
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD, {"id": "m2", "name": "Also good"}),
+        )
+
+        with pytest.raises(ResourceError) as exc_info:
+            Model.search()
+
+        message = str(exc_info.value)
+        assert "Failed to deserialize 1 of 3 Model record(s)" in message
+        # The message must tell the caller how to get the old behaviour back.
+        assert "strict=False" in message
+
+    def test_strict_false_corrects_total(self, monkeypatch):
+        """``strict=False`` skips the record *and* stops over-reporting."""
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD, {"id": "m2", "name": "Also good"}),
+        )
+
+        page = Model.search(strict=False)
+
+        assert len(page.results) == 2
+        # The backend said 3; a total that counts the dropped row is the bug.
+        assert page.total == 2
+        assert page.skipped == 1
+
+    def test_strict_false_subtracts_only_this_pages_drops(self, monkeypatch):
+        """A multi-page ``total`` stays meaningful: subtract, don't collapse."""
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope(
+                {"id": "m1", "name": "Good"},
+                BAD_RECORD,
+                total=97,
+                pageTotal=5,
+            ),
+        )
+
+        page = Model.search(strict=False)
+
+        assert len(page.results) == 1
+        assert page.total == 96
+        assert page.skipped == 1
+
+    def test_strict_false_never_reports_fewer_than_returned(self, monkeypatch):
+        """A nonsense backend ``total`` cannot push it below ``len(results)``."""
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD, total=1),
+        )
+
+        page = Model.search(strict=False)
+
+        assert page.total == 1
+        assert page.total >= len(page.results)
+
+    def test_strict_does_not_reach_the_wire(self, monkeypatch):
+        """``strict`` is a client-side concern; it must not become a filter."""
+        context = _bind(monkeypatch, Model, _model_envelope({"id": "m1", "name": "Good"}))
+
+        Model.search(strict=False)
+
+        body = context.client.request.call_args.kwargs["json"]
+        assert "strict" not in body
+
+    def test_all_valid_page_keeps_backend_total(self, monkeypatch):
+        """Regression guard: the happy path is untouched."""
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope({"id": "m1", "name": "Good"}, {"id": "m2", "name": "Also good"}, total=42, pageTotal=3),
+        )
+
+        page = Model.search()
+
+        assert len(page.results) == 2
+        assert page.total == 42
+        assert page.page_total == 3
+        assert page.skipped == 0
+
+    def test_paginate_strict_class_attribute_opts_out(self, monkeypatch):
+        """A resource whose rows are known to be heterogeneous can opt out."""
+        _bind(monkeypatch, Model, _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD))
+        monkeypatch.setattr(Model, "PAGINATE_STRICT", False, raising=False)
+
+        page = Model.search()
+
+        assert len(page.results) == 1
+        assert page.total == 1
+        assert page.skipped == 1
+
+    def test_per_call_strict_overrides_class_attribute(self, monkeypatch):
+        """``strict=True`` wins over ``PAGINATE_STRICT = False``."""
+        _bind(monkeypatch, Model, _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD))
+        monkeypatch.setattr(Model, "PAGINATE_STRICT", False, raising=False)
+
+        with pytest.raises(ResourceError):
+            Model.search(strict=True)
+
+    def test_build_resources_wrapper_still_returns_a_list(self, monkeypatch):
+        """The public-ish ``_build_resources`` signature is unchanged."""
+        context = _bind(monkeypatch, Model, _model_envelope())
+
+        resources = Model._build_resources([{"id": "m1", "name": "Good"}, BAD_RECORD], context)
+
+        assert [r.id for r in resources] == ["m1"]
+
+    def test_inspector_override_reports_errors(self, monkeypatch):
+        """``Inspector`` migrated its override to the new hook."""
+        _bind(monkeypatch, Inspector, _model_envelope(BAD_RECORD))
+
+        with pytest.raises(ResourceError, match="Inspector record"):
+            Inspector.search()
+
+    def test_inspector_lenient_mode_corrects_total(self, monkeypatch):
+        """``Inspector`` honours ``strict=False`` through the same hook."""
+        _bind(monkeypatch, Inspector, _model_envelope(BAD_RECORD, total=7))
+
+        page = Inspector.search(strict=False)
+
+        assert page.results == []
+        assert page.total == 6
+        assert page.skipped == 1
+
+    def test_page_defaults_skipped_to_zero(self):
+        """``Page`` gains ``skipped`` additively, so old constructions still work."""
+        page = Page(results=[], page_number=0, page_total=1, total=0)
+
+        assert page.skipped == 0
+
+
+# =============================================================================
+# Finding 2 -- a missing envelope key uses the computed default, not KeyError
+# =============================================================================
+
+
+class TestBuildPageDefaults:
+    """``_build_page`` must fall back to its own defaults, not raise."""
+
+    def test_missing_total_and_page_total_fall_back_to_item_count(self, monkeypatch):
+        """No ``total`` / ``pageTotal`` used to raise ``KeyError: 'total'``."""
+        _bind(monkeypatch, Model, {"results": [{"id": "m1", "name": "Good"}, {"id": "m2", "name": "Also"}]})
+
+        page = Model.search()
+
+        assert len(page.results) == 2
+        assert page.total == 2
+        assert page.page_total == 2
+
+    def test_missing_items_key_yields_an_empty_page(self, monkeypatch, caplog):
+        """A missing items key must not iterate the envelope's own keys."""
+        _bind(monkeypatch, Model, {"total": 5, "pageTotal": 1})
+
+        with caplog.at_level(logging.WARNING, logger="aixplain.v2.resource"):
+            page = Model.search()
+
+        assert page.results == []
+        assert page.total == 5
+        # The degradation has to be visible rather than silent.
+        assert any("'results'" in record.getMessage() for record in caplog.records)
+
+    def test_null_items_key_yields_an_empty_page(self, monkeypatch):
+        """``{"results": null}`` is an empty page, not a crash."""
+        _bind(monkeypatch, Model, {"results": None, "total": 0, "pageTotal": 0})
+
+        assert Model.search().results == []
+
+    def test_non_list_items_are_ignored(self, monkeypatch):
+        """A non-list ``results`` cannot be iterated into garbage resources."""
+        _bind(monkeypatch, Model, {"results": {"id": "m1"}, "total": 1, "pageTotal": 1})
+
+        page = Model.search()
+
+        assert page.results == []
+        assert page.total == 1
+
+    @pytest.mark.parametrize("bad_total", ["12", None, True, 3.5])
+    def test_non_int_total_falls_back_to_item_count(self, monkeypatch, bad_total):
+        """A malformed ``total`` degrades to the honest count."""
+        _bind(monkeypatch, Model, {"results": [{"id": "m1", "name": "Good"}], "total": bad_total})
+
+        page = Model.search()
+
+        assert page.total == 1
+        assert type(page.total) is int
+
+    def test_empty_envelope_does_not_raise(self, monkeypatch):
+        """The degenerate ``{}`` envelope yields an empty page."""
+        _bind(monkeypatch, Model, {})
+
+        page = Model.search()
+
+        assert page.results == []
+        assert page.total == 0
+        assert page.page_total == 0
+
+    def test_bare_array_response_is_unaffected(self, monkeypatch):
+        """``PAGINATE_ITEMS_KEY = None`` resources keep reading the top-level list."""
+        monkeypatch.setattr(Model, "PAGINATE_ITEMS_KEY", None, raising=False)
+        _bind(monkeypatch, Model, [{"id": "m1", "name": "Good"}, {"id": "m2", "name": "Also"}])
+
+        page = Model.search()
+
+        assert [r.id for r in page.results] == ["m1", "m2"]
+        assert page.total == 2
+        assert page.page_total == 2
+
+
+# =============================================================================
+# Finding 5 -- a polled falsy result must not be coerced to {}
+# =============================================================================
+
+
+def _create_runnable_resource():
+    """Create a minimal resource with run/poll capabilities."""
+
+    @dataclass_json
+    @dataclass
+    class RunnableResource(BaseResource, RunnableResourceMixin[BaseRunParams, Result]):
+        RESOURCE_PATH = "runnable"
+        RUN_ACTION_PATH = "run"
+
+    resource = RunnableResource(id="123", name="runnable")
+    resource.context = Mock()
+    return resource
+
+
+FALSY_PAYLOADS = ["", 0, False, [], 0.0]
+FALSY_IDS = ["empty-string", "zero", "false", "empty-list", "zero-float"]
+
+
+class TestPolledFalsyData:
+    """``poll()`` must preserve a falsy-but-present ``data`` payload."""
+
+    @pytest.mark.parametrize("payload", FALSY_PAYLOADS, ids=FALSY_IDS)
+    def test_falsy_data_is_preserved(self, payload):
+        """``0`` / ``""`` / ``False`` / ``[]`` used to arrive as ``{}``."""
+        resource = _create_runnable_resource()
+        resource.context.client.get = Mock(return_value={"status": "SUCCESS", "completed": True, "data": payload})
+
+        result = resource.poll("https://poll.url")
+
+        assert result.data == payload
+        assert type(result.data) is type(payload)
+
+    def test_empty_string_result_supports_string_methods(self):
+        """The reported symptom: ``result.data.strip()`` raised AttributeError."""
+        resource = _create_runnable_resource()
+        resource.context.client.get = Mock(return_value={"status": "SUCCESS", "completed": True, "data": ""})
+
+        result = resource.poll("https://poll.url")
+
+        assert result.data.strip() == ""
+
+    def test_absent_data_still_yields_empty_dict(self):
+        """Genuinely absent data keeps its historical shape."""
+        resource = _create_runnable_resource()
+        resource.context.client.get = Mock(return_value={"status": "SUCCESS", "completed": True})
+
+        assert resource.poll("https://poll.url").data == {}
+
+    def test_null_data_still_yields_empty_dict(self):
+        """An explicit ``null`` is treated as absent, as before."""
+        resource = _create_runnable_resource()
+        resource.context.client.get = Mock(return_value={"status": "SUCCESS", "completed": True, "data": None})
+
+        assert resource.poll("https://poll.url").data == {}
+
+    @pytest.mark.parametrize("payload", FALSY_PAYLOADS + [{"k": "v"}, "text"], ids=FALSY_IDS + ["dict", "text"])
+    def test_sync_and_polled_paths_agree(self, payload):
+        """The same model must not return ``""`` when sync and ``{}`` when polled."""
+        response = {"status": "SUCCESS", "completed": True, "data": payload}
+
+        sync_resource = _create_runnable_resource()
+        sync_result = sync_resource.handle_run_response(dict(response))
+
+        polled_resource = _create_runnable_resource()
+        polled_resource.context.client.get = Mock(return_value=dict(response))
+        polled_result = polled_resource.poll("https://poll.url")
+
+        assert polled_result.data == sync_result.data
+        assert type(polled_result.data) is type(sync_result.data)
+
+    @pytest.mark.parametrize("payload", ["", 0, False, []], ids=["empty-string", "zero", "false", "empty-list"])
+    def test_fallback_branch_preserves_falsy_data(self, payload, monkeypatch):
+        """The deserialization-fallback branch had the same ``or {}`` bug."""
+        resource = _create_runnable_resource()
+        resource.context.client.get = Mock(return_value={"status": "SUCCESS", "completed": True, "data": payload})
+
+        original_from_dict = Result.from_dict
+        calls = {"n": 0}
+
+        def flaky_from_dict(data, *args, **kwargs):
+            """Fail the first (full-payload) parse, succeed on the fallback."""
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ValueError("simulated deserialization failure")
+            return original_from_dict(data, *args, **kwargs)
+
+        monkeypatch.setattr(Result, "from_dict", flaky_from_dict)
+
+        result = resource.poll("https://poll.url")
+
+        assert calls["n"] == 2
+        assert result.data == payload
+        assert type(result.data) is type(payload)

--- a/tests/unit/v2/test_partial_results.py
+++ b/tests/unit/v2/test_partial_results.py
@@ -40,6 +40,7 @@ from aixplain.v2.resource import (
     Page,
     Result,
     RunnableResourceMixin,
+    SearchResourceMixin,
 )
 
 # A record the deserializer cannot handle at all: ``from_dict`` needs a mapping.
@@ -200,6 +201,30 @@ class TestStrictListing:
         assert page.results == []
         assert page.total == 6
         assert page.skipped == 1
+
+    def test_constructor_fallback_failure_is_reported_not_raised(self):
+        """The no-``from_dict`` branch reports failures like the main one does.
+
+        It used to build ``cls(**item)`` unguarded, so a record the constructor
+        rejects escaped as a raw ``TypeError`` -- even from a call that asked to
+        be lenient.
+        """
+
+        class Stub:
+            """A resource-shaped class without ``from_dict``."""
+
+            def __init__(self, id=None):
+                self.id = id
+
+            def _update_saved_state(self):
+                pass
+
+        deserialize = SearchResourceMixin.__dict__["_deserialize_items"].__func__
+        resources, errors = deserialize(Stub, [{"id": "s1"}, {"unexpected": "field"}], Mock())
+
+        assert [r.id for r in resources] == ["s1"]
+        assert len(errors) == 1
+        assert errors[0].startswith("item[1]:")
 
     def test_page_defaults_skipped_to_zero(self):
         """``Page`` gains ``skipped`` additively, so old constructions still work."""

--- a/tests/unit/v2/test_partial_results.py
+++ b/tests/unit/v2/test_partial_results.py
@@ -6,12 +6,18 @@ as a complete one:
 * ``search()`` / ``list()`` logged a warning and dropped any record it could
   not deserialize, while ``Page.total`` still came straight from the backend
   envelope -- so ``len(page.results) != page.total`` was a normal state and a
-  bulk ``for x in page`` silently skipped rows. Its siblings
-  ``GetResourceMixin.get`` and ``Session.search`` both *raise* on the identical
-  failure.
+  bulk ``for x in page`` silently skipped rows. Dropping the record stays the
+  default -- one unmodelled backend enum value must not break discovery on
+  ``Model.search`` / ``Inspector.search`` / ``APIKey.list`` / ``Trigger.list``
+  -- but the count is now corrected to match what was actually returned, the
+  skip is logged, and ``strict=True`` raises for callers that want the
+  ``get()``-like contract.
 * ``_build_page`` computed three sensible fallbacks and then overwrote each one
   with a raising ``json_data[key]`` lookup, so an envelope missing ``results``,
   ``total`` or ``pageTotal`` turned every search into ``KeyError: 'total'``.
+  The counts still fall back; a body carrying no readable item list at all is
+  now reported instead, because an empty page there is indistinguishable from
+  a search that genuinely matched nothing.
 * ``poll()`` did ``response.get("data") or {}``, so a classifier that
   legitimately answers ``0`` -- or a model whose correct answer is ``""`` --
   came back as ``{}``, and ``result.data.strip()`` then raised
@@ -71,8 +77,29 @@ def _bind(monkeypatch, cls, response):
 class TestStrictListing:
     """``search()`` must not return a ``total`` that counts records it dropped."""
 
-    def test_unparseable_record_raises_by_default(self, monkeypatch):
-        """Strict is the default, matching ``get()`` and ``Session.search``."""
+    def test_unparseable_record_is_skipped_by_default(self, monkeypatch, caplog):
+        """Lenient is the default: one bad row must not cost the whole listing."""
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD, {"id": "m2", "name": "Also good"}),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="aixplain.v2.resource"):
+            page = Model.search()
+
+        assert [r.id for r in page.results] == ["m1", "m2"]
+        # The count never lies: the dropped row is not counted.
+        assert page.total == 2
+        assert page.skipped == 1
+        # The degradation has to be visible rather than silent.
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("skipped 1 of 3 record(s)" in message for message in messages)
+        # And the message must tell the caller how to get the raising contract.
+        assert any("strict=True" in message for message in messages)
+
+    def test_strict_true_raises(self, monkeypatch):
+        """``strict=True`` opts into the ``get()``-like contract."""
         _bind(
             monkeypatch,
             Model,
@@ -80,11 +107,10 @@ class TestStrictListing:
         )
 
         with pytest.raises(ResourceError) as exc_info:
-            Model.search()
+            Model.search(strict=True)
 
         message = str(exc_info.value)
         assert "Failed to deserialize 1 of 3 Model record(s)" in message
-        # The message must tell the caller how to get the old behaviour back.
         assert "strict=False" in message
 
     def test_strict_false_corrects_total(self, monkeypatch):
@@ -158,24 +184,24 @@ class TestStrictListing:
         assert page.page_total == 3
         assert page.skipped == 0
 
-    def test_paginate_strict_class_attribute_opts_out(self, monkeypatch):
-        """A resource whose rows are known to be heterogeneous can opt out."""
+    def test_paginate_strict_class_attribute_opts_in(self, monkeypatch):
+        """A resource whose rows must all parse can opt into raising."""
         _bind(monkeypatch, Model, _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD))
-        monkeypatch.setattr(Model, "PAGINATE_STRICT", False, raising=False)
+        monkeypatch.setattr(Model, "PAGINATE_STRICT", True, raising=False)
 
-        page = Model.search()
+        with pytest.raises(ResourceError):
+            Model.search()
+
+    def test_per_call_strict_overrides_class_attribute(self, monkeypatch):
+        """``strict=False`` wins over ``PAGINATE_STRICT = True``."""
+        _bind(monkeypatch, Model, _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD))
+        monkeypatch.setattr(Model, "PAGINATE_STRICT", True, raising=False)
+
+        page = Model.search(strict=False)
 
         assert len(page.results) == 1
         assert page.total == 1
         assert page.skipped == 1
-
-    def test_per_call_strict_overrides_class_attribute(self, monkeypatch):
-        """``strict=True`` wins over ``PAGINATE_STRICT = False``."""
-        _bind(monkeypatch, Model, _model_envelope({"id": "m1", "name": "Good"}, BAD_RECORD))
-        monkeypatch.setattr(Model, "PAGINATE_STRICT", False, raising=False)
-
-        with pytest.raises(ResourceError):
-            Model.search(strict=True)
 
     def test_build_resources_wrapper_still_returns_a_list(self, monkeypatch):
         """The public-ish ``_build_resources`` signature is unchanged."""
@@ -190,7 +216,29 @@ class TestStrictListing:
         _bind(monkeypatch, Inspector, _model_envelope(BAD_RECORD))
 
         with pytest.raises(ResourceError, match="Inspector record"):
-            Inspector.search()
+            Inspector.search(strict=True)
+
+    def test_unmodelled_enum_value_does_not_break_discovery(self, monkeypatch):
+        """The motivating case: a new backend enum value must not kill search.
+
+        ``strict=True`` used to be the default, so a single record carrying a
+        value this client does not model yet took the whole listing with it.
+        """
+        _bind(
+            monkeypatch,
+            Model,
+            _model_envelope(
+                {"id": "m1", "name": "Good"},
+                {"id": "m2", "name": "Brand new", "status": "a_status_this_sdk_has_never_heard_of"},
+                total=2,
+            ),
+        )
+
+        page = Model.search()
+
+        assert [r.id for r in page.results] == ["m1"]
+        assert page.skipped == 1
+        assert page.total == len(page.results) == 1
 
     def test_inspector_lenient_mode_corrects_total(self, monkeypatch):
         """``Inspector`` honours ``strict=False`` through the same hook."""
@@ -239,7 +287,13 @@ class TestStrictListing:
 
 
 class TestBuildPageDefaults:
-    """``_build_page`` must fall back to its own defaults, not raise."""
+    """``_build_page`` falls back for the counts, but not for the records.
+
+    A missing ``total`` / ``pageTotal`` is a cosmetic gap with an honest
+    default. A missing (or unreadable) item list is not: it means the client
+    could not read the response at all, and returning it as an empty page hides
+    a renamed envelope or a 200 error body behind "no results".
+    """
 
     def test_missing_total_and_page_total_fall_back_to_item_count(self, monkeypatch):
         """No ``total`` / ``pageTotal`` used to raise ``KeyError: 'total'``."""
@@ -251,17 +305,34 @@ class TestBuildPageDefaults:
         assert page.total == 2
         assert page.page_total == 2
 
-    def test_missing_items_key_yields_an_empty_page(self, monkeypatch, caplog):
-        """A missing items key must not iterate the envelope's own keys."""
+    def test_missing_items_key_is_reported(self, monkeypatch):
+        """A renamed envelope must not masquerade as "no results"."""
         _bind(monkeypatch, Model, {"total": 5, "pageTotal": 1})
 
-        with caplog.at_level(logging.WARNING, logger="aixplain.v2.resource"):
-            page = Model.search()
+        with pytest.raises(ResourceError) as exc_info:
+            Model.search()
+
+        message = str(exc_info.value)
+        assert "'results'" in message
+        # The keys that *were* returned are what identifies the real envelope.
+        assert "total" in message
+
+    def test_error_body_served_with_status_200_is_reported(self, monkeypatch):
+        """The symptom: an error body is not an empty search result."""
+        _bind(monkeypatch, Model, {"error": "Forbidden resource", "statusCode": 403})
+
+        with pytest.raises(ResourceError, match="missing the 'results' key"):
+            Model.search()
+
+    def test_empty_items_list_is_a_genuinely_empty_page(self, monkeypatch):
+        """A search that matched nothing still returns an empty page."""
+        _bind(monkeypatch, Model, {"results": [], "total": 0, "pageTotal": 0})
+
+        page = Model.search()
 
         assert page.results == []
-        assert page.total == 5
-        # The degradation has to be visible rather than silent.
-        assert any("'results'" in record.getMessage() for record in caplog.records)
+        assert page.total == 0
+        assert page.skipped == 0
 
     def test_null_items_key_yields_an_empty_page(self, monkeypatch):
         """``{"results": null}`` is an empty page, not a crash."""
@@ -269,14 +340,19 @@ class TestBuildPageDefaults:
 
         assert Model.search().results == []
 
-    def test_non_list_items_are_ignored(self, monkeypatch):
+    def test_non_list_items_are_reported(self, monkeypatch):
         """A non-list ``results`` cannot be iterated into garbage resources."""
         _bind(monkeypatch, Model, {"results": {"id": "m1"}, "total": 1, "pageTotal": 1})
 
-        page = Model.search()
+        with pytest.raises(ResourceError, match="not a list of records"):
+            Model.search()
 
-        assert page.results == []
-        assert page.total == 1
+    def test_scalar_response_body_is_reported(self, monkeypatch):
+        """A body that is neither an envelope nor an array is unusable."""
+        _bind(monkeypatch, Model, "Service Unavailable")
+
+        with pytest.raises(ResourceError, match="not a list of records"):
+            Model.search()
 
     @pytest.mark.parametrize("bad_total", ["12", None, True, 3.5])
     def test_non_int_total_falls_back_to_item_count(self, monkeypatch, bad_total):
@@ -288,15 +364,12 @@ class TestBuildPageDefaults:
         assert page.total == 1
         assert type(page.total) is int
 
-    def test_empty_envelope_does_not_raise(self, monkeypatch):
-        """The degenerate ``{}`` envelope yields an empty page."""
+    def test_empty_envelope_is_reported(self, monkeypatch):
+        """The degenerate ``{}`` body carries no item list to read."""
         _bind(monkeypatch, Model, {})
 
-        page = Model.search()
-
-        assert page.results == []
-        assert page.total == 0
-        assert page.page_total == 0
+        with pytest.raises(ResourceError, match="missing the 'results' key"):
+            Model.search()
 
     def test_bare_array_response_is_unaffected(self, monkeypatch):
         """``PAGINATE_ITEMS_KEY = None`` resources keep reading the top-level list."""
@@ -308,6 +381,23 @@ class TestBuildPageDefaults:
         assert [r.id for r in page.results] == ["m1", "m2"]
         assert page.total == 2
         assert page.page_total == 2
+
+    def test_bare_array_is_read_even_when_a_key_is_configured(self, monkeypatch):
+        """``APIKey.list`` answers with an array while inheriting the key."""
+        _bind(monkeypatch, Model, [{"id": "m1", "name": "Good"}])
+
+        page = Model.search()
+
+        assert [r.id for r in page.results] == ["m1"]
+        assert page.total == 1
+
+    def test_object_body_for_a_bare_array_resource_is_reported(self, monkeypatch):
+        """``PAGINATE_ITEMS_KEY = None`` plus an object body is unreadable."""
+        monkeypatch.setattr(Model, "PAGINATE_ITEMS_KEY", None, raising=False)
+        _bind(monkeypatch, Model, {"results": [{"id": "m1", "name": "Good"}]})
+
+        with pytest.raises(ResourceError, match="expects a bare array"):
+            Model.search()
 
 
 # =============================================================================

--- a/tests/unit/v2/test_run_kwargs_stripped.py
+++ b/tests/unit/v2/test_run_kwargs_stripped.py
@@ -1,0 +1,204 @@
+"""SDK-control run kwargs must never reach the wire body (BUG-1091).
+
+``api_key`` and ``resource_path`` are declared on ``BaseParams``, so they can
+arrive on *any* v2 call. Neither is a backend body field:
+
+- ``api_key`` authenticates nothing — ``Client.request_raw`` always overlays
+  ``_auth_headers()`` from the Aixplain context — so its only observable effect
+  was riding into the model input body and, from there, the supplier's prompt
+  logs.
+- ``resource_path`` is consumed by the URL builders.
+
+Both are also not ``requests`` kwargs, which is why the same root cause made
+``delete(resource_path=…)`` and ``get(id, api_key=…)`` raise deep inside
+``requests``.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from dataclasses_json import dataclass_json
+
+from aixplain.v2.actions import Action, Actions, Inputs
+from aixplain.v2.agent import Agent
+from aixplain.v2.integration import ActionInputSpec
+from aixplain.v2.model import Model
+from aixplain.v2.resource import (
+    BaseDeleteParams,
+    BaseResource,
+    DeleteResourceMixin,
+    DeleteResult,
+    GetResourceMixin,
+    RunnableResourceMixin,
+)
+from aixplain.v2.tool import Tool
+
+SDK_REQUEST_KWARGS = {"api_key": "SECRET-TEAM-KEY", "resource_path": "v2/custom"}
+
+
+def _model(cls=Model):
+    model = cls.__new__(cls)
+    model.id = "test-model-id"
+    model.name = "Test Model"
+    model.connection_type = ["synchronous"]
+    model.params = None
+    model.__post_init__()
+    model.context = Mock()
+    model.context.model_url = "https://models.aixplain.com/api/v2/execute"
+    model.context.client.request.return_value = {"status": "SUCCESS", "completed": True, "data": "ok"}
+    return model
+
+
+def _tool():
+    """A Tool with one allowed action, wired to a mock client."""
+    tool = _model(Tool)
+    tool.description = "Tool description"
+    tool.allowed_actions = ["search"]
+    tool._dynamic_attrs = {}
+    spec = ActionInputSpec(
+        name="Query", code="query", datatype="string", default_value=[], required=False, description="Query"
+    )
+    action = Action(name="search", inputs=Inputs.from_action_input_specs([spec]))
+    tool.__dict__["actions"] = Actions(actions={"search": action})
+    return tool
+
+
+def _agent():
+    agent = Agent.from_dict({"id": "a1", "name": "t"})
+    agent.context = MagicMock()
+    agent.status = None
+    fake_result = MagicMock()
+    fake_result.url = None
+    fake_result.completed = True
+    agent.handle_run_response = lambda response, **kw: fake_result
+    return agent
+
+
+class TestControlKeysAreDeclaredOnce:
+    """One authoritative set, inherited by every runnable."""
+
+    def test_base_mixin_strips_the_dispatch_keys(self):
+        assert {"api_key", "resource_path"} <= RunnableResourceMixin._RUN_CONTROL_KEYS
+
+    def test_base_mixin_strips_the_progress_display_keys(self):
+        assert {
+            "show_progress",
+            "progress_format",
+            "progress_verbosity",
+            "progress_truncate",
+        } <= RunnableResourceMixin._RUN_CONTROL_KEYS
+
+    @pytest.mark.parametrize("cls", [Model, Tool, Agent])
+    def test_every_runnable_inherits_them(self, cls):
+        assert {"api_key", "resource_path"} <= cls._RUN_CONTROL_KEYS
+
+
+class TestApiKeyNeverReachesARunBody:
+    def test_model_build_run_payload(self):
+        assert _model().build_run_payload(text="hi", **SDK_REQUEST_KWARGS) == {"text": "hi"}
+
+    def test_tool_build_run_payload(self):
+        assert _model(Tool).build_run_payload(text="hi", **SDK_REQUEST_KWARGS) == {"text": "hi"}
+
+    def test_model_posted_body(self):
+        model = _model()
+        model.run(text="hi", **SDK_REQUEST_KWARGS)
+
+        body = model.context.client.request.call_args.kwargs["json"]
+        assert body == {"text": "hi"}
+
+    def test_tool_posted_body(self):
+        tool = _tool()
+        tool.run(data={"query": "hi"}, **SDK_REQUEST_KWARGS)
+
+        body = tool.context.client.request.call_args.kwargs["json"]
+        assert body == {"action": "search", "data": {"query": "hi"}}
+
+    def test_agent_posted_body(self):
+        agent = _agent()
+        agent.run(query="hi", **SDK_REQUEST_KWARGS)
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert SDK_REQUEST_KWARGS["api_key"] not in str(body)
+
+    def test_resource_path_still_selects_the_run_url(self):
+        """Stripping it from the *body* must not stop it steering the URL."""
+        model = _model()
+        model.run(text="hi", **SDK_REQUEST_KWARGS)
+
+        url = model.context.client.request.call_args[0][1]
+        assert url.endswith("/test-model-id")
+
+
+class TestDeleteAcceptsTheDispatchKeys:
+    """``delete()`` forwarded every kwarg to ``requests``, so passing either key
+    raised ``TypeError`` inside ``session.request()``."""
+
+    def _resource(self):
+        @dataclass_json
+        @dataclass
+        class DeletableResource(BaseResource, DeleteResourceMixin[BaseDeleteParams, DeleteResult]):
+            RESOURCE_PATH = "deletable"
+
+        resource = DeletableResource(id="123", name="to delete")
+        resource.context = Mock()
+        resource.context.client.request_raw = Mock(return_value=Mock())
+        return resource
+
+    def test_delete_with_resource_path_succeeds_and_uses_it(self):
+        resource = self._resource()
+
+        resource.delete(resource_path="sdk/agents")
+
+        call_args = resource.context.client.request_raw.call_args
+        assert call_args[0][0] == "delete"
+        assert "sdk/agents/123" in call_args[0][1]
+        assert "resource_path" not in call_args.kwargs
+
+    def test_delete_with_api_key_succeeds(self):
+        resource = self._resource()
+
+        resource.delete(api_key="SECRET-TEAM-KEY")
+
+        call_args = resource.context.client.request_raw.call_args
+        assert "deletable/123" in call_args[0][1]
+        assert "api_key" not in call_args.kwargs
+
+    def test_delete_still_forwards_genuine_request_kwargs(self):
+        resource = self._resource()
+
+        resource.delete(timeout=30)
+
+        assert resource.context.client.request_raw.call_args.kwargs["timeout"] == 30
+
+
+class TestGetAcceptsTheDispatchKeys:
+    def _cls(self):
+        @dataclass_json
+        @dataclass
+        class Gettable(BaseResource, GetResourceMixin[dict, "Gettable"]):
+            RESOURCE_PATH = "gettable"
+
+        Gettable.context = Mock()
+        Gettable.context.client.get = Mock(return_value={"id": "123", "name": "got"})
+        return Gettable
+
+    def test_get_with_api_key_succeeds(self):
+        cls = self._cls()
+
+        instance = cls.get("123", api_key="SECRET-TEAM-KEY")
+
+        assert instance.id == "123"
+        call_args = cls.context.client.get.call_args
+        assert call_args[0][0] == "gettable/123"
+        assert "api_key" not in call_args.kwargs
+
+    def test_get_still_forwards_genuine_request_kwargs(self):
+        cls = self._cls()
+
+        cls.get("123", timeout=30)
+
+        assert cls.context.client.get.call_args.kwargs["timeout"] == 30

--- a/tests/unit/v2/test_save_correctness.py
+++ b/tests/unit/v2/test_save_correctness.py
@@ -8,6 +8,12 @@ Covers two failure modes that damaged the user's resources:
 * ``_create()`` hydrated the POST response *before* recording the returned id,
   so a deserialization failure orphaned a resource that already existed
   remotely — and the obvious retry created a second one.
+
+The deleted-save assertions name ``ResourceError`` rather than the shared
+``AixplainV2Error`` base on purpose: asserting the base is what hid the guard
+raising ``ValidationError`` from ``Agent.save`` / ``File.save`` (outside
+``@with_hooks``) and ``ResourceError`` from ``BaseResource.save`` (inside it),
+so ``except ResourceError`` around ``agent.save()`` caught only some paths.
 """
 
 from dataclasses import dataclass, field
@@ -19,7 +25,7 @@ from dataclasses_json import config, dataclass_json
 
 from aixplain.v2.agent import Agent
 from aixplain.v2.enums import AssetStatus
-from aixplain.v2.exceptions import AixplainV2Error, ResourceError
+from aixplain.v2.exceptions import ResourceError, ValidationError
 from aixplain.v2.resource import (
     BaseResource,
     DeleteResourceMixin,
@@ -68,7 +74,7 @@ def test_save_after_delete_raises_and_issues_no_request():
     thing.mark_as_deleted()
     thing.context.client.request.reset_mock()
 
-    with pytest.raises(AixplainV2Error, match="deleted"):
+    with pytest.raises(ResourceError, match="deleted"):
         thing.save()
 
     assert thing.context.client.request.call_args_list == []
@@ -93,7 +99,7 @@ def test_save_after_delete_is_not_one_shot():
     thing.mark_as_deleted()
 
     for _ in range(2):
-        with pytest.raises(AixplainV2Error, match="deleted"):
+        with pytest.raises(ResourceError, match="deleted"):
             thing.save()
 
     assert _methods(thing.context) == []
@@ -128,7 +134,7 @@ def test_agent_save_after_delete_does_not_touch_subcomponents_or_status():
     agent.mark_as_deleted()
     agent.status = AssetStatus.DELETED
 
-    with pytest.raises(AixplainV2Error, match="deleted"):
+    with pytest.raises(ResourceError, match="deleted"):
         agent.save(save_subcomponents=True)
 
     assert agent.status == AssetStatus.DELETED
@@ -153,10 +159,63 @@ def test_file_save_after_delete_raises():
     file._deleted = True
     file.context.client.request.reset_mock()
 
-    with pytest.raises(AixplainV2Error, match="deleted"):
+    with pytest.raises(ResourceError, match="deleted"):
         file.save()
 
     assert file.context.client.request.call_args_list == []
+
+
+def _deleted_base_resource():
+    """A plain resource whose save() runs inside ``@with_hooks``."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+    return thing
+
+
+def _deleted_agent():
+    """An Agent, whose save() override guards before ``@with_hooks`` runs."""
+    agent = Agent(name="agent")
+    agent.context = MagicMock()
+    agent.id = "AGENT-1"
+    agent._update_saved_state()
+    agent.mark_as_deleted()
+    return agent
+
+
+def _deleted_file():
+    """A File, whose save() never reaches ``BaseResource.save`` at all."""
+    from aixplain.v2.file import File
+
+    file = File(id="FILE-1", name="report.pdf")
+    file.context = MagicMock()
+    file._update_saved_state()
+    file.id = None
+    file._deleted = True
+    return file
+
+
+@pytest.mark.parametrize(
+    "make_resource",
+    [_deleted_base_resource, _deleted_agent, _deleted_file],
+    ids=["base-resource", "agent", "file"],
+)
+def test_deleted_save_guards_raise_one_catchable_type(make_resource):
+    """``except ResourceError`` must catch the guard on every save path.
+
+    ``BaseResource.save`` is wrapped by ``@with_hooks``, which converts the
+    guard's error to ``ResourceError``; ``Agent.save`` and ``File.save`` guard
+    outside it and used to surface the raw ``ValidationError``. They are
+    sibling subclasses of ``AixplainV2Error``, so the split silently escaped
+    callers' ``except ResourceError``.
+    """
+    resource = make_resource()
+
+    with pytest.raises(ResourceError) as exc_info:
+        resource.save()
+
+    assert "deleted" in str(exc_info.value)
+    assert not isinstance(exc_info.value, ValidationError)
 
 
 # =============================================================================

--- a/tests/unit/v2/test_save_correctness.py
+++ b/tests/unit/v2/test_save_correctness.py
@@ -1,0 +1,235 @@
+"""Unit tests for save() correctness invariants (BUG-1093).
+
+Covers two failure modes that damaged the user's resources:
+
+* ``save()`` on a deleted resource took the create branch and POSTed a
+  duplicate, because ``save()`` was the only mutating path that never called
+  ``_ensure_valid_state()``.
+* ``_create()`` hydrated the POST response *before* recording the returned id,
+  so a deserialization failure orphaned a resource that already existed
+  remotely — and the obvious retry created a second one.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+from dataclasses_json import config, dataclass_json
+
+from aixplain.v2.agent import Agent
+from aixplain.v2.enums import AssetStatus
+from aixplain.v2.exceptions import AixplainV2Error, ResourceError
+from aixplain.v2.resource import (
+    BaseResource,
+    DeleteResourceMixin,
+    GetResourceMixin,
+)
+from aixplain.v2.tool import Tool
+
+
+def _reject(value):
+    """Decoder standing in for an SDK that is behind the backend."""
+    raise ValueError(f"unmodelled value {value!r}")
+
+
+@dataclass_json
+@dataclass
+class Thing(BaseResource, DeleteResourceMixin, GetResourceMixin):
+    """Minimal resource whose ``kind`` decoder rejects unmodelled values."""
+
+    kind: Optional[str] = field(default=None, metadata=config(decoder=_reject))
+
+
+Thing.RESOURCE_PATH = "v2/things"
+
+
+def _thing(**kwargs) -> Thing:
+    """Return a Thing bound to a mock context."""
+    thing = Thing(**kwargs)
+    thing.context = MagicMock()
+    return thing
+
+
+def _methods(context) -> list:
+    """Return the HTTP methods requested through *context*'s client."""
+    return [call.args[0] for call in context.client.request.call_args_list if call.args]
+
+
+# =============================================================================
+# Finding 1 — save() after delete() must not create a duplicate
+# =============================================================================
+
+
+def test_save_after_delete_raises_and_issues_no_request():
+    """A deleted resource must never fall through to the create branch."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+    thing.context.client.request.reset_mock()
+
+    with pytest.raises(AixplainV2Error, match="deleted"):
+        thing.save()
+
+    assert thing.context.client.request.call_args_list == []
+    assert thing.id is None
+
+
+def test_save_on_never_saved_resource_still_creates():
+    """The guard is conditional: a fresh resource must still be created."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {"id": "NEW-ID", "name": "thing"}
+
+    thing.save()
+
+    assert _methods(thing.context) == ["post"]
+    assert thing.id == "NEW-ID"
+
+
+def test_save_after_delete_is_not_one_shot():
+    """Repeated saves on a deleted resource keep raising."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+
+    for _ in range(2):
+        with pytest.raises(AixplainV2Error, match="deleted"):
+            thing.save()
+
+    assert _methods(thing.context) == []
+
+
+def test_clone_of_deleted_resource_can_be_saved():
+    """clone() produces a new resource, so the deleted flag must not carry over."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+
+    cloned = thing.clone(name="revived")
+    cloned.context = MagicMock()
+    cloned.context.client.request.return_value = {"id": "NEW-ID", "name": "revived"}
+
+    assert cloned.is_deleted is False
+    cloned.save()
+
+    assert _methods(cloned.context) == ["post"]
+    assert cloned.id == "NEW-ID"
+
+
+def test_agent_save_after_delete_does_not_touch_subcomponents_or_status():
+    """Agent.save() guards before saving children and before the status flip."""
+    child = Tool(name="child tool", code="def main():\n    return 1\n")
+    child.context = MagicMock()
+    agent = Agent(name="agent", tools=[child])
+    agent.context = MagicMock()
+    agent.id = "AGENT-1"
+    agent._update_saved_state()
+    agent.status = AssetStatus.ONBOARDED
+    agent.mark_as_deleted()
+    agent.status = AssetStatus.DELETED
+
+    with pytest.raises(AixplainV2Error, match="deleted"):
+        agent.save(save_subcomponents=True)
+
+    assert agent.status == AssetStatus.DELETED
+    assert child.id is None
+    assert agent.context.client.request.call_args_list == []
+    assert child.context.client.request.call_args_list == []
+
+
+def test_file_save_after_delete_raises():
+    """File.save() bypasses BaseResource.save(), so it carries its own guard.
+
+    File has no delete mixin today, so the deleted flag is set directly — the
+    guard exists so File never regains the duplicate-on-save behaviour if one
+    is added.
+    """
+    from aixplain.v2.file import File
+
+    file = File(id="FILE-1", name="report.pdf")
+    file.context = MagicMock()
+    file._update_saved_state()
+    file.id = None
+    file._deleted = True
+    file.context.client.request.reset_mock()
+
+    with pytest.raises(AixplainV2Error, match="deleted"):
+        file.save()
+
+    assert file.context.client.request.call_args_list == []
+
+
+# =============================================================================
+# Finding 2 — a create whose response cannot be hydrated must keep the id
+# =============================================================================
+
+
+def test_create_hydration_failure_records_server_id():
+    """The POST succeeded, so the id must land on self before hydration runs."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {
+        "id": "SERVER-ID-123",
+        "name": "thing",
+        "kind": "WEIRD_NEW_ENUM",
+    }
+
+    with pytest.raises(ResourceError) as excinfo:
+        thing.save()
+
+    assert thing.id == "SERVER-ID-123"
+    message = str(excinfo.value)
+    assert "SERVER-ID-123" in message
+    assert "do NOT retry" in message
+
+
+def test_create_hydration_failure_does_not_duplicate_on_second_save():
+    """After the failure the resource is reachable, so a retry updates it."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {
+        "id": "SERVER-ID-123",
+        "name": "thing",
+        "kind": "WEIRD_NEW_ENUM",
+    }
+    with pytest.raises(ResourceError):
+        thing.save()
+
+    thing.context.client.request.reset_mock()
+    thing.context.client.request.return_value = {"id": "SERVER-ID-123", "name": "thing"}
+    thing.save()
+
+    assert _methods(thing.context) == ["put"]
+    assert thing.context.client.request.call_args_list[0].args[1] == "v2/things/SERVER-ID-123"
+
+
+def test_api_key_create_reraises_hydration_failure():
+    """ApiKey._create's 422 fallback must not swallow the hydration error."""
+    from aixplain.v2.api_key import APIKey
+
+    api_key = APIKey(name="key")
+    api_key.context = MagicMock()
+    api_key.context.client.request.return_value = {"id": "KEY-1", "globalLimits": "not-a-mapping"}
+
+    with pytest.raises(ResourceError, match="do NOT retry"):
+        api_key.save()
+
+    assert api_key.id == "KEY-1"
+
+
+def test_create_preserves_recorded_id_when_response_omits_id_field():
+    """The copy loop must not overwrite the captured id with None."""
+
+    @dataclass_json
+    @dataclass
+    class IdLosingThing(BaseResource):
+        """Resource whose id decoder drops the value."""
+
+        id: Optional[str] = field(default=None, metadata=config(decoder=lambda _: None))
+
+    IdLosingThing.RESOURCE_PATH = "v2/things"
+    thing = IdLosingThing(name="thing")
+    thing.context = MagicMock()
+    thing.context.client.request.return_value = {"id": "SERVER-ID-123", "name": "thing"}
+
+    thing.save()
+
+    assert thing.id == "SERVER-ID-123"

--- a/tests/unit/v2/test_save_correctness.py
+++ b/tests/unit/v2/test_save_correctness.py
@@ -233,3 +233,17 @@ def test_create_preserves_recorded_id_when_response_omits_id_field():
     thing.save()
 
     assert thing.id == "SERVER-ID-123"
+
+
+def test_create_hydration_failure_without_id_gives_actionable_message():
+    """A response with no id cannot be re-fetched, so the hint must not claim it can."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {"name": "thing", "kind": "WEIRD_NEW_ENUM"}
+
+    with pytest.raises(ResourceError) as excinfo:
+        thing.save()
+
+    message = str(excinfo.value)
+    assert thing.id is None
+    assert "Thing.get(None)" not in message
+    assert "check before retrying" in message

--- a/tests/unit/v2/test_search_filters.py
+++ b/tests/unit/v2/test_search_filters.py
@@ -1,0 +1,229 @@
+"""Wire-level guards on how v2 search filters serialize their arguments.
+
+``OwnershipType``, ``SortBy``, ``SortOrder`` and ``Supplier`` are all
+``class X(str, Enum)``, so ``str(member)`` yields the *member repr*
+(``"OwnershipType.PRIVATE"``) rather than the wire value (``"PRIVATE"``).
+The filter builders used to call ``str()`` eagerly, which silently produced
+filters the backend could not match (BUG-1092): the request succeeded and
+returned the *unfiltered* catalogue.
+
+These tests are deliberately effect-based -- they assert on the exact JSON
+body handed to ``client.request``, because that is the only place the defect
+was observable. They also assert ``type(...) is str`` where relevant: a raw
+``str``-subclass enum member would otherwise satisfy a plain ``==``.
+"""
+
+from enum import Enum
+
+import pytest
+from unittest.mock import Mock
+
+from aixplain.v2.agent import Agent
+from aixplain.v2.enums import OwnershipType, SortBy, SortOrder, Supplier
+from aixplain.v2.integration import Integration
+from aixplain.v2.model import Model
+from aixplain.v2.skill import Skill
+from aixplain.v2.tool import Tool
+
+# Resources whose filters come straight from ``_populate_base_filters``, plus
+# the ones with overrides, so the fix is proven to be inherited rather than
+# per-class.
+RESOURCES = [Agent, Model, Tool, Integration, Skill]
+RESOURCE_IDS = [cls.__name__ for cls in RESOURCES]
+
+
+def _bind(monkeypatch, cls):
+    """Bind *cls* to a mock context and return the mock client."""
+    context = Mock(client=Mock(), backend_url="https://platform-api.aixplain.com", api_key="test_key")
+    context.client.request.return_value = {"items": [], "results": [], "total": 0, "pageTotal": 0}
+    monkeypatch.setattr(cls, "context", context, raising=False)
+    return context.client
+
+
+def _body(client):
+    """Return the JSON body of the single request the client received."""
+    client.request.assert_called_once()
+    return client.request.call_args.kwargs["json"]
+
+
+# =============================================================================
+# ownership
+# =============================================================================
+
+
+@pytest.mark.parametrize("cls", RESOURCES, ids=RESOURCE_IDS)
+def test_ownership_enum_sends_value(monkeypatch, cls):
+    """``ownership=OwnershipType.PRIVATE`` must send ``"PRIVATE"``."""
+    client = _bind(monkeypatch, cls)
+
+    cls.search(ownership=OwnershipType.PRIVATE)
+
+    ownership = _body(client)["ownership"]
+    assert ownership == "PRIVATE"
+    assert type(ownership) is str, "enum member leaked into the request body"
+
+
+@pytest.mark.parametrize("cls", RESOURCES, ids=RESOURCE_IDS)
+def test_ownership_string_is_unchanged(monkeypatch, cls):
+    """Plain strings keep their exact pre-fix wire representation."""
+    client = _bind(monkeypatch, cls)
+
+    cls.search(ownership="team")
+
+    assert _body(client)["ownership"] == "team"
+
+
+def test_ownership_sequence_sends_list_of_values(monkeypatch):
+    """A sequence of enums becomes a list of values, not a stringified list."""
+    client = _bind(monkeypatch, Agent)
+
+    Agent.search(ownership=[OwnershipType.PRIVATE, OwnershipType.TEAM])
+
+    ownership = _body(client)["ownership"]
+    assert ownership == ["PRIVATE", "TEAM"]
+    assert all(type(o) is str for o in ownership)
+
+
+def test_ownership_tuple_sends_list_of_values(monkeypatch):
+    """Tuples are accepted too -- ``BaseSearchParams`` types ownership as one."""
+    client = _bind(monkeypatch, Agent)
+
+    Agent.search(ownership=(OwnershipType.PUBLIC,))
+
+    assert _body(client)["ownership"] == ["PUBLIC"]
+
+
+# =============================================================================
+# sortBy / sortOrder
+# =============================================================================
+
+
+@pytest.mark.parametrize("cls", RESOURCES, ids=RESOURCE_IDS)
+def test_sort_enums_send_values(monkeypatch, cls):
+    """``sort_by``/``sort_order`` enums must send their values."""
+    client = _bind(monkeypatch, cls)
+
+    cls.search(sort_by=SortBy.NAME, sort_order=SortOrder.DESC)
+
+    body = _body(client)
+    assert body["sortBy"] == "NAME"
+    assert body["sortOrder"] == "DESC"
+    assert type(body["sortBy"]) is str
+    assert type(body["sortOrder"]) is str
+
+
+@pytest.mark.parametrize("cls", RESOURCES, ids=RESOURCE_IDS)
+def test_sort_strings_are_unchanged(monkeypatch, cls):
+    """Plain strings pass through verbatim -- no case normalization."""
+    client = _bind(monkeypatch, cls)
+
+    cls.search(sort_by="name", sort_order="asc")
+
+    body = _body(client)
+    assert body["sortBy"] == "name"
+    assert body["sortOrder"] == "asc"
+
+
+# =============================================================================
+# Model.sort[].dir -- the backend contract is +/-1
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "sort_order, expected_dir",
+    [
+        (SortOrder.ASC, 1),
+        (SortOrder.DESC, -1),
+        ("asc", 1),
+        ("ASC", 1),
+        ("desc", -1),
+        ("DESC", -1),
+    ],
+    ids=["enum-asc", "enum-desc", "str-asc", "str-ASC", "str-desc", "str-DESC"],
+)
+def test_model_sort_dir_is_plus_or_minus_one(monkeypatch, sort_order, expected_dir):
+    """``sort[].dir`` is an integer +/-1 for both enum and string inputs."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(sort_by=SortBy.NAME, sort_order=sort_order)
+
+    sort = _body(client)["sort"]
+    assert sort == [{"field": "NAME", "dir": expected_dir}]
+    assert type(sort[0]["dir"]) is int
+
+
+def test_model_sort_field_defaults_to_name(monkeypatch):
+    """``sort_order`` alone still yields a well-formed sort entry."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(sort_order=SortOrder.DESC)
+
+    assert _body(client)["sort"] == [{"field": "name", "dir": -1}]
+
+
+def test_model_sort_empty_without_sort_args(monkeypatch):
+    """Unsorted searches still send the empty sort array the backend wants."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search()
+
+    assert _body(client)["sort"] == [{}]
+
+
+# =============================================================================
+# Model suppliers
+# =============================================================================
+
+
+class _DictValuedSupplier(Enum):
+    """Stand-in for v1's dict-valued ``Supplier`` enum."""
+
+    OPENAI = {"id": "1", "code": "openai", "name": "OpenAI"}
+
+
+def test_model_supplier_enum_sends_value(monkeypatch):
+    """A single v2 ``Supplier`` enum must send its value, not its repr."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(vendors=Supplier.OPENAI)
+
+    assert _body(client)["suppliers"] == ["OPENAI"]
+
+
+def test_model_supplier_list_mixes_enums_and_strings(monkeypatch):
+    """Lists of enums and plain strings are both normalized."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(vendors=[Supplier.OPENAI, "cohere"])
+
+    assert _body(client)["suppliers"] == ["OPENAI", "cohere"]
+
+
+def test_model_supplier_dict_valued_enum_uses_code(monkeypatch):
+    """A dict-valued (v1-shaped) supplier degrades to its ``code``."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(vendors=_DictValuedSupplier.OPENAI)
+
+    assert _body(client)["suppliers"] == ["openai"]
+
+
+def test_skill_supplier_enum_sends_value(monkeypatch):
+    """``Skill``'s own suppliers filter normalizes the same way."""
+    client = _bind(monkeypatch, Skill)
+
+    Skill.search(suppliers=[Supplier.OPENAI])
+
+    assert _body(client)["suppliers"] == ["OPENAI"]
+
+
+# =============================================================================
+# Dead code removal
+# =============================================================================
+
+
+def test_find_supplier_by_id_is_gone():
+    """``find_supplier_by_id`` raised ``AttributeError`` on every call."""
+    import aixplain.v2.model as model_module
+
+    assert not hasattr(model_module, "find_supplier_by_id")

--- a/tests/unit/v2/test_search_filters.py
+++ b/tests/unit/v2/test_search_filters.py
@@ -24,11 +24,12 @@ from aixplain.v2.integration import Integration
 from aixplain.v2.model import Model
 from aixplain.v2.skill import Skill
 from aixplain.v2.tool import Tool
+from aixplain.v2.utility import Utility
 
 # Resources whose filters come straight from ``_populate_base_filters``, plus
 # the ones with overrides, so the fix is proven to be inherited rather than
 # per-class.
-RESOURCES = [Agent, Model, Tool, Integration, Skill]
+RESOURCES = [Agent, Model, Tool, Integration, Skill, Utility]
 RESOURCE_IDS = [cls.__name__ for cls in RESOURCES]
 
 
@@ -227,3 +228,81 @@ def test_find_supplier_by_id_is_gone():
     import aixplain.v2.model as model_module
 
     assert not hasattr(model_module, "find_supplier_by_id")
+
+
+# =============================================================================
+# sort direction robustness
+# =============================================================================
+
+
+class _V1SortOrder(Enum):
+    """Stand-in for v1's integer-valued ``SortOrder`` enum."""
+
+    ASCENDING = 1
+    DESCENDING = -1
+
+
+@pytest.mark.parametrize(
+    "sort_order, expected_dir",
+    [
+        (_V1SortOrder.ASCENDING, 1),
+        (_V1SortOrder.DESCENDING, -1),
+        (1, 1),
+        (-1, -1),
+        ("ascending", 1),
+        ("DESCENDING", -1),
+    ],
+    ids=["v1-enum-asc", "v1-enum-desc", "int-asc", "int-desc", "str-ascending", "str-DESCENDING"],
+)
+def test_model_sort_dir_accepts_numeric_and_long_spellings(monkeypatch, sort_order, expected_dir):
+    """Numeric (v1-shaped) and ``*ENDING`` sort orders keep their direction."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(sort_by=SortBy.NAME, sort_order=sort_order)
+
+    assert _body(client)["sort"] == [{"field": "NAME", "dir": expected_dir}]
+
+
+def test_model_sort_dir_unknown_order_defaults_to_ascending(monkeypatch):
+    """An unrecognized sort order falls back to the documented default."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(sort_by=SortBy.NAME, sort_order="sideways")
+
+    assert _body(client)["sort"] == [{"field": "NAME", "dir": 1}]
+
+
+# =============================================================================
+# explicit ``None`` halves must not be serialized
+# =============================================================================
+
+
+def test_model_sort_with_explicit_none_field(monkeypatch):
+    """``sort_by=None`` falls back to ``"name"`` instead of sending ``"None"``."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(sort_by=None, sort_order=SortOrder.DESC)
+
+    assert _body(client)["sort"] == [{"field": "name", "dir": -1}]
+
+
+def test_model_sort_with_explicit_none_order(monkeypatch):
+    """``sort_order=None`` falls back to ascending."""
+    client = _bind(monkeypatch, Model)
+
+    Model.search(sort_by=SortBy.CREATED_AT, sort_order=None)
+
+    assert _body(client)["sort"] == [{"field": "CREATED_AT", "dir": 1}]
+
+
+@pytest.mark.parametrize("cls", RESOURCES, ids=RESOURCE_IDS)
+def test_explicit_none_filters_are_omitted(monkeypatch, cls):
+    """``None`` filters stay out of the body entirely."""
+    client = _bind(monkeypatch, cls)
+
+    cls.search(ownership=None, sort_by=None, sort_order=None)
+
+    body = _body(client)
+    assert "ownership" not in body
+    assert "sortBy" not in body
+    assert "sortOrder" not in body

--- a/tests/unit/v2/test_session.py
+++ b/tests/unit/v2/test_session.py
@@ -1242,6 +1242,43 @@ class TestExecutionConfigBudget:
             )
         assert cfg.to_api_dict()["executionParams"]["budget"]["maxIterations"] == 9
 
+    def test_from_dict_lifts_nested_budget_out_of_execution_params(self):
+        """Decoding must mirror encoding: ``executionParams.budget`` -> ``budget``.
+
+        ``to_api_dict`` nests the cap inside ``executionParams``, but nothing
+        decoded it back out, so a backend-loaded session had ``budget=None`` with
+        the real cap buried in ``execution_params``. Anything that then set
+        ``budget`` (the run path seeds it from ``agent.budget``) silently
+        overwrote the persisted cap on the next send (BUG-1091).
+        """
+        sent = ExecutionConfig(execution_params={"maxTokens": 64}, budget=Budget(max_cost=5.0)).to_api_dict()
+
+        cfg = ExecutionConfig.from_dict(sent)
+
+        assert cfg.budget == Budget(max_cost=5.0)
+        assert cfg.execution_params == {"maxTokens": 64}
+        assert cfg.to_api_dict() == sent  # round-trip is stable
+
+    def test_from_dict_nested_budget_defers_to_an_explicit_top_level_one(self):
+        cfg = ExecutionConfig.from_dict(
+            {"executionParams": {"budget": {"maxCost": 5.0}}, "budget": {"maxCost": 1.0}}
+        )
+
+        assert cfg.budget == Budget(max_cost=1.0)
+        assert cfg.to_api_dict() == {"executionParams": {"budget": {"maxCost": 1.0}}}
+
+    def test_session_from_dict_lifts_nested_budget(self):
+        session = Session.from_dict(
+            {
+                "id": "s1",
+                "agentId": "a1",
+                "executionConfig": {"executionParams": {"maxTokens": 64, "budget": {"maxCost": 5.0}}},
+            }
+        )
+
+        assert session.execution_config.budget == Budget(max_cost=5.0)
+        assert session.execution_config.execution_params == {"maxTokens": 64}
+
     def test_session_from_dict_legacy_execution_config_no_warning(self):
         # Loading a Session whose nested executionConfig carries a legacy
         # maxIterations must not warn and must fold into budget.


### PR DESCRIPTION
## Summary

This branch carries four SEV2 correctness tickets, merged in dependency order because all four touch `aixplain/v2/resource.py` and `aixplain/v2/model.py`. Every ticket was reviewed and CI-checked as its own pull request before being merged down into this one; those PRs are linked below and their full write-ups remain readable there.

## Tickets in this branch

| Ticket | Reviewed in | What it fixes |
|---|---|---|
| [BUG-1092](https://aixplain.atlassian.net/browse/BUG-1092) | #1074 (this PR) | Search filters sent the enum member repr (`"SortBy.NAME"`) instead of its value, so ownership and sort filters never applied; sort direction is now ±1 for both enum and string inputs, and supplier filtering is normalised. |
| [BUG-1094](https://aixplain.atlassian.net/browse/BUG-1094) | #1077 | Partial results and failures were reported as complete successes: unparseable records no longer vanish while `total` still counts them, a missing envelope key uses the computed default rather than raising, an errored or truncated stream reports a non-SUCCESS status, and a polled empty or zero result is no longer coerced to `{}`. Item 4 (the v1 streamer) was skipped because v1 is unmaintained. |
| [BUG-1093](https://aixplain.atlassian.net/browse/BUG-1093) | #1079 | `save()` on a deleted resource raises instead of creating a duplicate, a create whose response fails to hydrate still records the server id so a retry cannot orphan it, and `save()` no longer writes SDK defaults over server-side fields the hydrating response omitted. |
| [BUG-1091](https://aixplain.atlassian.net/browse/BUG-1091) | #1084 | Caller-supplied run values are honoured or stripped rather than silently discarded: `stream=True` dispatches, `api_key` never rides in the model input body, a per-run override cannot delete a session's persisted spend cap, `run_stream` sends the same identity headers as `run`, and progress kwargs stay off the wire. |

## Jira tickets closed by this branch

- [BUG-1092](https://aixplain.atlassian.net/browse/BUG-1092) — Search filters serialize Python repr() strings, so ownership/sort filters never apply
- [BUG-1094](https://aixplain.atlassian.net/browse/BUG-1094) — Partial results and failures are reported as complete successes
- [BUG-1093](https://aixplain.atlassian.net/browse/BUG-1093) — save() can resurrect a deleted resource or orphan a duplicate, and silently drops server-side fields
- [BUG-1091](https://aixplain.atlassian.net/browse/BUG-1091) — Caller-supplied values are accepted and silently discarded

## Notes for review

**Deliberate deviation (BUG-1091, acceptance criterion 4):** unknown run kwargs are still forwarded rather than rejected. Model parameters are declared per-model by the backend and ship without an SDK release, so a closed allowlist would reject valid parameters. The reasoning and the follow-up shape are recorded in #1084.

**Open question (BUG-1093):** whether the backend PUT is merge- or replace-semantics determines the blast radius of `save()` omitting unmodelled fields. Worth one backend check before sizing it; details in #1079.

## Testing

`python -m pytest tests/unit` passes on this branch, and pre-commit is green on every constituent pull request. No functional or network tests were run locally.

## Original ticket write-up

The detailed per-finding analysis for the head ticket follows; the other tickets' write-ups are in their linked pull requests.

---
## Summary

`OwnershipType`, `SortBy`, `SortOrder` and `Supplier` are all declared as `class X(str, Enum)`. For those, `str(member)` returns the member *repr* (`"OwnershipType.PRIVATE"`), not the wire value (`"PRIVATE"`). The v2 search filter builders called `str()` eagerly, so passing the SDK's own enums to the SDK's own `search()` produced filters the backend could not match — the request came back **HTTP 200 with the unfiltered catalogue**, which makes the bug easy to miss.

## Changes

**`aixplain/v2/resource.py`** — three module-private helpers, now the single place this normalization lives:

- `_filter_value` — string enums, dict-valued enums (legacy v1 `Supplier`, via `code`/`id`), and plain strings.
- `_filter_values` — same, for filters the backend expects as an array; a scalar is wrapped in a one-element list, so `Supplier.OPENAI` and `[Supplier.OPENAI, "cohere"]` both work.
- `_sort_direction` — returns the contractual ±1 integer. Handles v2's `"ASC"`/`"DESC"`, the `"ASCENDING"`/`"DESCENDING"` spellings, and already-numeric input (v1's `SortOrder` is valued `1`/`-1`) mapped by sign, so a caller migrating from v1 keeps the direction they asked for.

`_populate_base_filters` uses them for `ownership`, `sortBy` and `sortOrder`. A sequence of ownerships now serializes to a list of values instead of one stringified list; `list`, `tuple` and `set` are all accepted.

**`aixplain/v2/model.py`**

- `functions`, `vendors`, `status`, `source_languages` and `target_languages` route through the shared helper, replacing ten near-identical copies of the `hasattr(x, "value")` idiom that was the root cause. The `vendors` guard in particular was written against v1's dict-valued `Supplier` and fell through to `str(s)` for v2's string-valued one, sending `"Supplier.OPENAI"`.
- `sort[].dir` is now ±1 for both enum and string inputs; it was previously the string `"DESC"` for an enum and `-1` for the equivalent plain string.
- An explicit `sort_by=None` / `sort_order=None` no longer serializes as the literal string `"None"` — each half independently falls back to its documented default (`"name"` / ascending).
- Deleted `find_supplier_by_id`: it called `.value.get("id")` on a `str`, so it raised `AttributeError` on every call. It had zero consumers. Regenerated docs entries removed alongside it.

**`aixplain/v2/skill.py`** — `suppliers` normalized the same way.

## Testing

The only existing test on this path passed plain strings, so the enum path had never been exercised. New `tests/unit/v2/test_search_filters.py` (308 lines) asserts the exact `client.request` body for enum inputs across five resource types, plus the numeric/spelling variants of sort order and the `None` defaults.

- `python -m pytest tests/unit` → **2026 passed, 3 skipped**
- `ruff check` + `ruff format` clean; pre-commit (including its pytest hook) passed on commit.

## Notes

The helpers are module-private (`_`-prefixed) and additive — no public API changes beyond the removal of the always-broken `find_supplier_by_id`.


## Jira

https://aixplain.atlassian.net/browse/BUG-1092



[BUG-1092]: https://aixplain.atlassian.net/browse/BUG-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUG-1094]: https://aixplain.atlassian.net/browse/BUG-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUG-1093]: https://aixplain.atlassian.net/browse/BUG-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ