### PR TITLE
fix: SEV2 HTTP, load, security and control-effectiveness fixes (BUG-942, BUG-1097, BUG-941, BUG-939, BUG-946)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,26 @@ BACKEND_URL=https://platform-api.aixplain.com
 MODELS_RUN_URL=https://models.aixplain.com/api/v1/execute
 PIPELINE_API_KEY=<API_KEY>
 MODEL_API_KEY=<API_KEY>
-LOG_LEVEL=DEBUG
+# DEBUG is deliberately not the documented value: it used to log full request
+# and response bodies, including the aiXplain API key and any third-party token
+# inside a tool payload (BUG-939).
+LOG_LEVEL=INFO
 TEAM_API_KEY=<YOUR_API_KEY>
+
+# --- Optional security opt-ins (all default to off) ---
+# Log request/response bodies at DEBUG. Values are redacted and truncated, but
+# redaction is best-effort: do not enable it on a shared log sink.
+# AIXPLAIN_LOG_BODIES=1
+#
+# Allow plain http:// for BACKEND_URL / MODELS_RUN_URL / PIPELINES_RUN_URL and
+# for presigned upload URLs. Needed for local development against
+# http://localhost, and for an on-prem deployment terminating TLS elsewhere.
+# AIXPLAIN_ALLOW_INSECURE_URLS=1
+#
+# Allow the SDK to fetch code/artifact URLs that resolve to private or loopback
+# addresses. Only set this if your artifact host really is internal.
+# AIXPLAIN_ALLOW_PRIVATE_FETCH=1
+#
+# Extra hosts accepted as presigned upload targets, comma separated.
+# *.amazonaws.com and *.aixplain.com are always allowed.
+# AIXPLAIN_UPLOAD_HOST_ALLOWLIST=storage.example.com

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@ TEAM_API_KEY=<YOUR_API_KEY>
 # AIXPLAIN_ALLOW_INSECURE_URLS=1
 #
 # Allow the SDK to fetch code/artifact URLs that resolve to private or loopback
-# addresses. Only set this if your artifact host really is internal.
+# addresses. Only set this if your artifact host really is internal. The cloud
+# metadata endpoints stay blocked either way.
 # AIXPLAIN_ALLOW_PRIVATE_FETCH=1
 #
 # Extra hosts accepted as presigned upload targets, comma separated.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -369,6 +369,58 @@ Beyond the factories, three more legacy prefixes redirect into v1:
 | `from aixplain.modules import Agent, Model, ...` | `aix.Agent`, `aix.Model`, … — v2 resources replace the v1 domain objects |
 | `from aixplain.decorators import ...`, `aixplain.base`, `aixplain.processes` | Internal helpers with no public v2 counterpart |
 
+## Polling behaviour changes
+
+Two polling defaults changed. Both bound a loop that was previously unbounded or
+effectively unbounded; both are opt-out-able through the same parameter you
+already pass.
+
+### `Pipeline.run` / `Pipeline.poll` stop polling after 30 minutes
+
+The default `timeout` on `aixplain.modules.pipeline.Pipeline.run()` (and the
+private polling loop behind it) dropped from **20,000 seconds (5h 33m) to 1,800
+seconds (30 minutes)**.
+
+A pipeline that legitimately runs longer than 30 minutes will now stop being
+polled and be reported as a failure, even though the run itself continues on the
+platform. If you have such a pipeline, raise the budget explicitly:
+
+```python
+pipeline.run(data, timeout=20000.0)   # the previous default
+```
+
+The old default meant a pipeline that never completed pinned a thread for over
+five hours; 30 minutes is the bound for the common case, and the parameter is
+there for the rest.
+
+### `AgentProgressTracker.stream_progress` is bounded and raises on expiry
+
+`stream_progress` used to be a `while True` loop with no `timeout` parameter at
+all. It now takes `timeout` (default **300 seconds**) and raises
+`TimeoutError` when that budget expires with the run still non-terminal.
+
+This matches `sync_poll`, which has always raised `TimeoutError` in the same
+situation — the two polling surfaces previously disagreed about whether an
+expired budget was a result or an error.
+
+```python
+# previous behaviour: poll forever
+tracker.stream_progress(url, timeout=None)
+
+# a longer budget
+tracker.stream_progress(url, timeout=1800)
+
+# or handle the expiry
+try:
+    response = tracker.stream_progress(url)
+except TimeoutError:
+    ...
+```
+
+A terminal status (`SUCCESS`, `FAILED`, `ABORTED`, `CANCELLED`, `ERROR`) and the
+`max_polls` cap still *return* the response as before; only the wall-clock
+deadline raises.
+
 ## Getting help
 
 - Open an issue at <https://github.com/aixplain/aiXplain/issues> — especially if a gap above blocks you; that feedback shapes the removal timeline.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,6 +49,25 @@ A `filterwarnings` entry in your `pytest.ini` or `pyproject.toml` works too.
 
 One ordering caveat: to make the notice visible at all, the SDK inserts a `default` filter for its own category while `aixplain` is being imported — but only when `sys.warnoptions` is empty, i.e. when you passed no `-W` and set no `PYTHONWARNINGS`. A bare `warnings.simplefilter("ignore")` issued *before* `import aixplain` is therefore overridden. Use the environment variable, use `-W`/`PYTHONWARNINGS`, or register your filter after the import — all three win.
 
+## `aixplain.aixplain_v2` is deprecated
+
+The module-level `aixplain_v2` client is deprecated and will be removed in a future release. Construct a client explicitly instead:
+
+```python
+# deprecated
+from aixplain import aixplain_v2
+agent = aixplain_v2.Agent.get("...")
+
+# use instead
+from aixplain import Aixplain
+aix = Aixplain()            # or Aixplain(api_key="...")
+agent = aix.Agent.get("...")
+```
+
+It used to be built at import time with the failure swallowed, so a missing `TEAM_API_KEY` left the symbol bound to `None` and the first use failed with `AttributeError: 'NoneType' object has no attribute 'Agent'` rather than the actual cause. It is now constructed on first access and raises the real error (`API key is required. Pass api_key=... to Aixplain() or set TEAM_API_KEY or AIXPLAIN_API_KEY.`), and the first access emits a `DeprecationWarning`.
+
+`from aixplain import aixplain_v2` still works. It is no longer part of `from aixplain import *`, so a star import no longer needs a credential.
+
 ## Factory map at a glance
 
 | v1 factory | v2 equivalent | Status |

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -22,7 +22,28 @@ import os
 import logging
 from dotenv import load_dotenv
 
-load_dotenv()
+
+def _load_cwd_dotenv() -> bool:
+    """Load only the ``.env`` in the current working directory, never an ancestor's.
+
+    A bare ``load_dotenv()`` -- and ``find_dotenv(usecwd=True)`` -- searches
+    *parent* directories, so a ``.env`` shipped inside a cloned sample project or
+    a bug-report attachment could set ``BACKEND_URL``, ``TEAM_API_KEY``,
+    ``LOG_LEVEL`` or ``SENTRY_DSN`` for a user who merely ``cd``s into a
+    subdirectory and runs their own script with their own key (BUG-939). Loading
+    an explicit path removes the walk-up while keeping the documented behaviour
+    for a ``.env`` in the working directory itself.
+
+    Existing environment variables still win (``override=False``), as with the
+    bare call this replaces.
+
+    Returns:
+        bool: True when a ``.env`` was found in the working directory and loaded.
+    """
+    return load_dotenv(os.path.join(os.getcwd(), ".env"), override=False)
+
+
+_load_cwd_dotenv()
 
 from aixplain._compat import install as _install_compat  # noqa: E402
 

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -56,11 +56,51 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=LOG_LEVEL)
 
 
-aixplain_v2 = None
-try:
-    aixplain_v2 = Aixplain()
-except Exception:
-    pass
+_AIXPLAIN_V2_DEPRECATION = (
+    "'aixplain.aixplain_v2' is deprecated and will be removed in a future release. "
+    "Construct a client explicitly instead: 'from aixplain import Aixplain; aix = Aixplain()'."
+)
 
 
-__all__ = ["Aixplain", "File", "aixplain_v2"]
+def __getattr__(name: str):
+    """Lazily construct the deprecated module-level ``aixplain_v2`` client.
+
+    Constructing it at import time and swallowing the failure left a public
+    symbol bound to ``None``, so a missing credential surfaced much later as
+    ``AttributeError: 'NoneType' object has no attribute 'Agent'`` instead of the
+    actionable message ``Aixplain()`` already raises (BUG-946). Deferring the
+    construction to first access keeps ``import aixplain`` working without a key
+    -- which ``aixplain --help`` and unit-test collection rely on -- while
+    letting the real error reach whoever actually asks for the client.
+
+    Args:
+        name (str): Attribute being looked up on the package.
+
+    Returns:
+        Aixplain: The lazily constructed client, cached in module globals.
+
+    Raises:
+        AttributeError: If ``name`` is anything other than ``aixplain_v2``.
+    """
+    if name != "aixplain_v2":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import warnings
+
+    warnings.warn(_AIXPLAIN_V2_DEPRECATION, DeprecationWarning, stacklevel=2)
+    # Raises the real error (e.g. "API key is required...") when unconfigured.
+    client = Aixplain()
+    # Cache so repeated access returns the same client and skips this hook.
+    globals()["aixplain_v2"] = client
+    return client
+
+
+def __dir__():
+    """Keep the lazily provided ``aixplain_v2`` discoverable via ``dir()``."""
+    return sorted(set(globals()) | {"aixplain_v2"})
+
+
+# ``aixplain_v2`` is deliberately absent: it stays importable by name through
+# ``__getattr__`` above, but keeping it here would make ``from aixplain import *``
+# construct a client -- and therefore raise -- in a keyless environment.
+__all__ = ["Aixplain", "File"]

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -15,21 +15,60 @@ limitations under the License.
 
 import os
 import logging
+from typing import Optional
+
 import sentry_sdk
 
-from aixplain.utils.url_safety import validate_config_url
+from aixplain.utils.url_safety import UnsafeURLError, validate_config_url
 
 logger = logging.getLogger(__name__)
 
 BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com")
 MODELS_RUN_URL = os.getenv("MODELS_RUN_URL", "https://models.aixplain.com/api/v1/execute")
 
-# Both are read straight from the environment, so any ``.env`` on the machine can
-# choose where the team API key is sent. Fail closed on a non-https endpoint and
-# warn once on a non-aiXplain host, before ``ENV`` or Sentry is derived from a
-# value that may not be ours (BUG-939).
-validate_config_url(BACKEND_URL, "BACKEND_URL")
-validate_config_url(MODELS_RUN_URL, "MODELS_RUN_URL")
+#: Set when a configured endpoint failed the policy at import time. The failure
+#: is reported again, as a raise, by :func:`ensure_config_urls_safe`.
+_DEFERRED_CONFIG_URL_ERROR: Optional[str] = None
+
+
+def _check_config_url(url: str, name: str) -> None:
+    """Apply the config-URL policy to *url*, deferring a failure to first use.
+
+    ``BACKEND_URL`` and ``MODELS_RUN_URL`` are read straight from the
+    environment, so any ``.env`` on the machine can choose where the team API
+    key is sent -- the policy has to be applied (BUG-939). It is *not* applied
+    as an import-time raise, though: this module is imported by ``import
+    aixplain`` itself, so raising here would break ``aixplain --help`` and unit
+    test collection on a machine with no valid environment (BUG-946).
+
+    The failure is therefore logged once, at WARNING, and re-raised by
+    :func:`ensure_config_urls_safe` before the first request actually goes out,
+    so nothing is ever sent to a rejected endpoint.
+    """
+    global _DEFERRED_CONFIG_URL_ERROR
+    try:
+        validate_config_url(url, name)
+    except UnsafeURLError as exc:
+        if _DEFERRED_CONFIG_URL_ERROR is None:
+            _DEFERRED_CONFIG_URL_ERROR = str(exc)
+        logger.warning(f"{exc} No request will be sent until this is fixed.")
+
+
+def ensure_config_urls_safe() -> None:
+    """Raise if a configured endpoint failed the policy at import time.
+
+    Called from the request choke point so an unsafe endpoint is refused before
+    a socket is opened, rather than at ``import aixplain``.
+
+    Raises:
+        UnsafeURLError: If ``BACKEND_URL`` or ``MODELS_RUN_URL`` is not allowed.
+    """
+    if _DEFERRED_CONFIG_URL_ERROR is not None:
+        raise UnsafeURLError(_DEFERRED_CONFIG_URL_ERROR)
+
+
+_check_config_url(BACKEND_URL, "BACKEND_URL")
+_check_config_url(MODELS_RUN_URL, "MODELS_RUN_URL")
 # GET THE API KEY FROM CMD
 TEAM_API_KEY = os.getenv("TEAM_API_KEY", "")
 AIXPLAIN_API_KEY = os.getenv("AIXPLAIN_API_KEY", "")

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -17,10 +17,19 @@ import os
 import logging
 import sentry_sdk
 
+from aixplain.utils.url_safety import validate_config_url
+
 logger = logging.getLogger(__name__)
 
 BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com")
 MODELS_RUN_URL = os.getenv("MODELS_RUN_URL", "https://models.aixplain.com/api/v1/execute")
+
+# Both are read straight from the environment, so any ``.env`` on the machine can
+# choose where the team API key is sent. Fail closed on a non-https endpoint and
+# warn once on a non-aiXplain host, before ``ENV`` or Sentry is derived from a
+# value that may not be ours (BUG-939).
+validate_config_url(BACKEND_URL, "BACKEND_URL")
+validate_config_url(MODELS_RUN_URL, "MODELS_RUN_URL")
 # GET THE API KEY FROM CMD
 TEAM_API_KEY = os.getenv("TEAM_API_KEY", "")
 AIXPLAIN_API_KEY = os.getenv("AIXPLAIN_API_KEY", "")

--- a/aixplain/utils/file_utils.py
+++ b/aixplain/utils/file_utils.py
@@ -22,6 +22,7 @@ import requests
 import aixplain.utils.config as config
 from aixplain.enums.license import License
 from aixplain.utils.request_utils import _request_with_retry
+from aixplain.utils.url_safety import UnsafeURLError, validate_upload_url
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional, Text, Tuple, Union, Dict, List
@@ -237,6 +238,9 @@ def upload_data(
         path = response["key"]
         # Upload data
         presigned_url = response["uploadUrl"]  # pre-signed URL
+        # The upload target is chosen by a backend response, so it is validated
+        # before any file bytes leave the machine (BUG-939).
+        validate_upload_url(presigned_url)
         download_link = response.get("downloadUrl", "")
         headers = {"Content-Type": content_type}
         if content_encoding is not None:
@@ -263,6 +267,11 @@ def upload_data(
         if return_download_link is False:
             return _build_s3_link_from_presigned_url(presigned_url, path)
         return download_link
+    except UnsafeURLError:
+        # A refused upload host is a configuration/trust failure, not a transient
+        # one: retrying cannot fix it, and the generic handler below would mask
+        # the reason behind "Failure on Uploading to S3."
+        raise
     except Exception:
         if nattempts > 0:
             return upload_data(

--- a/aixplain/utils/file_utils.py
+++ b/aixplain/utils/file_utils.py
@@ -21,8 +21,8 @@ import requests
 
 import aixplain.utils.config as config
 from aixplain.enums.license import License
-from aixplain.utils.request_utils import _request_with_retry
-from aixplain.utils.url_safety import UnsafeURLError, validate_upload_url
+from aixplain.utils.request_utils import _request_with_retry, get_session
+from aixplain.utils.url_safety import UnsafeURLError, safe_get, validate_upload_url
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional, Text, Tuple, Union, Dict, List
@@ -95,7 +95,12 @@ def save_file(download_url: Text, download_file_path: Optional[Union[str, Path]]
         save_dir.mkdir(parents=True, exist_ok=True)
         file_ext = Path(download_url).suffix.split("?")[0]
         download_file_path = save_dir / (str(uuid4()) + file_ext)
-    r = _request_with_retry("get", download_url)
+    # ``safe_get`` re-validates every hop instead of letting ``requests`` follow
+    # redirects unchecked: the caller's one-shot ``validate_fetch_url`` says
+    # nothing about where a 302 from an allowed host would land (BUG-939). The
+    # thread's retrying session is reused so the download keeps its retries and
+    # keep-alive.
+    r = safe_get(download_url, session=get_session())
     with open(download_file_path, "wb") as f:
         f.write(r.content)
     return download_file_path
@@ -246,8 +251,10 @@ def upload_data(
         if content_encoding is not None:
             headers["Content-Encoding"] = content_encoding
         payload = open(file_name, "rb").read()
-        # saving the file into the pre-signed URL
-        r = _request_with_retry("put", presigned_url, headers=headers, data=payload)
+        # saving the file into the pre-signed URL. A presigned S3 PUT never
+        # legitimately redirects; following a 307 would re-send the bytes to a
+        # host ``validate_upload_url`` never saw (BUG-939).
+        r = _request_with_retry("put", presigned_url, headers=headers, data=payload, allow_redirects=False)
 
         # if the process fail, try one more
         if r.status_code != 200:

--- a/aixplain/utils/request_utils.py
+++ b/aixplain/utils/request_utils.py
@@ -2,6 +2,15 @@ from requests.adapters import HTTPAdapter, Retry
 import requests
 from typing import Text
 
+# One session for the process instead of one per call. A 5-minute v1 job polls
+# ~44 times, and a per-call Session meant ~44 TLS handshakes where keep-alive
+# needs one (BUG-942 item 3). ``requests.Session`` is safe for this use: it is
+# configured here at import and never mutated afterwards, and it carries no
+# credentials (every caller passes its own headers).
+_RETRIES = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
+_SESSION = requests.Session()
+_SESSION.mount("https://", HTTPAdapter(max_retries=_RETRIES))
+
 
 def _request_with_retry(method: Text, url: Text, **params) -> requests.Response:
     """Wrapper around requests with Session to retry in case it fails
@@ -14,8 +23,4 @@ def _request_with_retry(method: Text, url: Text, **params) -> requests.Response:
     Returns:
         requests.Response: Response object of the request.
     """
-    session = requests.Session()
-    retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
-    session.mount("https://", HTTPAdapter(max_retries=retries))
-    response = session.request(method=method.upper(), url=url, **params)
-    return response
+    return _SESSION.request(method=method.upper(), url=url, **params)

--- a/aixplain/utils/request_utils.py
+++ b/aixplain/utils/request_utils.py
@@ -1,28 +1,48 @@
-from requests.adapters import HTTPAdapter, Retry
-import requests
+import threading
 from typing import Text
 
-# One session for the process instead of one per call. A 5-minute v1 job polls
-# ~44 times, and a per-call Session meant ~44 TLS handshakes where keep-alive
-# needs one (BUG-942 item 3). ``requests.Session`` is safe for this use: it is
-# configured here at import and never mutated afterwards, and it carries no
-# credentials (every caller passes its own headers).
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+# One session per *thread* instead of one per call. A 5-minute v1 job polls ~44
+# times, and a per-call Session meant ~44 TLS handshakes where keep-alive needs
+# one (BUG-942 item 3).
 #
-# Sized explicitly, matching ``aixplain.v2.client``. Now that the session is
-# shared, urllib3's 10/10 default would bite at concurrency: above 10 in-flight
-# requests the adapter opens a connection, uses it once and *discards* it
-# instead of pooling it, logging "Connection pool is full" each time -- which
-# would cancel out the reuse this module now exists to provide. Duplicated here
-# rather than imported so importing v1 does not drag in v2.
+# Per-thread rather than per-process: ``requests`` documents ``Session`` as not
+# thread-safe, and v1 reaches this module from ``ThreadPoolExecutor`` pools
+# (``agent_factory/utils.py``, ``team_agent_factory/utils.py``). A single shared
+# Session would also share ``session.cookies``, so a ``Set-Cookie`` from any host
+# would persist process-wide and ride along on later requests to that host --
+# state that did not exist when every call built its own Session. Pool workers
+# are long-lived, so connection reuse is preserved.
 _POOL_CONNECTIONS = 32
 _POOL_MAXSIZE = 64
 
 _RETRIES = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
-_SESSION = requests.Session()
-_SESSION.mount(
-    "https://",
-    HTTPAdapter(max_retries=_RETRIES, pool_connections=_POOL_CONNECTIONS, pool_maxsize=_POOL_MAXSIZE),
-)
+_THREAD_STATE = threading.local()
+
+
+def _new_session() -> requests.Session:
+    """Build a retrying session for the calling thread."""
+    session = requests.Session()
+    session.mount(
+        "https://",
+        HTTPAdapter(max_retries=_RETRIES, pool_connections=_POOL_CONNECTIONS, pool_maxsize=_POOL_MAXSIZE),
+    )
+    return session
+
+
+def get_session() -> requests.Session:
+    """Return this thread's session, creating it on first use.
+
+    Returns:
+        requests.Session: A session owned exclusively by the calling thread.
+    """
+    session = getattr(_THREAD_STATE, "session", None)
+    if session is None:
+        session = _new_session()
+        _THREAD_STATE.session = session
+    return session
 
 
 def _request_with_retry(method: Text, url: Text, **params) -> requests.Response:
@@ -35,5 +55,14 @@ def _request_with_retry(method: Text, url: Text, **params) -> requests.Response:
 
     Returns:
         requests.Response: Response object of the request.
+
+    Raises:
+        UnsafeURLError: If a configured endpoint failed the config-URL policy at
+            import time. Importing ``aixplain`` only warns about that (BUG-946);
+            this is the choke point where it becomes a refusal, before a socket
+            is opened (BUG-939).
     """
-    return _SESSION.request(method=method.upper(), url=url, **params)
+    from aixplain.utils.config import ensure_config_urls_safe
+
+    ensure_config_urls_safe()
+    return get_session().request(method=method.upper(), url=url, **params)

--- a/aixplain/utils/request_utils.py
+++ b/aixplain/utils/request_utils.py
@@ -7,9 +7,22 @@ from typing import Text
 # needs one (BUG-942 item 3). ``requests.Session`` is safe for this use: it is
 # configured here at import and never mutated afterwards, and it carries no
 # credentials (every caller passes its own headers).
+#
+# Sized explicitly, matching ``aixplain.v2.client``. Now that the session is
+# shared, urllib3's 10/10 default would bite at concurrency: above 10 in-flight
+# requests the adapter opens a connection, uses it once and *discards* it
+# instead of pooling it, logging "Connection pool is full" each time -- which
+# would cancel out the reuse this module now exists to provide. Duplicated here
+# rather than imported so importing v1 does not drag in v2.
+_POOL_CONNECTIONS = 32
+_POOL_MAXSIZE = 64
+
 _RETRIES = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
 _SESSION = requests.Session()
-_SESSION.mount("https://", HTTPAdapter(max_retries=_RETRIES))
+_SESSION.mount(
+    "https://",
+    HTTPAdapter(max_retries=_RETRIES, pool_connections=_POOL_CONNECTIONS, pool_maxsize=_POOL_MAXSIZE),
+)
 
 
 def _request_with_retry(method: Text, url: Text, **params) -> requests.Response:

--- a/aixplain/utils/url_safety.py
+++ b/aixplain/utils/url_safety.py
@@ -236,7 +236,11 @@ def validate_fetch_url(url: str) -> str:
     unspecified or a known cloud-metadata endpoint.
 
     Set ``AIXPLAIN_ALLOW_PRIVATE_FETCH=1`` on an on-prem deployment whose
-    artifact host lives on a private range.
+    artifact host lives on a private range. That opt-in relaxes the *private
+    range* rule only -- the cloud metadata endpoints stay refused either way.
+    Nobody's artifact host is ``169.254.169.254``, and the flag exists to reach
+    an internal file server, not to let a caller-supplied (or model-generated)
+    URL read the container's instance credentials and upload them.
 
     Args:
         url: The URL about to be fetched.
@@ -250,16 +254,22 @@ def validate_fetch_url(url: str) -> str:
     """
     parsed = _parse_http_url(url, "URL")
     host = parsed.hostname.lower().rstrip(".")
-    if _env_flag(ALLOW_PRIVATE_FETCH_ENV_VAR):
-        return url
     if host in _METADATA_HOSTS:
         raise UnsafeURLError(f"Refusing to fetch cloud metadata host {host!r}: {url}")
+    allow_private = _env_flag(ALLOW_PRIVATE_FETCH_ENV_VAR)
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     for raw in _resolve(host, port):
         try:
             address = _classify_address(raw)
         except ValueError as exc:
             raise UnsafeURLError(f"Host {host!r} resolved to an unusable address {raw!r}: {exc}")
+        if str(address) in _METADATA_IPS:
+            raise UnsafeURLError(
+                f"Refusing to fetch {url!r}: host {host!r} resolves to the cloud metadata address "
+                f"{address}, which stays blocked even under {ALLOW_PRIVATE_FETCH_ENV_VAR}."
+            )
+        if allow_private:
+            continue
         if _is_blocked_address(address):
             raise UnsafeURLError(
                 f"Refusing to fetch {url!r}: host {host!r} resolves to the non-public address {address}. "
@@ -340,12 +350,13 @@ def safe_get(
         timeout = (FETCH_TIMEOUT_CONNECT, FETCH_TIMEOUT_READ)
     requester = session or requests
     current = url
+    current_headers = headers
     for _ in range(max_redirects + 1):
         validate_fetch_url(current)
         response = requester.get(
             current,
             timeout=timeout,
-            headers=headers,
+            headers=current_headers,
             stream=True if max_bytes is not None else stream,
             allow_redirects=False,
             **kwargs,
@@ -353,7 +364,13 @@ def safe_get(
         location = response.headers.get("Location") if response.status_code in _REDIRECT_STATUSES else None
         if location:
             response.close()
-            current = urljoin(current, location)
+            following = urljoin(current, location)
+            if current_headers and urlparse(following).netloc != urlparse(current).netloc:
+                # ``requests`` drops ``Authorization`` across a host change; following
+                # redirects by hand means doing that here, for every header, or a
+                # 302 becomes a way to harvest whatever the caller passed in.
+                current_headers = None
+            current = following
             continue
         if max_bytes is not None:
             _read_bounded(response, max_bytes, current)

--- a/aixplain/utils/url_safety.py
+++ b/aixplain/utils/url_safety.py
@@ -1,0 +1,405 @@
+"""Central URL trust policy for the SDK (BUG-939).
+
+Three unrelated code paths used to trust a URL simply because it parsed:
+
+* the configured endpoints (``BACKEND_URL``, ``MODELS_RUN_URL``,
+  ``PIPELINES_RUN_URL``), which are read straight from the environment and can
+  therefore be set by any ``.env`` on the machine;
+* URLs handed to the SDK by a caller or read out of a backend response, which
+  were gated only by ``validators.url()`` -- a *syntax* check that happily
+  accepts ``http://169.254.169.254/latest/meta-data/``, ``http://127.0.0.1:8080/x``
+  and ``http://10.0.0.1/``;
+* the presigned ``uploadUrl``, which decides where every dataset, database file
+  and attachment is PUT.
+
+All three decisions live here so the call sites stay one-liners and the policy
+cannot drift between v1, v2 and ``aixplain/utils``. This module deliberately
+imports nothing from ``aixplain.v2`` -- it is consumed by ``aixplain.utils.config``
+and by v1, neither of which may depend on v2.
+
+Residual risk: :func:`safe_get` resolves the host to validate it and then lets
+``requests`` resolve it again to connect, so a hostile resolver serving a
+zero-TTL record can still swing the second lookup (classic DNS rebinding).
+Closing that window requires connecting to the pinned address with an explicit
+``Host`` header and an SNI override; it is tracked separately.
+"""
+
+import ipaddress
+import logging
+import os
+import socket
+from typing import Any, List, Optional, Set, Tuple, Union
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+#: Opt-in that allows plain ``http://`` config and upload URLs (local dev, on-prem).
+INSECURE_OPT_IN_ENV_VAR = "AIXPLAIN_ALLOW_INSECURE_URLS"
+
+#: Opt-in that allows :func:`safe_get` to reach private/loopback addresses.
+ALLOW_PRIVATE_FETCH_ENV_VAR = "AIXPLAIN_ALLOW_PRIVATE_FETCH"
+
+#: Comma-separated extra hosts/suffixes accepted by :func:`validate_upload_url`.
+UPLOAD_ALLOWLIST_ENV_VAR = "AIXPLAIN_UPLOAD_HOST_ALLOWLIST"
+
+#: Host suffix considered "an aiXplain endpoint" for the config-URL warning.
+AIXPLAIN_HOST_SUFFIX = "aixplain.com"
+
+#: Upload hosts accepted without configuration.
+DEFAULT_UPLOAD_HOST_SUFFIXES = ("amazonaws.com", "aixplain.com")
+
+# Deliberately tighter than the API client's 300s read timeout: this fetches an
+# arbitrary caller-supplied URL, so it bounds an attacker-controlled peer rather
+# than a model execution.
+FETCH_TIMEOUT_CONNECT = 10.0
+FETCH_TIMEOUT_READ = 30.0
+
+#: How many redirects :func:`safe_get` will follow (each one re-validated).
+MAX_FETCH_REDIRECTS = 3
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_METADATA_HOSTS = frozenset({"metadata.google.internal", "metadata.goog"})
+_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+# NAT64: ``64:ff9b::7f00:1`` is 127.0.0.1 reached over IPv6.
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+# ``(variable, host)`` pairs already warned about, so a module reload or a second
+# ``Aixplain()`` does not repeat the line. A plain set (not ``lru_cache``) so a
+# test fixture can clear it.
+_WARNED_CONFIG_HOSTS: Set[Tuple[str, str]] = set()
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL fails the SDK's trust policy.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers at
+    the call sites keep working.
+    """
+
+
+def _env_flag(name: str) -> bool:
+    """Return True when environment variable *name* holds an affirmative value."""
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _parse_http_url(url: str, label: str) -> Any:
+    """Parse *url* and enforce the shared structural rules.
+
+    Rejects anything that is not an ``http``/``https`` URL with a host, and
+    anything carrying userinfo (``https://trusted.example@evil.tld/``), which no
+    legitimate aiXplain endpoint ever does and which exists mainly to disguise
+    the real target.
+
+    Args:
+        url: The URL to parse.
+        label: Human-readable name of the URL, used in error messages.
+
+    Returns:
+        urllib.parse.ParseResult: The parsed URL.
+
+    Raises:
+        UnsafeURLError: If the URL is unparseable, not http(s), carries userinfo,
+            or has no host.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UnsafeURLError(f"{label} must be a non-empty URL string")
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise UnsafeURLError(f"{label} is not a parseable URL: {exc}")
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeURLError(f"{label} must use http or https, got {parsed.scheme or '(none)'!r}: {url}")
+    try:
+        has_userinfo = bool(parsed.username or parsed.password)
+        parsed.port  # noqa: B018 -- the attribute access is what validates the port
+    except ValueError as exc:  # malformed port, e.g. "https://host:notaport/x"
+        raise UnsafeURLError(f"{label} has a malformed host or port: {exc}")
+    if has_userinfo:
+        raise UnsafeURLError(f"{label} must not contain credentials in the URL: {url}")
+    if not parsed.hostname:
+        raise UnsafeURLError(f"{label} has no host: {url}")
+    return parsed
+
+
+def _host_matches(host: str, suffix: str) -> bool:
+    """True if *host* equals *suffix* or is a subdomain of it.
+
+    Suffix matching is done label-wise, so ``evil-aixplain.com`` does not match
+    ``aixplain.com``.
+    """
+    host = host.lower().rstrip(".")
+    suffix = suffix.lower().lstrip("*").lstrip(".").rstrip(".")
+    return bool(suffix) and (host == suffix or host.endswith("." + suffix))
+
+
+def validate_config_url(url: str, name: str) -> str:
+    """Validate a configured endpoint URL (``BACKEND_URL``, ``*_RUN_URL``).
+
+    Requires ``https://`` unless ``AIXPLAIN_ALLOW_INSECURE_URLS=1``, which is
+    also what permits ``http://localhost`` for local development. Emits one
+    WARNING per ``(name, host)`` when the host is not an ``aixplain.com`` host,
+    because a redirected endpoint is the difference between the team key
+    reaching aiXplain and reaching whoever wrote the ``.env`` (BUG-939).
+
+    Args:
+        url: The configured URL.
+        name: The environment variable name, used in messages.
+
+    Returns:
+        str: *url* unchanged, when it satisfies the policy.
+
+    Raises:
+        UnsafeURLError: If the URL is not http(s), has no host, carries
+            userinfo, or is ``http://`` without the explicit opt-in.
+    """
+    parsed = _parse_http_url(url, name)
+    if parsed.scheme != "https" and not _env_flag(INSECURE_OPT_IN_ENV_VAR):
+        raise UnsafeURLError(
+            f"{name} must use https (got {url!r}). The API key is sent on every request, so plain http would "
+            f"put it on the wire in clear text. Set {INSECURE_OPT_IN_ENV_VAR}=1 to allow http for local "
+            f"development or an on-prem deployment."
+        )
+    host = parsed.hostname.lower()
+    if host in _LOOPBACK_HOSTS:
+        # A loopback endpoint under the explicit insecure opt-in is local dev;
+        # warning about it every process would be pure noise.
+        return url
+    if not _host_matches(host, AIXPLAIN_HOST_SUFFIX) and (name, host) not in _WARNED_CONFIG_HOSTS:
+        _WARNED_CONFIG_HOSTS.add((name, host))
+        logger.warning(
+            f"{name} points at {host!r}, which is not an aiXplain host. The aiXplain API key will be sent "
+            f"there. If you did not configure this deliberately, check for a .env file or an exported "
+            f"{name} in your environment."
+        )
+    return url
+
+
+def _classify_address(raw: str) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:
+    """Return *raw* as an address object, unwrapping IPv4-in-IPv6 forms.
+
+    ``::ffff:127.0.0.1`` is loopback, but ``IPv6Address.is_loopback`` is False
+    for it, so the mapped form has to be unwrapped before classification.
+    """
+    address = ipaddress.ip_address(raw)
+    if isinstance(address, ipaddress.IPv6Address):
+        mapped = address.ipv4_mapped or address.sixtofour
+        if mapped is not None:
+            return mapped
+    return address
+
+
+def _is_blocked_address(address: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> bool:
+    """True if *address* is one the SDK must never be pointed at."""
+    if str(address) in _METADATA_IPS:
+        return True
+    if isinstance(address, ipaddress.IPv6Address) and address in _NAT64_PREFIX:
+        return True
+    return bool(
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+def _resolve(host: str, port: int) -> List[str]:
+    """Resolve *host* to the list of addresses a connection could actually use.
+
+    Raises:
+        UnsafeURLError: If the host does not resolve. A name that cannot be
+            resolved is rejected rather than passed through, so a resolver
+            failure can never be mistaken for a successful check.
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UnsafeURLError(f"Cannot resolve host {host!r}: {exc}")
+    return [info[4][0] for info in infos]
+
+
+def validate_fetch_url(url: str) -> str:
+    """Validate a URL the SDK is about to fetch for a caller or from a response.
+
+    ``validators.url()`` -- the check these call sites used to rely on -- is a
+    syntax check: against validators 0.35.0 it returns True for
+    ``http://169.254.169.254/latest/meta-data/``, ``http://127.0.0.1:8080/x``
+    and ``http://10.0.0.1/`` (BUG-939). This is the security check that has to
+    sit next to it: scheme allowlist, no userinfo, and *every* resolved address
+    rejected if it is loopback, private, link-local, reserved, multicast,
+    unspecified or a known cloud-metadata endpoint.
+
+    Set ``AIXPLAIN_ALLOW_PRIVATE_FETCH=1`` on an on-prem deployment whose
+    artifact host lives on a private range.
+
+    Args:
+        url: The URL about to be fetched.
+
+    Returns:
+        str: *url* unchanged, when it satisfies the policy.
+
+    Raises:
+        UnsafeURLError: If the scheme, host or any resolved address is rejected,
+            or if the host does not resolve.
+    """
+    parsed = _parse_http_url(url, "URL")
+    host = parsed.hostname.lower().rstrip(".")
+    if _env_flag(ALLOW_PRIVATE_FETCH_ENV_VAR):
+        return url
+    if host in _METADATA_HOSTS:
+        raise UnsafeURLError(f"Refusing to fetch cloud metadata host {host!r}: {url}")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    for raw in _resolve(host, port):
+        try:
+            address = _classify_address(raw)
+        except ValueError as exc:
+            raise UnsafeURLError(f"Host {host!r} resolved to an unusable address {raw!r}: {exc}")
+        if _is_blocked_address(address):
+            raise UnsafeURLError(
+                f"Refusing to fetch {url!r}: host {host!r} resolves to the non-public address {address}. "
+                f"Set {ALLOW_PRIVATE_FETCH_ENV_VAR}=1 if this deployment really does host artifacts on an "
+                f"internal address."
+            )
+    return url
+
+
+def _read_bounded(response: requests.Response, max_bytes: int, url: str) -> None:
+    """Consume *response* into memory, refusing to buffer more than *max_bytes*.
+
+    The body of a fetched URL is uploaded to the platform as a utility model's
+    source, so a hostile endpoint must not be able to balloon the memory of the
+    process (often an agent container) that fetched it.
+
+    Raises:
+        UnsafeURLError: If the body exceeds *max_bytes*.
+    """
+    if getattr(response, "raw", None) is None or getattr(response, "_content_consumed", False):
+        # Already buffered by the adapter: there is nothing to stream, so the
+        # cap is enforced against what is in hand.
+        buffered = response._content if isinstance(response._content, (bytes, bytearray)) else b""
+        if len(buffered) > max_bytes:
+            raise UnsafeURLError(f"Refusing to read more than {max_bytes} bytes from {url!r}")
+        response._content_consumed = True
+        return
+
+    body = bytearray()
+    for chunk in response.iter_content(chunk_size=8192):
+        if not chunk:
+            continue
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            response.close()
+            raise UnsafeURLError(f"Refusing to read more than {max_bytes} bytes from {url!r}")
+    response._content = bytes(body)
+    response._content_consumed = True
+
+
+def safe_get(
+    url: str,
+    *,
+    timeout: Optional[Any] = None,
+    stream: bool = False,
+    headers: Optional[dict] = None,
+    max_redirects: int = MAX_FETCH_REDIRECTS,
+    max_bytes: Optional[int] = None,
+    session: Optional[requests.Session] = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """GET *url*, applying :func:`validate_fetch_url` to it and to every redirect.
+
+    Redirects are followed manually (``allow_redirects=False``) so that each
+    ``Location`` is re-validated: a perfectly public host that 302s to
+    ``http://169.254.169.254/`` is otherwise indistinguishable from a safe fetch.
+
+    Args:
+        url: The URL to fetch.
+        timeout: ``requests`` timeout; defaults to
+            ``(FETCH_TIMEOUT_CONNECT, FETCH_TIMEOUT_READ)``.
+        stream: Leave the body unconsumed (ignored when *max_bytes* is set).
+        headers: Extra request headers.
+        max_redirects: How many redirects to follow before giving up.
+        max_bytes: Optional cap on the response body size.
+        session: Optional ``requests.Session`` to issue the request on.
+        **kwargs: Forwarded to ``requests.get``.
+
+    Returns:
+        requests.Response: The final response. The status is **not** raised on,
+        so callers keep their existing error handling.
+
+    Raises:
+        UnsafeURLError: If the target, or any redirect target, fails the policy,
+            or if the redirect budget is exhausted.
+    """
+    if timeout is None:
+        timeout = (FETCH_TIMEOUT_CONNECT, FETCH_TIMEOUT_READ)
+    requester = session or requests
+    current = url
+    for _ in range(max_redirects + 1):
+        validate_fetch_url(current)
+        response = requester.get(
+            current,
+            timeout=timeout,
+            headers=headers,
+            stream=True if max_bytes is not None else stream,
+            allow_redirects=False,
+            **kwargs,
+        )
+        location = response.headers.get("Location") if response.status_code in _REDIRECT_STATUSES else None
+        if location:
+            response.close()
+            current = urljoin(current, location)
+            continue
+        if max_bytes is not None:
+            _read_bounded(response, max_bytes, current)
+        return response
+    raise UnsafeURLError(f"Refusing to follow more than {max_redirects} redirects from {url!r}")
+
+
+def _upload_host_suffixes() -> Tuple[str, ...]:
+    """Return the allowed upload host suffixes, including the env extension."""
+    extra = os.getenv(UPLOAD_ALLOWLIST_ENV_VAR, "")
+    entries = [entry.strip() for entry in extra.split(",") if entry.strip()]
+    return DEFAULT_UPLOAD_HOST_SUFFIXES + tuple(entries)
+
+
+def validate_upload_url(url: str) -> str:
+    """Validate a presigned ``uploadUrl`` before the SDK PUTs a file to it.
+
+    The URL comes straight out of a backend response, so a compromised backend
+    -- or a ``BACKEND_URL`` redirected by an ambient ``.env`` -- would otherwise
+    receive every dataset, database file, skill bundle and attachment while the
+    SDK reported success (BUG-939).
+
+    ``*.amazonaws.com`` and ``*.aixplain.com`` are allowed by default; extend
+    with a comma-separated ``AIXPLAIN_UPLOAD_HOST_ALLOWLIST`` (each entry may be
+    a bare host, ``.suffix`` or ``*.suffix``). https is required unless
+    ``AIXPLAIN_ALLOW_INSECURE_URLS=1``.
+
+    Args:
+        url: The presigned upload URL returned by the backend.
+
+    Returns:
+        str: *url* unchanged, when it satisfies the policy.
+
+    Raises:
+        UnsafeURLError: If the scheme or host is not allowed.
+    """
+    parsed = _parse_http_url(url, "Upload URL")
+    if parsed.scheme != "https" and not _env_flag(INSECURE_OPT_IN_ENV_VAR):
+        raise UnsafeURLError(
+            f"Refusing to upload over plain http to {parsed.hostname!r}. Set {INSECURE_OPT_IN_ENV_VAR}=1 to allow it."
+        )
+    host = parsed.hostname.lower()
+    suffixes = _upload_host_suffixes()
+    if not any(_host_matches(host, suffix) for suffix in suffixes):
+        raise UnsafeURLError(
+            f"Refusing to upload to unexpected host {host!r}. Allowed: {', '.join(suffixes)}. "
+            f"Set {UPLOAD_ALLOWLIST_ENV_VAR} to add a host."
+        )
+    return url

--- a/aixplain/utils/url_safety.py
+++ b/aixplain/utils/url_safety.py
@@ -310,6 +310,16 @@ def _read_bounded(response: requests.Response, max_bytes: int, url: str) -> None
     response._content_consumed = True
 
 
+def _credential_scope(url: str) -> Tuple[str, str]:
+    """Return the ``(scheme, netloc)`` pair that request headers are scoped to.
+
+    Headers are dropped whenever this changes across a redirect: a different
+    host obviously, but also the same host over a weaker scheme.
+    """
+    parsed = urlparse(url)
+    return parsed.scheme.lower(), parsed.netloc.lower()
+
+
 def safe_get(
     url: str,
     *,
@@ -365,10 +375,14 @@ def safe_get(
         if location:
             response.close()
             following = urljoin(current, location)
-            if current_headers and urlparse(following).netloc != urlparse(current).netloc:
+            if current_headers and _credential_scope(following) != _credential_scope(current):
                 # ``requests`` drops ``Authorization`` across a host change; following
                 # redirects by hand means doing that here, for every header, or a
                 # 302 becomes a way to harvest whatever the caller passed in.
+                # The scheme is part of the comparison because ``validate_fetch_url``
+                # permits http: an https -> http downgrade keeps the netloc
+                # identical and would otherwise put the caller's headers on the
+                # wire in clear text.
                 current_headers = None
             current = following
             continue

--- a/aixplain/v1/factories/model_factory/utils.py
+++ b/aixplain/v1/factories/model_factory/utils.py
@@ -21,6 +21,7 @@ from aixplain.enums import (
 )
 from aixplain.utils import config
 from aixplain.utils.request_utils import _request_with_retry
+from aixplain.utils.url_safety import safe_get
 from datetime import datetime
 from typing import Dict, Union, List, Optional, Tuple
 from urllib.parse import urljoin
@@ -119,7 +120,7 @@ def create_model_from_response(response: Dict) -> Model:
                 version_link = response["version"]["id"]
                 if version_link:
                     try:
-                        version_content = requests.get(version_link).text
+                        version_content = safe_get(version_link).text
                         code = version_content
                     except Exception:
                         code = ""

--- a/aixplain/v1/modules/agent/__init__.py
+++ b/aixplain/v1/modules/agent/__init__.py
@@ -574,7 +574,12 @@ class Agent(Model, DeployableMixin[Union[Tool, DeployableTool]]):
             print(completion_msg, flush=True)
 
         if response_body["completed"] is True:
-            logging.debug(f"Polling for Agent: Final status of polling for {name}: {response_body}")
+            # Status only, lazily -- never the body; see BUG-942 item 5.
+            logging.debug(
+                "Polling for Agent: Final status of polling for %s: %s",
+                name,
+                getattr(response_body, "status", None),
+            )
         else:
             response_body = AgentResponse(
                 status=ResponseStatus.FAILED,

--- a/aixplain/v1/modules/agent/__init__.py
+++ b/aixplain/v1/modules/agent/__init__.py
@@ -28,6 +28,7 @@ import inspect
 import json
 import logging
 import re
+import random
 import time
 import traceback
 from datetime import datetime
@@ -547,7 +548,10 @@ class Agent(Model, DeployableMixin[Union[Tool, DeployableTool]]):
 
                 end = time.time()
                 if completed is False:
-                    time.sleep(wait_time)
+                    # Jittered: a deterministic interval keeps every client
+                    # launched together phase-locked for the whole run, so the
+                    # fleet polls in synchronized waves (BUG-942).
+                    time.sleep(wait_time * random.uniform(0.8, 1.2))
                     if wait_time < 60:
                         wait_time *= 1.1
             except Exception as e:

--- a/aixplain/v1/modules/agent/tool/sql_tool.py
+++ b/aixplain/v1/modules/agent/tool/sql_tool.py
@@ -33,6 +33,7 @@ import numpy as np
 from typing import Text, Optional, Dict, List, Union
 import sqlite3
 from aixplain.enums import AssetStatus
+from aixplain.utils.url_safety import safe_get
 from aixplain.modules.agent.tool import DeployableTool
 
 
@@ -499,7 +500,7 @@ class SQLTool(DeployableTool):
 
         # Download database file
         if str(self.database).startswith(("http://", "https://")):
-            response = requests.get(self.database)
+            response = safe_get(self.database)
             response.raise_for_status()
             with open(local_path, "wb") as f:
                 f.write(response.content)

--- a/aixplain/v1/modules/benchmark_job.py
+++ b/aixplain/v1/modules/benchmark_job.py
@@ -113,7 +113,9 @@ class BenchmarkJob:
                 return None
             csv_url = resp["reportUrl"]
             # ``reportUrl`` comes from a backend response, so it is SSRF-gated
-            # before ``save_file`` fetches it (BUG-939).
+            # before ``save_file`` fetches it, and ``save_file`` re-validates
+            # every redirect hop rather than letting ``requests`` follow a 302
+            # from an allowed host to a private address (BUG-939).
             validate_fetch_url(csv_url)
             if return_dataframe:
                 downloaded_path = save_file(csv_url, save_path)

--- a/aixplain/v1/modules/benchmark_job.py
+++ b/aixplain/v1/modules/benchmark_job.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from aixplain.utils.request_utils import _request_with_retry
 from aixplain.utils.file_utils import save_file
+from aixplain.utils.url_safety import validate_fetch_url
 
 
 class BenchmarkJob:
@@ -111,6 +112,9 @@ class BenchmarkJob:
                 )
                 return None
             csv_url = resp["reportUrl"]
+            # ``reportUrl`` comes from a backend response, so it is SSRF-gated
+            # before ``save_file`` fetches it (BUG-939).
+            validate_fetch_url(csv_url)
             if return_dataframe:
                 downloaded_path = save_file(csv_url, save_path)
                 df = pd.read_csv(downloaded_path)

--- a/aixplain/v1/modules/model/__init__.py
+++ b/aixplain/v1/modules/model/__init__.py
@@ -23,6 +23,7 @@ Date: September 1st 2022
 """
 
 __author__ = "lucaspavanelli"
+import random
 import time
 import logging
 import traceback
@@ -238,7 +239,10 @@ class Model(Asset):
 
                 end = time.time()
                 if completed is False:
-                    time.sleep(wait_time)
+                    # Jittered: a deterministic interval keeps every client
+                    # launched together phase-locked for the whole run, so the
+                    # fleet polls in synchronized waves (BUG-942).
+                    time.sleep(wait_time * random.uniform(0.8, 1.2))
                     if wait_time < 60:
                         wait_time *= 1.1
             except Exception as e:

--- a/aixplain/v1/modules/model/__init__.py
+++ b/aixplain/v1/modules/model/__init__.py
@@ -254,7 +254,11 @@ class Model(Asset):
                 logging.error(f"Polling for Model: polling for {name}: {e}")
                 break
         if response_body["completed"] is True:
-            logging.debug(f"Polling for Model: Final status of polling for {name}: {response_body}")
+            logging.debug(
+                "Polling for Model: Final status of polling for %s: %s",
+                name,
+                getattr(response_body, "status", None),
+            )
         else:
             response_body = ModelResponse(
                 status=ResponseStatus.FAILED,
@@ -262,7 +266,9 @@ class Model(Asset):
                 error_message="No response from the service.",
             )
             logging.error(
-                f"Polling for Model: Final status of polling for {name}: No response in {timeout} seconds - {response_body}"
+                "Polling for Model: Final status of polling for %s: No response in %s seconds",
+                name,
+                timeout,
             )
         return response_body
 
@@ -293,7 +299,8 @@ class Model(Asset):
             else:
                 status = ResponseStatus.IN_PROGRESS
 
-            logging.debug(f"Single Poll for Model: Status of polling for {name}: {resp}")
+            # Status only, lazily -- never the body; see BUG-942 item 5.
+            logging.debug("Single Poll for Model: Status of polling for %s: %s", name, resp.get("status"))
 
             raw_status = resp.pop("status", status)
             # Convert string status to ResponseStatus enum if needed

--- a/aixplain/v1/modules/model/rlm.py
+++ b/aixplain/v1/modules/model/rlm.py
@@ -890,8 +890,9 @@ def llm_query(prompt):
         """
         if not (isinstance(context, str) and (context.startswith("http://") or context.startswith("https://"))):
             return context
-        import requests
-        r = requests.get(context, timeout=60)
+        from aixplain.utils.url_safety import safe_get
+
+        r = safe_get(context, timeout=60)
         r.raise_for_status()
         ct = r.headers.get("Content-Type", "")
         url_path = context.split("?")[0].lower()

--- a/aixplain/v1/modules/model/utils.py
+++ b/aixplain/v1/modules/model/utils.py
@@ -10,6 +10,7 @@ import json
 import logging
 import ast
 import inspect
+import requests
 from aixplain.utils.file_utils import _request_with_retry
 from typing import Callable, Dict, List, Text, Tuple, Union, Optional
 from aixplain.exceptions import get_error_from_status_code
@@ -150,6 +151,11 @@ def build_payload(
             return [_serialize_value(item) for item in obj]
         return obj
 
+    # ``deepcopy`` is the first statement in the try and can itself raise
+    # TypeError (a lock, a socket, a module), leaving ``parametersTemp``
+    # unbound when the handler below reads it (BUG-941). ``_serialize_value``
+    # does not mutate its argument, so falling back to the original is safe.
+    parametersTemp = parameters
     try:
         parametersTemp = copy.deepcopy(parameters)
         if not payload:
@@ -197,17 +203,39 @@ def call_run_endpoint(url: Text, api_key: Text, payload: Dict) -> Dict:
     try:
         logging.debug(f"Calling {url} with payload: {payload}")
         r = _request_with_retry("post", url, headers=headers, data=payload)
-        resp = r.json()
-    except Exception as e:
+    except (requests.exceptions.RequestException, OSError) as e:
+        # This handler used to build the FAILED response and then fall through
+        # to ``r.status_code``, which is unbound when the request itself raised
+        # -- an UnboundLocalError instead of the documented FAILED response
+        # (BUG-941). The catch stays wide enough for the builtin
+        # ``ConnectionError``/``OSError`` the socket layer can raise, which are
+        # not ``requests.exceptions.RequestException`` subclasses, but narrow
+        # enough that a genuine bug in our own code still surfaces.
         logging.error(f"Error in request: {e}")
-        response = {
+        return {
             "status": "FAILED",
             "completed": True,
             "error_message": "Model Run: An error occurred while processing your request.",
         }
 
+    try:
+        resp = r.json()
+    except ValueError as e:
+        # ``requests.exceptions.JSONDecodeError`` subclasses ValueError. ``resp``
+        # deliberately keeps its sentinel: for a non-2xx body the branch below
+        # still maps the HTTP status onto a specific error message (BUG-941).
+        logging.error(f"Error parsing the response of {url}: {e}")
+
     if 200 <= r.status_code < 300:
         logging.info(f"Result of request: {r.status_code} - {resp}")
+        if not isinstance(resp, dict):
+            # A 2xx body we could not decode: ``resp.get`` used to raise
+            # AttributeError on the sentinel string (BUG-941).
+            return {
+                "status": "FAILED",
+                "completed": True,
+                "error_message": "Model Run: An error occurred while processing your request.",
+            }
         status = resp.get("status", "IN_PROGRESS")
         data = resp.get("data", None)
         if status == "IN_PROGRESS":

--- a/aixplain/v1/modules/model/utils.py
+++ b/aixplain/v1/modules/model/utils.py
@@ -12,6 +12,7 @@ import ast
 import inspect
 import requests
 from aixplain.utils.file_utils import _request_with_retry
+from aixplain.utils.url_safety import safe_get
 from typing import Callable, Dict, List, Text, Tuple, Union, Optional
 from aixplain.exceptions import get_error_from_status_code
 import copy
@@ -317,7 +318,7 @@ def parse_code(code: Union[Text, Callable], api_key: Optional[Text] = None) -> T
         with open(code, "r") as f:
             str_code = f.read()
     elif validators.url(code):
-        str_code = requests.get(code).text
+        str_code = safe_get(code).text
     else:
         str_code = code
     # assert str_code has a main function
@@ -534,7 +535,7 @@ def parse_code_decorated(code: Union[Text, Callable], api_key: Optional[Text] = 
             with open(code, "r") as f:
                 str_code = f.read()
         elif validators.url(code):
-            str_code = requests.get(code).text
+            str_code = safe_get(code).text
         else:
             str_code = code
 

--- a/aixplain/v1/modules/pipeline/asset.py
+++ b/aixplain/v1/modules/pipeline/asset.py
@@ -166,6 +166,10 @@ class Pipeline(Asset, DeployableMixin):
             "Content-Type": "application/json",
         }
         r = _request_with_retry("get", poll_url, headers=headers)
+        # Bound before the try: ``r.json()`` is the first statement inside it and
+        # raises on a non-JSON body (a 502/504 gateway page, an empty body), yet
+        # the handler below reads ``resp`` -- UnboundLocalError (BUG-941).
+        resp = {}
         try:
             resp = r.json()
             if "data" in resp and isinstance(resp["data"], str):
@@ -196,6 +200,11 @@ class Pipeline(Asset, DeployableMixin):
             return response
 
         except Exception:
+            if not isinstance(resp, dict):
+                # A JSON array or scalar body binds ``resp`` to a non-dict, and
+                # ``.pop("error", None)`` then raises TypeError out of this
+                # handler instead of returning FAILED (BUG-941).
+                resp = {}
             return PipelineResponse(
                 status=ResponseStatus.FAILED,
                 error=resp.pop("error", None),

--- a/aixplain/v1/modules/pipeline/asset.py
+++ b/aixplain/v1/modules/pipeline/asset.py
@@ -117,7 +117,9 @@ class Pipeline(Asset, DeployableMixin):
         while not response_body["completed"] and (end - start) < timeout:
             try:
                 response_body = self.poll(poll_url, name=name)
-                logging.debug(f"Polling for Pipeline: Status of polling for {name} : {response_body}")
+                # Status only, lazily: an eager f-string stringifies the whole
+                # response body on every poll even when DEBUG is off (BUG-942 item 5).
+                logging.debug("Polling for Pipeline: Status of polling for %s: %s", name, response_body.get("status"))
                 end = time.time()
                 if not response_body["completed"]:
                     # Jittered: a deterministic interval keeps every client
@@ -129,18 +131,21 @@ class Pipeline(Asset, DeployableMixin):
             except Exception:
                 logging.error(f"Polling for Pipeline '{self.id}': polling for {name} ({poll_url}): Continue")
                 break
+        # Lazy ``%s`` args and no response body: see BUG-942 item 5.
         if response_body["status"] == ResponseStatus.SUCCESS:
-            try:
-                logging.debug(
-                    f"Polling for Pipeline '{self.id}' - Final status of polling for {name} ({poll_url}): SUCCESS - {response_body}"
-                )
-            except Exception:
-                logging.error(
-                    f"Polling for Pipeline '{self.id}' - Final status of polling for {name} ({poll_url}): ERROR - {response_body}"
-                )
+            logging.debug(
+                "Polling for Pipeline '%s' - Final status of polling for %s (%s): SUCCESS",
+                self.id,
+                name,
+                poll_url,
+            )
         else:
             logging.error(
-                f"Polling for Pipeline '{self.id}' - Final status of polling for {name} ({poll_url}): No response in {timeout} seconds - {response_body}"
+                "Polling for Pipeline '%s' - Final status of polling for %s (%s): No response in %s seconds",
+                self.id,
+                name,
+                poll_url,
+                timeout,
             )
         return response_body
 

--- a/aixplain/v1/modules/pipeline/asset.py
+++ b/aixplain/v1/modules/pipeline/asset.py
@@ -21,6 +21,7 @@ Description:
     Pipeline Asset Class
 """
 
+import random
 import time
 import json
 import os
@@ -95,7 +96,7 @@ class Pipeline(Asset, DeployableMixin):
         poll_url: Text,
         name: Text = "pipeline_process",
         wait_time: float = 1.0,
-        timeout: float = 20000.0,
+        timeout: float = 1800.0,
     ) -> Dict:
         """Keeps polling the platform to check whether an asynchronous call is done.
 
@@ -103,7 +104,7 @@ class Pipeline(Asset, DeployableMixin):
             poll_url (str): polling URL
             name (str, optional): ID given to a call. Defaults to "pipeline_process".
             wait_time (float, optional): wait time in seconds between polling calls. Defaults to 1.0.
-            timeout (float, optional): total polling time. Defaults to 20000.0.
+            timeout (float, optional): total polling time. Defaults to 1800.0 (30 minutes).
 
         Returns:
             dict: response obtained by polling call
@@ -119,7 +120,10 @@ class Pipeline(Asset, DeployableMixin):
                 logging.debug(f"Polling for Pipeline: Status of polling for {name} : {response_body}")
                 end = time.time()
                 if not response_body["completed"]:
-                    time.sleep(wait_time)
+                    # Jittered: a deterministic interval keeps every client
+                    # launched together phase-locked for the whole run, so the
+                    # fleet polls in synchronized waves (BUG-942).
+                    time.sleep(wait_time * random.uniform(0.8, 1.2))
                     if wait_time < 60:
                         wait_time *= 1.1
             except Exception:
@@ -164,7 +168,17 @@ class Pipeline(Asset, DeployableMixin):
                     resp["data"] = json.loads(resp["data"])["response"]
                 except Exception:
                     resp = r.json()
-            logging.info(f"Single Poll for Pipeline '{self.id}' - Status of polling for {name} ({poll_url}): {resp}")
+            # Lazy ``%s`` args and status only: this ran at INFO on every poll
+            # with the whole response interpolated eagerly, so a pipeline
+            # returning a 500KB transcript emitted ~180MB of logs per run
+            # (BUG-942 item 5).
+            logging.debug(
+                "Single Poll for Pipeline '%s' - Status of polling for %s (%s): %s",
+                self.id,
+                name,
+                poll_url,
+                resp.get("status") if isinstance(resp, dict) else None,
+            )
             if response_version == "v1":
                 return resp
             status = ResponseStatus(resp.pop("status", "failed"))
@@ -189,7 +203,7 @@ class Pipeline(Asset, DeployableMixin):
         data: Union[Text, Dict],
         data_asset: Optional[Union[Text, Dict]] = None,
         name: Text = "pipeline_process",
-        timeout: float = 20000.0,
+        timeout: float = 1800.0,
         wait_time: float = 1.0,
         version: Optional[Text] = None,
         response_version: Text = "v2",
@@ -211,7 +225,7 @@ class Pipeline(Asset, DeployableMixin):
             name (Text, optional): Identifier for this pipeline run. Used for
                 logging. Defaults to "pipeline_process".
             timeout (float, optional): Maximum time in seconds to wait for
-                completion. Defaults to 20000.0.
+                completion. Defaults to 1800.0 (30 minutes).
             wait_time (float, optional): Initial time in seconds between polling
                 attempts. May increase over time. Defaults to 1.0.
             version (Optional[Text], optional): Specific pipeline version to run.

--- a/aixplain/v1/modules/team_agent/__init__.py
+++ b/aixplain/v1/modules/team_agent/__init__.py
@@ -593,7 +593,12 @@ class TeamAgent(Model, DeployableMixin[Agent]):
             print(completion_msg, flush=True)
 
         if response_body["completed"] is True:
-            logging.debug(f"Polling for Team Agent: Final status of polling for {name}: {response_body}")
+            # Status only, lazily -- never the body; see BUG-942 item 5.
+            logging.debug(
+                "Polling for Team Agent: Final status of polling for %s: %s",
+                name,
+                getattr(response_body, "status", None),
+            )
         else:
             response_body = AgentResponse(
                 status=ResponseStatus.FAILED,
@@ -923,7 +928,8 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                     error_message = resp.get("error_message")
             else:
                 status = ResponseStatus.IN_PROGRESS
-            logging.debug(f"Single Poll for Team Agent: Status of polling for {name}: {resp}")
+            # Status only, lazily -- never the body; see BUG-942 item 5.
+            logging.debug("Single Poll for Team Agent: Status of polling for %s: %s", name, resp.get("status"))
 
             resp_data = resp.get("data") or {}
             diagnostic_error_codes = self._extract_diagnostic_error_codes(resp, resp_data)

--- a/aixplain/v1/modules/team_agent/__init__.py
+++ b/aixplain/v1/modules/team_agent/__init__.py
@@ -703,7 +703,13 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                 return response
             poll_url = response["url"]
             end = time.time()
-            result = self.sync_poll(poll_url, name=name, timeout=timeout, wait_time=wait_time)
+            result = self.sync_poll(
+                poll_url,
+                name=name,
+                timeout=timeout,
+                wait_time=wait_time,
+                progress_verbosity=progress_verbosity,
+            )
             result_data = result.data or {}
             diagnostic_error_codes = result.diagnostic_error_codes
             if result.status == ResponseStatus.FAILED:

--- a/aixplain/v1/modules/team_agent/__init__.py
+++ b/aixplain/v1/modules/team_agent/__init__.py
@@ -27,6 +27,7 @@ __author__ = "aiXplain"
 
 import json
 import logging
+import random
 import time
 import traceback
 import re
@@ -567,7 +568,10 @@ class TeamAgent(Model, DeployableMixin[Agent]):
 
                 end = time.time()
                 if completed is False:
-                    time.sleep(wait_time)
+                    # Jittered: a deterministic interval keeps every client
+                    # launched together phase-locked for the whole run, so the
+                    # fleet polls in synchronized waves (BUG-942).
+                    time.sleep(wait_time * random.uniform(0.8, 1.2))
                     if wait_time < 60:
                         wait_time *= 1.1
             except Exception as e:

--- a/aixplain/v2/_backoff.py
+++ b/aixplain/v2/_backoff.py
@@ -1,0 +1,88 @@
+"""Jittered backoff helpers for v2 poll loops.
+
+Every poll interval in this SDK used to grow deterministically from a shared
+start (``wait_time *= 1.1``, capped at 60s), so any batch of clients launched
+together -- a CI matrix, a notebook fan-out, or a platform-wide recovery after
+an outage -- stayed phase-locked for the whole run and hit the platform in
+synchronized waves (BUG-942).  Jitter is what breaks that correlation.
+
+The form used here is *multiplicative and symmetric*: ``wait * U(1-s, 1+s)``.
+It preserves the mean poll rate, so no individual run gets slower on average,
+and it scales correctly across an interval range that spans 300x (0.2s to 60s)
+-- unlike additive jitter, which would be a 500% perturbation at the bottom of
+that range and noise at the top.
+"""
+
+import random
+import time
+from typing import Optional
+
+# +/-20% around the nominal interval. Enough spread to decorrelate a fleet
+# within a couple of intervals, small enough that a caller's observed latency
+# and the 60s cap keep their intended meaning.
+JITTER_SPREAD = 0.2
+
+# The SDK-wide poll backoff: grow by 10% per poll, never sleep more than a
+# minute between polls.
+BACKOFF_FACTOR = 1.1
+BACKOFF_CAP = 60.0
+
+
+def jitter(wait_time: float, spread: float = JITTER_SPREAD) -> float:
+    """Scale *wait_time* by ``uniform(1 - spread, 1 + spread)``.
+
+    Args:
+        wait_time: Nominal interval in seconds. Non-positive values return 0.0.
+        spread: Fractional spread, clamped to ``[0.0, 1.0]``. ``0.0`` disables
+            jitter and returns *wait_time* unchanged.
+
+    Returns:
+        The jittered interval in seconds, never negative.
+    """
+    if wait_time <= 0:
+        return 0.0
+    spread = min(max(spread, 0.0), 1.0)
+    if spread == 0.0:
+        return float(wait_time)
+    return max(0.0, wait_time * random.uniform(1.0 - spread, 1.0 + spread))
+
+
+def next_wait(wait_time: float, factor: float = BACKOFF_FACTOR, cap: float = BACKOFF_CAP) -> float:
+    """Grow *wait_time* geometrically, capped at *cap*.
+
+    Args:
+        wait_time: Current interval in seconds.
+        factor: Growth factor per step.
+        cap: Upper bound on the returned interval.
+
+    Returns:
+        The next nominal interval in seconds.
+    """
+    if wait_time >= cap:
+        return cap
+    return min(wait_time * factor, cap)
+
+
+def sleep_with_jitter(
+    wait_time: float,
+    spread: float = JITTER_SPREAD,
+    max_sleep: Optional[float] = None,
+) -> float:
+    """Sleep ``jitter(wait_time)`` seconds, clamped to *max_sleep*.
+
+    Args:
+        wait_time: Nominal interval in seconds.
+        spread: Fractional jitter spread; see :func:`jitter`.
+        max_sleep: The caller's remaining budget, if any. Jitter must be able to
+            shorten a sleep but never to push a loop past its own deadline, so
+            the delay is clamped to this value.
+
+    Returns:
+        The number of seconds actually slept.
+    """
+    delay = jitter(wait_time, spread)
+    if max_sleep is not None:
+        delay = min(delay, max(0.0, max_sleep))
+    if delay > 0:
+        time.sleep(delay)
+    return delay

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -964,9 +964,11 @@ class Agent(
         progress_truncate = kwargs.get("progress_truncate", True)
         fmt = ProgressFormat(progress_format)
 
+        # ``poll_interval`` is deliberately not set: this tracker is driven by the
+        # start/update/finish hooks off ``sync_poll``, which owns the interval.
+        # It would only be slept on by ``stream_progress``, which is not used here.
         self._progress_tracker = AgentProgressTracker(
             poll_func=lambda url: self.poll(url),
-            poll_interval=0.05,
             max_polls=None,
         )
         self._progress_tracker.start(
@@ -1197,7 +1199,7 @@ class Agent(
         path = self.POLL_URL_TEMPLATE.format(execution_id=poll_url)
         return f"{backend_url}/{path}"
 
-    def poll(self, poll_url: str) -> AgentRunResult:
+    def poll(self, poll_url: str, timeout: Optional[float] = None) -> AgentRunResult:
         """Poll for the result of an asynchronous agent execution.
 
         Unlike the base implementation, *poll_url* may be either a full URL
@@ -1209,11 +1211,13 @@ class Agent(
 
         Args:
             poll_url: Full poll URL or execution ID.
+            timeout: Optional upper bound, in seconds, on this single request's
+                read phase. See :meth:`RunnableResourceMixin.poll`.
 
         Returns:
             AgentRunResult with current execution status.
         """
-        return super().poll(self._resolve_poll_url(poll_url))
+        return super().poll(self._resolve_poll_url(poll_url), timeout=timeout)
 
     def sync_poll(self, poll_url: str, **kwargs: Unpack[AgentRunParams]) -> AgentRunResult:
         """Poll until an asynchronous agent execution completes.

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -835,12 +835,6 @@ class Agent(
             ]
             self.files = current_ids
 
-        # TODO: Re-enable this validation after backend data consistency is fixed
-        # if self.agents and (self.tasks or self.tools):
-        #     raise ValueError(
-        #         "Team agents cannot have tasks or tools. Please remove the tasks or tools and try again."
-        #     )
-
     @staticmethod
     def _skill_reference_id(skill: Optional[Union[str, Dict[str, Any], "Skill"]]) -> Optional[str]:
         """Return the backend ID represented by one Skill reference."""

--- a/aixplain/v2/agent_progress.py
+++ b/aixplain/v2/agent_progress.py
@@ -911,14 +911,19 @@ class AgentProgressTracker:
             format: Display format (status, logs, none)
             verbosity: Detail level (1=minimal, 2=thoughts, 3=full I/O)
             truncate: Whether to truncate long text
-            timeout: Wall-clock budget in seconds (default: 300). On expiry the
-                last (non-terminal) response is returned and a warning is
-                logged -- this method has never raised, so it still doesn't.
-                Pass ``None`` for the previous unbounded behaviour.
+            timeout: Wall-clock budget in seconds (default: 300). On expiry
+                ``TimeoutError`` is raised, matching ``sync_poll``: a run that
+                is still IN_PROGRESS is not a result, and returning one made the
+                two polling surfaces disagree about what a timeout means. Pass
+                ``None`` for the previous unbounded behaviour.
 
         Returns:
             Final response from the agent, or the last polled response if
-            *timeout* or ``max_polls`` was reached first.
+            ``max_polls`` was reached first.
+
+        Raises:
+            TimeoutError: If *timeout* elapses before the run reaches a terminal
+                status.
         """
         terminal_success = "SUCCESS"
         terminal_failures = {"FAILED", "ABORTED", "CANCELLED", "ERROR"}
@@ -986,7 +991,9 @@ class AgentProgressTracker:
                     )
                     if self._format != ProgressFormat.NONE:
                         self._print_completion_message("TIMEOUT", steps)
-                    return resp
+                    raise TimeoutError(
+                        f"Operation timed out after {timeout} seconds (last status: {status_up or 'UNKNOWN'})"
+                    )
 
                 sleep_with_jitter(interval, max_sleep=remaining)
                 interval = next_wait(interval)

--- a/aixplain/v2/agent_progress.py
+++ b/aixplain/v2/agent_progress.py
@@ -12,11 +12,16 @@ Both modes use carriage return (\r) for in-place line updates.
 """
 
 import json
+import logging
 import sys
 import time
 import threading
 from enum import Enum
 from typing import Any, Dict, List, Optional, Callable
+
+from ._backoff import next_wait, sleep_with_jitter
+
+logger = logging.getLogger(__name__)
 
 
 # Internal flag to use legacy time format (MM:SS.cc always)
@@ -74,7 +79,8 @@ class AgentProgressTracker:
 
     Attributes:
         poll_func: Callable that polls for agent status
-        poll_interval: Time between polls in seconds
+        poll_interval: Starting time between polls in seconds (backed off by
+            ``stream_progress``)
         max_polls: Maximum number of polls (None for unlimited)
         format: Display format (status, logs, none)
         verbosity: Detail level (1=minimal, 2=thoughts, 3=full I/O)
@@ -84,17 +90,30 @@ class AgentProgressTracker:
     SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
     DISPLAY_REFRESH_RATE = 0.05  # 50ms = 20 FPS
 
+    # Starting interval for ``stream_progress``. It used to be 0.05s, i.e. 20
+    # requests/second per job with no ceiling -- 12,000 requests for a single
+    # 10-minute run (BUG-942). 0.5s matches ``sync_poll``'s default and is
+    # backed off from there. Note this is unrelated to DISPLAY_REFRESH_RATE,
+    # which drives the local spinner and issues no requests.
+    DEFAULT_POLL_INTERVAL = 0.5
+
+    # Wall-clock budget for a ``stream_progress`` call, matching ``sync_poll``.
+    DEFAULT_STREAM_TIMEOUT = 300.0
+
     def __init__(
         self,
         poll_func: Callable[[str], Any],
-        poll_interval: float = 0.05,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
         max_polls: Optional[int] = None,
     ):
         """Initialize the progress tracker.
 
         Args:
             poll_func: Function that takes a URL and returns poll response
-            poll_interval: Time in seconds between polls (default: 0.05)
+            poll_interval: Starting time in seconds between polls in
+                :meth:`stream_progress`, which backs it off from there
+                (default: 0.5). Unused by the start/update/finish flow, where
+                the caller's own poll loop owns the interval.
             max_polls: Maximum number of polls before stopping (default: None)
         """
         self.poll = poll_func
@@ -644,6 +663,14 @@ class AgentProgressTracker:
                 f"API {self._total_api_calls} · "
                 f"${self._total_credits:.6f}{token_suffix}"
             )
+        elif status == "TIMEOUT":
+            print(
+                f"{prefix}⏸ Stopped: progress stream timed out · "
+                f"{total_steps} steps · "
+                f"⏱ {self._format_elapsed(total_elapsed)} · "
+                f"API {self._total_api_calls} · "
+                f"${self._total_credits:.6f}{token_suffix}"
+            )
         else:
             print(
                 f"{prefix}⏸ Stopped: reached max polling limit ({self.max_polls}) · "
@@ -867,6 +894,7 @@ class AgentProgressTracker:
         format: ProgressFormat = ProgressFormat.STATUS,
         verbosity: int = 1,
         truncate: bool = True,
+        timeout: Optional[float] = DEFAULT_STREAM_TIMEOUT,
     ) -> Any:
         """Stream agent progress until completion (standalone polling mode).
 
@@ -874,14 +902,23 @@ class AgentProgressTracker:
         progress streaming. For integration with existing polling (via on_poll hook),
         use the start/update/finish methods instead.
 
+        The poll interval starts at ``self.poll_interval`` and is backed off by
+        10% per poll (capped at 60s) with jitter, so a fleet of clients started
+        together does not stay phase-locked (BUG-942).
+
         Args:
             url: Polling URL to check for updates
             format: Display format (status, logs, none)
             verbosity: Detail level (1=minimal, 2=thoughts, 3=full I/O)
             truncate: Whether to truncate long text
+            timeout: Wall-clock budget in seconds (default: 300). On expiry the
+                last (non-terminal) response is returned and a warning is
+                logged -- this method has never raised, so it still doesn't.
+                Pass ``None`` for the previous unbounded behaviour.
 
         Returns:
-            Final response from the agent
+            Final response from the agent, or the last polled response if
+            *timeout* or ``max_polls`` was reached first.
         """
         terminal_success = "SUCCESS"
         terminal_failures = {"FAILED", "ABORTED", "CANCELLED", "ERROR"}
@@ -891,9 +928,17 @@ class AgentProgressTracker:
         # Override _total_start_time to None - will be set on first steps
         self._total_start_time = None
 
+        deadline = None if timeout is None else self._now() + timeout
+        interval = max(self.poll_interval, self.DISPLAY_REFRESH_RATE)
+
         try:
             while True:
                 resp = self.poll(url)
+                # Unconditional, matching ``update()``: a valid non-terminal
+                # response carrying no ``steps`` array must still count, or
+                # ``max_polls`` is unreachable and the loop never ends (BUG-942).
+                self._poll_count += 1
+
                 status = getattr(resp, "status", None)
                 status_up = (str(status) if status else "").upper()
 
@@ -904,7 +949,6 @@ class AgentProgressTracker:
 
                 # Update metrics and display using shared logic
                 if steps:
-                    self._poll_count += 1
                     self._update_metrics(steps)
 
                     # Update shared display data for background thread (terminal mode)
@@ -933,7 +977,19 @@ class AgentProgressTracker:
                         self._print_completion_message("MAX_POLLS", steps)
                     return resp
 
-                time.sleep(self.poll_interval)
+                remaining = None if deadline is None else deadline - self._now()
+                if remaining is not None and remaining <= 0:
+                    logger.warning(
+                        "stream_progress timed out after %ss with status %s",
+                        timeout,
+                        status_up or "UNKNOWN",
+                    )
+                    if self._format != ProgressFormat.NONE:
+                        self._print_completion_message("TIMEOUT", steps)
+                    return resp
+
+                sleep_with_jitter(interval, max_sleep=remaining)
+                interval = next_wait(interval)
 
         finally:
             self._stop_display.set()

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, Optional, Tuple, Union, List, FrozenSet
 import inspect
 import logging
 import os
+import re
 import requests
 from requests.adapters import HTTPAdapter, Retry
 from urllib.parse import urljoin, urlparse
@@ -117,6 +118,150 @@ DEFAULT_TRUSTED_URLS = (
     "https://platform-api.aixplain.com",
     "https://models.aixplain.com",
 )
+
+
+# Opt-in that re-enables (redacted, truncated) body logging at DEBUG.
+LOG_BODIES_ENV_VAR = "AIXPLAIN_LOG_BODIES"
+LOG_BODY_MAX_BYTES = 2048
+
+# Keys whose *value* is a credential, whatever the surrounding structure.
+_REDACT_KEYS = frozenset(
+    {
+        "x-api-key",
+        "x-aixplain-key",
+        "authorization",
+        "api_key",
+        "apikey",
+        "access_key",
+        "accesskey",
+        "secret",
+        "client_secret",
+        "password",
+        "token",
+        "access_token",
+        "refresh_token",
+        "credential",
+        "credentials",
+    }
+)
+
+# Values that look like a credential even under a key we don't recognise: the
+# leak this closes was a *third-party* Slack token nested inside a tool payload.
+_TOKEN_PATTERNS = (
+    re.compile(r"xox[baprs]-[\w-]+"),  # Slack
+    re.compile(r"\b(?:sk|pk|rk)-[A-Za-z0-9]{16,}"),  # OpenAI-style
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub
+    re.compile(r"\bBearer\s+[A-Za-z0-9._\-]{16,}"),
+    re.compile(r"\beyJ[A-Za-z0-9._\-]{20,}"),  # JWT
+)
+
+_REDACTED = "***REDACTED***"
+
+
+def _log_path(url: str) -> str:
+    """Return *url* reduced to scheme, host and path, dropping the query string.
+
+    Query strings carry presigned signatures and one-time tokens, so only the
+    path is safe to put in a log record.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return "<unparseable url>"
+    if not parsed.netloc:
+        return parsed.path or url
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+def _redact(value: Any) -> Any:
+    """Return *value* with credential-shaped keys and token-shaped strings masked.
+
+    Recurses through dicts and lists so a token nested inside a tool payload is
+    caught as well as a top-level one.
+    """
+    if isinstance(value, dict):
+        return {key: (_REDACTED if str(key).lower() in _REDACT_KEYS else _redact(item)) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact(item) for item in value]
+    if isinstance(value, str):
+        redacted = value
+        for pattern in _TOKEN_PATTERNS:
+            redacted = pattern.sub(_REDACTED, redacted)
+        return redacted
+    return value
+
+
+def _truncate(text: str) -> str:
+    """Cap *text* at :data:`LOG_BODY_MAX_BYTES` characters with a visible marker."""
+    if len(text) <= LOG_BODY_MAX_BYTES:
+        return text
+    return f"{text[:LOG_BODY_MAX_BYTES]}…(truncated)"
+
+
+def _log_request(method: str, url: str, kwargs: Optional[dict] = None) -> None:
+    """Log the outline of an outgoing request: method and path, nothing more.
+
+    Headers are never logged, opt-in or not: ``request_raw`` merges the API key
+    into ``kwargs["headers"]`` before this point, which is exactly how the team
+    key -- and the third-party tokens inside tool payloads -- used to reach DEBUG
+    logs (BUG-939). The body is logged only under ``AIXPLAIN_LOG_BODIES=1``, and
+    then redacted and truncated.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    logger.debug(f"Requesting {method} {_log_path(url)}")
+    if not _log_bodies_enabled() or not kwargs:
+        return
+    body = kwargs.get("json", kwargs.get("data"))
+    if body is None:
+        return
+    logger.debug(f"Request body ({method} {_log_path(url)}): {_truncate(str(_redact(body)))}")
+
+
+def _log_bodies_enabled() -> bool:
+    """True when the operator explicitly opted into body logging."""
+    return os.getenv(LOG_BODIES_ENV_VAR, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _response_size(response: requests.Response, read_body: bool) -> Optional[int]:
+    """Best-effort byte count for *response* without consuming a stream.
+
+    ``read_body`` is False on the streaming path, where touching ``.content``
+    would consume the very stream the caller is about to iterate.
+    """
+    length = response.headers.get("Content-Length")
+    if length is not None:
+        try:
+            return int(length)
+        except (TypeError, ValueError):
+            pass
+    if not read_body:
+        return None
+    try:
+        return len(response.content)
+    except Exception:
+        return None
+
+
+def _log_response(method: str, url: str, response: requests.Response, *, read_body: bool = True) -> None:
+    """Log the outline of a response: method, path, status and byte count.
+
+    The body itself is logged only under ``AIXPLAIN_LOG_BODIES=1`` (redacted and
+    truncated) and never on the streaming path.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    size = _response_size(response, read_body)
+    size_text = f"{size} bytes" if size is not None else "unknown size"
+    logger.debug(f"Response {method} {_log_path(url)} -> {response.status_code} ({size_text})")
+    if not (read_body and _log_bodies_enabled()):
+        return
+    try:
+        body = response.text
+    except Exception:
+        return
+    logger.debug(f"Response body ({method} {_log_path(url)}): {_truncate(_redact(body))}")
+
 
 # Every header that carries an aiXplain credential.  These are custom headers,
 # so ``requests`` does not strip them across a redirect the way it does
@@ -441,10 +586,11 @@ class AixplainClient:
         url = self.ensure_trusted_url(path)
         kwargs["headers"] = {**self._auth_headers(), **(kwargs.pop("headers", None) or {})}
         kwargs.setdefault("timeout", self.timeout)
-        # ``headers`` now carries the API key, so it stays out of the log line.
-        logger.debug(f"Requesting {method} {url} with kwargs: {kwargs}")
+        # ``headers`` now carries the API key, and ``kwargs`` carries the request
+        # body, so neither is ever formatted into a log record (BUG-939).
+        _log_request(method, url, kwargs)
         response = self.session.request(method=method, url=url, **kwargs)
-        logger.debug(f"Response: {response.text}")
+        _log_response(method, url, response)
         if not response.ok:
             error_obj = None
             try:
@@ -534,8 +680,6 @@ class AixplainClient:
         """
         url = self.ensure_trusted_url(path)
 
-        logger.debug(f"Requesting streaming {method} {url}")
-
         kwargs["headers"] = {**self._auth_headers(), **(kwargs.pop("headers", None) or {})}
         # Enable streaming mode
         kwargs["stream"] = True
@@ -544,7 +688,11 @@ class AixplainClient:
         # as the server keeps sending (events or keep-alives).
         kwargs.setdefault("timeout", self.timeout)
 
+        _log_request(method, url, kwargs)
         response = self.session.request(method=method, url=url, **kwargs)
+        # ``read_body=False``: the caller iterates this stream, so the log line
+        # must not consume it.
+        _log_response(method, url, response, read_body=False)
 
         # For streaming, we check status but don't consume the response body
         if not response.ok:

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -1,6 +1,7 @@
 """Client module for making HTTP requests to the aiXplain API."""
 
 from typing import Any, Iterable, Optional, Tuple, Union, List, FrozenSet
+import inspect
 import logging
 import os
 import requests
@@ -14,7 +15,35 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RETRY_TOTAL = 5
 DEFAULT_RETRY_BACKOFF_FACTOR = 0.1
-DEFAULT_RETRY_STATUS_FORCELIST = [500, 502, 503, 504]
+
+# 429 belongs in the forcelist now that ``allowed_methods`` is GET-only: retrying
+# a throttled *poll* is safe, and is what lets the client honour the server's own
+# backoff signal instead of hammering through it. A throttled POST is still never
+# re-sent (see RETRY_ALLOWED_METHODS below), so this cannot duplicate a billable
+# submission.
+DEFAULT_RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]
+
+# urllib3's ``backoff_jitter`` is *additive*: the sleep becomes
+# ``backoff_factor * 2**(n-1) + uniform(0, backoff_jitter)``. With
+# backoff_factor=0.1 the nominal sleeps are 0.1/0.2/0.4/0.8/1.6s, so 0.3s of
+# spread decorrelates a fleet across that whole window without materially
+# slowing any one client. Without it, a platform 5xx makes every installed copy
+# of the SDK retry inside the same ~3s window, and the recovery wave
+# re-degrades the platform it is recovering (BUG-942).
+DEFAULT_RETRY_BACKOFF_JITTER = 0.3
+
+# Bound both sleep sources. urllib3's own defaults are 120s of backoff and
+# **6 hours** of Retry-After; honouring an unbounded header would hand a
+# misconfigured (or hostile) edge the ability to pin a caller's thread.
+DEFAULT_RETRY_BACKOFF_MAX = 60.0
+DEFAULT_RETRY_AFTER_MAX = 60.0
+
+# urllib3 defaults to 10/10 with block=False, so above 10 in-flight requests the
+# adapter opens connections and then *discards* them instead of pooling them --
+# a fresh TLS handshake per request plus a "Connection pool is full" warning
+# each time. That peaks exactly when the poll burst does.
+DEFAULT_POOL_CONNECTIONS = 32
+DEFAULT_POOL_MAXSIZE = 64
 
 # Methods urllib3 may retry once a request has actually been put on the wire.
 # Dropping POST is what closes BUG-1090: with POST listed, a single ``/execute``
@@ -200,6 +229,34 @@ class _AixplainSession(requests.Session):
                 prepared_request.headers.pop(name, None)
 
 
+_RETRY_INIT_PARAMS = frozenset(inspect.signature(Retry.__init__).parameters)
+
+
+def _build_retry(**kwargs: Any) -> Retry:
+    """Construct a ``Retry``, dropping kwargs the installed urllib3 doesn't accept.
+
+    ``backoff_jitter`` landed in urllib3 2.0 and ``retry_after_max`` in 2.1,
+    while the only declared bound is ``requests``' own loose ``urllib3<3`` --
+    so an environment resolving to 1.26 must lose the jitter, not raise
+    ``TypeError``.
+
+    Args:
+        **kwargs: Candidate ``Retry`` keyword arguments.
+
+    Returns:
+        urllib3.util.Retry: Configured with every supported kwarg.
+    """
+    unsupported = sorted(key for key in kwargs if key not in _RETRY_INIT_PARAMS)
+    for key in unsupported:
+        kwargs.pop(key)
+    if unsupported:
+        logger.debug(
+            "Installed urllib3 Retry does not support %s; continuing without it",
+            ", ".join(unsupported),
+        )
+    return Retry(**kwargs)
+
+
 def create_retry_session(
     total: Optional[int] = None,
     backoff_factor: Optional[float] = None,
@@ -217,7 +274,9 @@ def create_retry_session(
     Args:
         total (int, optional): Total number of retries allowed. Defaults to 5.
         backoff_factor (float, optional): Backoff factor to apply between retry attempts. Defaults to 0.1.
-        status_forcelist (list, optional): List of HTTP status codes to force a retry on. Defaults to [500, 502, 503, 504].
+        status_forcelist (list, optional): List of HTTP status codes to force a retry on.
+            Defaults to [429, 500, 502, 503, 504]. Retries are jittered and honour ``Retry-After``
+            (bounded by DEFAULT_RETRY_AFTER_MAX).
         trusted_origins (frozenset, optional): ``(scheme, host, port)`` triples allowed
             to receive aiXplain credentials across a redirect. Defaults to none, i.e.
             any redirect drops them.
@@ -229,15 +288,26 @@ def create_retry_session(
     total = total or DEFAULT_RETRY_TOTAL
     backoff_factor = backoff_factor or DEFAULT_RETRY_BACKOFF_FACTOR
     status_forcelist = status_forcelist or DEFAULT_RETRY_STATUS_FORCELIST
-    retry_strategy = Retry(
-        total=total,
-        backoff_factor=backoff_factor,
-        status_forcelist=status_forcelist,
-        allowed_methods=RETRY_ALLOWED_METHODS,
-        **kwargs,
-    )
+    retry_kwargs: dict = {
+        "total": total,
+        "backoff_factor": backoff_factor,
+        "status_forcelist": status_forcelist,
+        "allowed_methods": RETRY_ALLOWED_METHODS,
+        "backoff_jitter": DEFAULT_RETRY_BACKOFF_JITTER,
+        "backoff_max": DEFAULT_RETRY_BACKOFF_MAX,
+        "respect_retry_after_header": True,
+        "retry_after_max": DEFAULT_RETRY_AFTER_MAX,
+    }
+    # Caller kwargs win over the defaults above rather than colliding with them.
+    retry_kwargs.update(kwargs)
+    retry_strategy = _build_retry(**retry_kwargs)
     session = _AixplainSession(trusted_origins=trusted_origins)
-    adapter = HTTPAdapter(max_retries=retry_strategy)
+    adapter = HTTPAdapter(
+        max_retries=retry_strategy,
+        pool_connections=DEFAULT_POOL_CONNECTIONS,
+        pool_maxsize=DEFAULT_POOL_MAXSIZE,
+        pool_block=False,
+    )
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     return session
@@ -265,7 +335,8 @@ class AixplainClient:
             team_api_key (str, optional): The team API key.
             retry_total (int): Total number of retries allowed. Defaults to 5.
             retry_backoff_factor (float): Backoff factor between retry attempts. Defaults to 0.1.
-            retry_status_forcelist (list): HTTP status codes that trigger a retry. Defaults to [500, 502, 503, 504].
+            retry_status_forcelist (list): HTTP status codes that trigger a retry.
+                Defaults to [429, 500, 502, 503, 504].
             timeout (float or (float, float) tuple, optional): Default timeout for every
                 request that doesn't pass its own ``timeout=``. Defaults to
                 (AIXPLAIN_HTTP_CONNECT_TIMEOUT or 10, AIXPLAIN_HTTP_READ_TIMEOUT or 300)

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -555,6 +555,10 @@ class AixplainClient:
         """
         self.base_url = base_url
         self.timeout: TimeoutType = timeout if timeout is not None else default_timeout()
+        # How many times urllib3 may re-send one retryable request underneath
+        # ``requests``. Callers that need a wall-clock bound have to divide by
+        # ``retry_total + 1`` -- see ``BaseResource.poll`` (BUG-1097).
+        self.retry_total = retry_total
         self.team_api_key = team_api_key
         self.aixplain_api_key = aixplain_api_key
 

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -231,22 +231,40 @@ class _AixplainSession(requests.Session):
 
 _RETRY_INIT_PARAMS = frozenset(inspect.signature(Retry.__init__).parameters)
 
+# The hardening kwargs this module adds that a pre-2.x urllib3 may not accept:
+# ``backoff_jitter``/``backoff_max`` landed in 2.0 and ``retry_after_max`` in
+# 2.1, while the only declared bound is ``requests``' own loose ``urllib3<3``.
+# Deliberately a closed list -- anything *outside* it still reaches ``Retry``
+# and raises, so a caller's typo is not silently discarded as "unsupported".
+_OPTIONAL_RETRY_KWARGS = frozenset(
+    {
+        "backoff_jitter",
+        "backoff_max",
+        "respect_retry_after_header",
+        "retry_after_max",
+    }
+)
+
 
 def _build_retry(**kwargs: Any) -> Retry:
-    """Construct a ``Retry``, dropping kwargs the installed urllib3 doesn't accept.
+    """Construct a ``Retry``, dropping optional kwargs this urllib3 doesn't accept.
 
-    ``backoff_jitter`` landed in urllib3 2.0 and ``retry_after_max`` in 2.1,
-    while the only declared bound is ``requests``' own loose ``urllib3<3`` --
-    so an environment resolving to 1.26 must lose the jitter, not raise
-    ``TypeError``.
+    Only the names in :data:`_OPTIONAL_RETRY_KWARGS` are droppable: an
+    environment resolving to urllib3 1.26 must lose the jitter rather than raise
+    ``TypeError``. Every other keyword is passed through untouched, so an
+    unrecognised one still fails loudly instead of being quietly ignored.
 
     Args:
         **kwargs: Candidate ``Retry`` keyword arguments.
 
     Returns:
         urllib3.util.Retry: Configured with every supported kwarg.
+
+    Raises:
+        TypeError: If a keyword outside the optional set is not a ``Retry``
+            parameter.
     """
-    unsupported = sorted(key for key in kwargs if key not in _RETRY_INIT_PARAMS)
+    unsupported = sorted(key for key in kwargs if key in _OPTIONAL_RETRY_KWARGS and key not in _RETRY_INIT_PARAMS)
     for key in unsupported:
         kwargs.pop(key)
     if unsupported:

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Iterable, Optional, Tuple, Union, List, FrozenSet
 import inspect
+import json
 import logging
 import os
 import re
@@ -191,6 +192,49 @@ def _redact(value: Any) -> Any:
     return value
 
 
+def _render_redacted_body(value: Any) -> str:
+    """Render *value* as text with credential-shaped keys and values masked.
+
+    A body arrives here either as a structure (``json=``) or already serialised
+    (``data=`` and ``response.text``). The serialised form has to be parsed back
+    before it can be redacted *by key*: ``{"accessKey": "..."}`` -- which is what
+    ``APIKey.list()`` returns for every key on the account -- and an ``x-api-key``
+    nested in a serialised payload match none of the token patterns, so treating
+    the body as an opaque string would log them verbatim (BUG-939). Anything that
+    is not JSON falls back to pattern redaction alone.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError:
+            return f"<{len(value)} bytes of non-text body>"
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            return _redact(value)
+        if isinstance(parsed, (dict, list)):
+            return json.dumps(_redact(parsed), default=str)
+        return _redact(value)
+    return str(_redact(value))
+
+
+def _redact_body(value: Any) -> str:
+    """Total wrapper around :func:`_render_redacted_body`.
+
+    Rendering a body walks an arbitrary structure that a *response* can shape,
+    so it can fail in ways the request itself would not -- deeply nested JSON
+    raises ``RecursionError`` out of ``json.loads``, and a ``__str__`` on a
+    caller's object can raise anything. A diagnostic must never turn a working
+    call into a traceback, and it must never fall back to emitting the raw body,
+    so every failure collapses to a placeholder.
+    """
+    try:
+        return _render_redacted_body(value)
+    except Exception:  # noqa: BLE001 -- a log line must not break the request
+        return "<body omitted: could not be redacted>"
+
+
 def _truncate(text: str) -> str:
     """Cap *text* at :data:`LOG_BODY_MAX_BYTES` characters with a visible marker."""
     if len(text) <= LOG_BODY_MAX_BYTES:
@@ -215,7 +259,7 @@ def _log_request(method: str, url: str, kwargs: Optional[dict] = None) -> None:
     body = kwargs.get("json", kwargs.get("data"))
     if body is None:
         return
-    logger.debug(f"Request body ({method} {_log_path(url)}): {_truncate(str(_redact(body)))}")
+    logger.debug(f"Request body ({method} {_log_path(url)}): {_truncate(_redact_body(body))}")
 
 
 def _log_bodies_enabled() -> bool:
@@ -260,7 +304,7 @@ def _log_response(method: str, url: str, response: requests.Response, *, read_bo
         body = response.text
     except Exception:
         return
-    logger.debug(f"Response body ({method} {_log_path(url)}): {_truncate(_redact(body))}")
+    logger.debug(f"Response body ({method} {_log_path(url)}): {_truncate(_redact_body(body))}")
 
 
 # Every header that carries an aiXplain credential.  These are custom headers,

--- a/aixplain/v2/code_utils.py
+++ b/aixplain/v2/code_utils.py
@@ -13,14 +13,18 @@ from dataclasses import dataclass
 from typing import Callable, List, Text, Tuple, Union, Optional
 from uuid import uuid4
 
-import requests
 import validators
 
-from .client import default_timeout
+from aixplain.utils.url_safety import safe_get
 from .enums import DataType
 from .upload_utils import FileUploader
 
 logger = logging.getLogger(__name__)
+
+# A remote code URL is fetched into memory and then uploaded as the utility
+# model's source, so a hostile endpoint must not be able to balloon the memory
+# of the process (often an agent container) that fetched it.
+MAX_REMOTE_CODE_BYTES = 5 * 1024 * 1024
 
 
 @dataclass
@@ -164,7 +168,7 @@ def parse_code(
         with open(code, "r") as f:
             str_code = f.read()
     elif validators.url(code):
-        str_code = requests.get(code, timeout=default_timeout()).text
+        str_code = safe_get(code, max_bytes=MAX_REMOTE_CODE_BYTES).text
     else:
         str_code = code
 
@@ -274,7 +278,7 @@ def parse_code_decorated(
             with open(code, "r") as f:
                 str_code = f.read()
         elif validators.url(code):
-            str_code = requests.get(code, timeout=default_timeout()).text
+            str_code = safe_get(code, max_bytes=MAX_REMOTE_CODE_BYTES).text
         else:
             str_code = code
 

--- a/aixplain/v2/core.py
+++ b/aixplain/v2/core.py
@@ -4,6 +4,8 @@ import os
 import sys
 from typing import Optional, TypeVar
 
+from aixplain.utils.url_safety import validate_config_url
+
 from .client import AixplainClient
 from .model import Model
 from .agent import Agent
@@ -130,6 +132,14 @@ class Aixplain:
         self.backend_url = backend_url or os.getenv("BACKEND_URL") or self.BACKEND_URL
         self.pipeline_url = pipeline_url or os.getenv("PIPELINES_RUN_URL") or self.PIPELINES_RUN_URL
         self.model_url = model_url or os.getenv("MODELS_RUN_URL") or self.MODELS_RUN_URL
+
+        # All three become trusted origins for the API key below, and all three
+        # default to an environment variable, so each has to satisfy the config
+        # URL policy first (BUG-939). ``PIPELINES_RUN_URL`` in particular is read
+        # nowhere else, so this is its only check.
+        validate_config_url(self.backend_url, "BACKEND_URL")
+        validate_config_url(self.pipeline_url, "PIPELINES_RUN_URL")
+        validate_config_url(self.model_url, "MODELS_RUN_URL")
 
         self.init_client()
         self.init_resources()

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -30,7 +30,7 @@ from urllib.parse import quote, unquote, urlparse
 import requests
 from dataclasses_json import config, dataclass_json
 
-from aixplain.utils.url_safety import validate_fetch_url, validate_upload_url
+from aixplain.utils.url_safety import safe_get, validate_upload_url
 
 from .enums import FileType, Privacy
 from .exceptions import APIError, FileUploadError, ResourceError, ValidationError
@@ -215,11 +215,15 @@ class File(BaseResource):
         # the file bytes leave the machine (BUG-939).
         validate_upload_url(upload_url)
         with open(local_path, "rb") as handle:
+            # A presigned S3 PUT never legitimately redirects, and following one
+            # would re-send the file bytes to a host that never passed
+            # ``validate_upload_url`` (BUG-939).
             upload_response = requests.put(
                 upload_url,
                 data=handle,
                 headers={"Content-Type": content_type},
                 timeout=self.context.client.timeout,
+                allow_redirects=False,
             )
         if not upload_response.ok:
             raise FileUploadError(f"Upload failed with HTTP {upload_response.status_code}")
@@ -306,8 +310,10 @@ class File(BaseResource):
                 # ``source`` is caller-supplied and its body is uploaded to the
                 # platform, so it is the same SSRF sink as the remote-code fetch
                 # in ``code_utils`` and is gated the same way (BUG-939).
-                validate_fetch_url(self.source)
-                with requests.get(self.source, stream=True, timeout=self.context.client.timeout) as response:
+                # ``safe_get`` re-validates every redirect target: a public host
+                # that 302s to ``http://169.254.169.254/`` would otherwise defeat
+                # a one-shot check on ``self.source``.
+                with safe_get(self.source, stream=True, timeout=self.context.client.timeout) as response:
                     response.raise_for_status()
                     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
                         temporary_path = handle.name

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -30,7 +30,7 @@ from urllib.parse import quote, unquote, urlparse
 import requests
 from dataclasses_json import config, dataclass_json
 
-from aixplain.utils.url_safety import validate_upload_url
+from aixplain.utils.url_safety import validate_fetch_url, validate_upload_url
 
 from .enums import FileType, Privacy
 from .exceptions import APIError, FileUploadError, ResourceError, ValidationError
@@ -303,6 +303,10 @@ class File(BaseResource):
         try:
             if parsed.scheme in {"http", "https"}:
                 suffix = Path(parsed.path).suffix
+                # ``source`` is caller-supplied and its body is uploaded to the
+                # platform, so it is the same SSRF sink as the remote-code fetch
+                # in ``code_utils`` and is gated the same way (BUG-939).
+                validate_fetch_url(self.source)
                 with requests.get(self.source, stream=True, timeout=self.context.client.timeout) as response:
                     response.raise_for_status()
                     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -30,6 +30,8 @@ from urllib.parse import quote, unquote, urlparse
 import requests
 from dataclasses_json import config, dataclass_json
 
+from aixplain.utils.url_safety import validate_upload_url
+
 from .enums import FileType, Privacy
 from .exceptions import APIError, FileUploadError, ResourceError, ValidationError
 from .resource import BaseResource, Page, _is_excluded_from_serialization
@@ -209,6 +211,9 @@ class File(BaseResource):
         reference = response.get("downloadUrl") or response.get("url") or response.get("key")
         if not upload_url or not reference:
             raise FileUploadError("Temporary upload response did not include uploadUrl and a file reference")
+        # ``uploadUrl`` is chosen by the response, so the host is checked before
+        # the file bytes leave the machine (BUG-939).
+        validate_upload_url(upload_url)
         with open(local_path, "rb") as handle:
             upload_response = requests.put(
                 upload_url,

--- a/aixplain/v2/integration.py
+++ b/aixplain/v2/integration.py
@@ -1,11 +1,13 @@
 """Integration module for managing external service integrations."""
 
+import time
 import warnings
 from typing import Optional, List, Any, Dict, TYPE_CHECKING
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json, config
 from functools import cached_property
 
+from ._backoff import next_wait, sleep_with_jitter
 from .resource import BaseSearchParams, Result
 from .model import Model
 from .enums import AuthenticationScheme
@@ -200,20 +202,24 @@ class ActionMixin:
 
     def _poll_for_data(self, response: dict, timeout: float = 30, wait_time: float = 1) -> Any:
         """Poll an async response until completion and return the ``data`` field."""
-        import time
-
         data = response.get("data")
         if response.get("completed", True) or not isinstance(data, str) or not data.startswith("http"):
             return data
 
         poll_url = data
         start = time.time()
-        while (time.time() - start) < timeout:
-            time.sleep(wait_time)
+        while True:
+            remaining = timeout - (time.time() - start)
+            if remaining <= 0:
+                return None
+            # Jittered and backed off, rather than a fixed 1s tick: a fleet of
+            # clients polling in lockstep is the load shape BUG-942 is about.
+            # Clamped to the remaining budget so jitter never overruns *timeout*.
+            sleep_with_jitter(wait_time, max_sleep=remaining)
+            wait_time = next_wait(wait_time)
             poll_resp = self.context.client.request("get", poll_url)
             if poll_resp.get("completed", False) or poll_resp.get("status") == "SUCCESS":
                 return poll_resp.get("data")
-        return None
 
     def list_actions(self) -> List[ActionSpec]:
         """List available actions for the integration.

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -52,6 +52,28 @@ logger = logging.getLogger(__name__)
 _POLL_TIMEOUT_SUPPORT: dict = {}
 
 
+def _client_timeout_bounds(client: Any) -> Tuple[float, float]:
+    """The ``(connect, read)`` timeout the *client* is actually configured with.
+
+    ``AixplainClient.timeout`` is either a single float or a ``(connect, read)``
+    pair, and a deployment may have narrowed it below the module defaults --
+    reading the module default instead would silently widen the bound a caller
+    asked for. Anything unrecognisable (a mock, ``None``) falls back to the
+    defaults so a poll is still bounded.
+    """
+    configured = getattr(client, "timeout", None)
+    if isinstance(configured, (tuple, list)) and len(configured) == 2:
+        connect, read = configured
+    elif isinstance(configured, (int, float)) and not isinstance(configured, bool):
+        connect = read = configured
+    else:
+        return default_timeout()
+    try:
+        return float(connect), float(read)
+    except (TypeError, ValueError):
+        return default_timeout()
+
+
 # Hook decorator system
 def with_hooks(func: Callable) -> Callable:
     """Generic decorator to add before/after hooks to resource operations.
@@ -1599,10 +1621,10 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         self.context.client.ensure_trusted_url(poll_url)
         request_kwargs: dict = {}
         if timeout is not None:
-            connect_timeout, read_timeout = default_timeout()
+            connect_timeout, read_timeout = _client_timeout_bounds(self.context.client)
             # Floor at 1s so a nearly-exhausted budget still sends a real request
-            # instead of one guaranteed to time out, and never exceed the client
-            # default the deployment configured.
+            # instead of one guaranteed to time out, and never exceed the read
+            # timeout the deployment configured.
             request_kwargs["timeout"] = (connect_timeout, max(1.0, min(timeout, read_timeout)))
         try:
             # Use context.client for all polling operations
@@ -1747,11 +1769,22 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                         logger.info(f"Operation completed successfully ({elapsed_time:.1f}s total)")
                     return result
 
-            except (APIError, ResourceError, UntrustedURLError) as e:
-                # Re-raise API, resource and untrusted-URL errors immediately.
-                # Without UntrustedURLError here the broad ``except`` below would
+            except UntrustedURLError:
+                # Never softened: without this the broad ``except`` below would
                 # turn a refused credential leak into a silent poll-until-timeout.
-                raise e
+                raise
+            except (APIError, ResourceError) as e:
+                # Re-raise API and resource errors immediately -- unless the
+                # budget is already gone. Each poll is now bounded by the
+                # remaining budget (BUG-1097), so the *last* poll before the
+                # deadline can fail precisely because the deadline arrived;
+                # reporting that as an APIError rather than the documented
+                # TimeoutError would be an artefact of the bound. Logged so the
+                # underlying failure is still visible.
+                if timeout - (time.time() - start_time) > 0:
+                    raise
+                logger.warning(f"Final poll failed as the {timeout}s budget expired: {e}")
+                break
             except Exception as e:
                 # Log other errors but continue polling
                 logger.warning(f"Polling error: {e}, continuing...")

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -1,6 +1,7 @@
 """Resource management module for v2 API."""
 
 import requests
+import inspect
 import logging
 import time
 import reprlib
@@ -27,6 +28,8 @@ from functools import wraps
 from copy import deepcopy
 
 
+from ._backoff import next_wait, sleep_with_jitter
+from .client import default_timeout
 from .enums import OwnershipType, SortBy, SortOrder
 from .exceptions import (
     ResourceError,
@@ -43,6 +46,10 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# Whether a given ``poll`` callable accepts the per-request ``timeout`` bound.
+# Keyed by the underlying function so every instance of a class shares one answer.
+_POLL_TIMEOUT_SUPPORT: dict = {}
 
 
 # Hook decorator system
@@ -1315,7 +1322,9 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
             except APIError as e:
                 if not self._is_retryable_run_error(e) or attempt >= run_retries:
                     raise
-                time.sleep(run_retry_wait)
+                # Jittered: a platform blip otherwise makes every client
+                # re-submit in the same instant (BUG-942).
+                sleep_with_jitter(run_retry_wait)
 
         raise RuntimeError("run submission retry loop exhausted without return")
 
@@ -1565,11 +1574,16 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
 
         return self._submit_with_retries(**kwargs)
 
-    def poll(self, poll_url: str) -> ResultT:
+    def poll(self, poll_url: str, timeout: Optional[float] = None) -> ResultT:
         """Poll for the result of an asynchronous operation.
 
         Args:
             poll_url: URL to poll for results
+            timeout: Optional upper bound, in seconds, on this single request's
+                read phase -- normally the budget ``sync_poll`` has left. When
+                omitted the client's own default read timeout applies, which is
+                long enough for one hung poll to consume an entire poll budget
+                (BUG-1097).
 
         Returns:
             Response instance from the configured RESPONSE_CLASS
@@ -1583,11 +1597,18 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         # credential is attached. ``client.get`` re-checks; doing it here keeps the
         # error precise instead of being rewrapped as "Polling failed: ..." below.
         self.context.client.ensure_trusted_url(poll_url)
+        request_kwargs: dict = {}
+        if timeout is not None:
+            connect_timeout, read_timeout = default_timeout()
+            # Floor at 1s so a nearly-exhausted budget still sends a real request
+            # instead of one guaranteed to time out, and never exceed the client
+            # default the deployment configured.
+            request_kwargs["timeout"] = (connect_timeout, max(1.0, min(timeout, read_timeout)))
         try:
             # Use context.client for all polling operations
             # If poll_url is a full URL, urljoin will use it directly
             # If it's a relative path, it will be joined with base_url
-            response = self.context.client.get(poll_url)
+            response = self.context.client.get(poll_url, **request_kwargs)
         except Exception as e:
             # Re-raise as APIError instead of silently returning failed result
             from .exceptions import APIError
@@ -1645,6 +1666,27 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         result._raw_data = response
         return result
 
+    def _poll_accepts_timeout(self) -> bool:
+        """Whether ``self.poll`` accepts the per-request ``timeout`` bound.
+
+        ``poll`` gained ``timeout`` additively, so a third-party subclass may
+        still override it with the old ``poll(self, poll_url)`` signature.
+        Passing the budget to such an override would raise ``TypeError``; it
+        should simply lose the bound instead. Resolved per callable and cached,
+        so ``sync_poll`` pays the introspection cost once, not once per poll.
+        """
+        func = getattr(type(self).poll, "__func__", type(self).poll)
+        cached = _POLL_TIMEOUT_SUPPORT.get(func)
+        if cached is None:
+            try:
+                params = inspect.signature(func).parameters
+            except (TypeError, ValueError):  # C-implemented or unintrospectable
+                cached = True
+            else:
+                cached = "timeout" in params or any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+            _POLL_TIMEOUT_SUPPORT[func] = cached
+        return cached
+
     def on_poll(self, response: ResultT, **kwargs: Unpack[RunParamsT]) -> None:
         """Hook called after each successful poll with the poll response.
 
@@ -1679,10 +1721,22 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
 
         start_time = time.time()
         wait_time = max(wait_time, 0.2)  # Minimum wait time
+        poll_accepts_timeout = self._poll_accepts_timeout()
 
-        while (time.time() - start_time) < timeout:
+        while True:
+            remaining = timeout - (time.time() - start_time)
+            if remaining <= 0:
+                break
             try:
-                result = self.poll(poll_url)
+                # Bound the request by what is left of the caller's budget.
+                # Without this the client's own read timeout applies, so a single
+                # hung poll eats the whole ``timeout`` -- and, because GET is
+                # still retryable at the transport layer, up to
+                # ``DEFAULT_RETRY_TOTAL`` times that (BUG-1097).
+                if poll_accepts_timeout:
+                    result = self.poll(poll_url, timeout=remaining)
+                else:
+                    result = self.poll(poll_url)
 
                 # Call the hook with the poll response
                 self.on_poll(result, **kwargs)
@@ -1702,9 +1756,14 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                 # Log other errors but continue polling
                 logger.warning(f"Polling error: {e}, continuing...")
 
-            time.sleep(wait_time)
-            if wait_time < 60:
-                wait_time *= 1.1  # Exponential backoff
+            remaining = timeout - (time.time() - start_time)
+            if remaining <= 0:
+                break
+            # Jittered so a batch of clients started together doesn't stay
+            # phase-locked for the whole run (BUG-942); clamped to the remaining
+            # budget so jitter can shorten a sleep but never overrun ``timeout``.
+            sleep_with_jitter(wait_time, max_sleep=remaining)
+            wait_time = next_wait(wait_time)
 
         if show_progress:
             logger.error(f"Operation timeout - No response after {timeout}s")

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -29,7 +29,7 @@ from copy import deepcopy
 
 
 from ._backoff import next_wait, sleep_with_jitter
-from .client import default_timeout
+from .client import DEFAULT_RETRY_TOTAL, default_timeout
 from .enums import OwnershipType, SortBy, SortOrder
 from .exceptions import (
     ResourceError,
@@ -72,6 +72,26 @@ def _client_timeout_bounds(client: Any) -> Tuple[float, float]:
         return float(connect), float(read)
     except (TypeError, ValueError):
         return default_timeout()
+
+
+def _client_retry_attempts(client: Any) -> int:
+    """How many times the transport may send one poll before giving up.
+
+    ``GET`` is in ``RETRY_ALLOWED_METHODS``, so urllib3 re-sends a poll that
+    raises ``ReadTimeoutError`` up to ``retry_total`` further times *underneath*
+    ``requests``. Bounding one request's read phase by the remaining budget is
+    therefore not enough on its own: ``sync_poll(timeout=300)`` against a hung
+    endpoint would still block ``300 * (retry_total + 1)`` seconds before the
+    deadline is re-checked (BUG-1097). Dividing by the value returned here is
+    what makes the wall-clock budget hold.
+
+    Anything unrecognisable (a mock, an old client) falls back to the module
+    default, which is the conservative direction: a shorter per-request bound.
+    """
+    total = getattr(client, "retry_total", None)
+    if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+        return DEFAULT_RETRY_TOTAL + 1
+    return total + 1
 
 
 # Hook decorator system
@@ -1601,11 +1621,13 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
 
         Args:
             poll_url: URL to poll for results
-            timeout: Optional upper bound, in seconds, on this single request's
-                read phase -- normally the budget ``sync_poll`` has left. When
-                omitted the client's own default read timeout applies, which is
-                long enough for one hung poll to consume an entire poll budget
-                (BUG-1097).
+            timeout: Optional upper bound, in seconds, on the *wall clock* this
+                single poll may consume -- normally the budget ``sync_poll`` has
+                left. It is divided by the number of transport-level attempts
+                before being applied as a read timeout, because urllib3 retries a
+                timed-out GET underneath ``requests``. When omitted the client's
+                own default read timeout applies, which is long enough for one
+                hung poll to consume an entire poll budget (BUG-1097).
 
         Returns:
             Response instance from the configured RESPONSE_CLASS
@@ -1622,10 +1644,14 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         request_kwargs: dict = {}
         if timeout is not None:
             connect_timeout, read_timeout = _client_timeout_bounds(self.context.client)
-            # Floor at 1s so a nearly-exhausted budget still sends a real request
-            # instead of one guaranteed to time out, and never exceed the read
-            # timeout the deployment configured.
-            request_kwargs["timeout"] = (connect_timeout, max(1.0, min(timeout, read_timeout)))
+            # Divided by the number of transport attempts, because urllib3 may
+            # re-send a timed-out GET underneath ``requests``: without this the
+            # caller's budget is silently multiplied by ``retry_total + 1``
+            # (BUG-1097). Floor at 1s so a nearly-exhausted budget still sends a
+            # real request instead of one guaranteed to time out, and never
+            # exceed the read timeout the deployment configured.
+            attempts = _client_retry_attempts(self.context.client)
+            request_kwargs["timeout"] = (connect_timeout, max(1.0, min(timeout / attempts, read_timeout)))
         try:
             # Use context.client for all polling operations
             # If poll_url is a full URL, urljoin will use it directly
@@ -1735,7 +1761,10 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
             Response instance from the configured RESPONSE_CLASS
 
         Raises:
-            TimeoutError: If the operation exceeds the timeout duration
+            TimeoutError: If the operation exceeds the timeout duration. When the
+                budget expired on a poll that also failed (a 401 on the last
+                attempt, say), that failure is chained as ``__cause__`` rather
+                than being flattened into "Operation timed out".
         """
         timeout = kwargs.get("timeout", 300)
         wait_time = kwargs.get("wait_time", 0.5)
@@ -1744,6 +1773,7 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         start_time = time.time()
         wait_time = max(wait_time, 0.2)  # Minimum wait time
         poll_accepts_timeout = self._poll_accepts_timeout()
+        last_error: Optional[Exception] = None
 
         while True:
             remaining = timeout - (time.time() - start_time)
@@ -1754,7 +1784,8 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                 # Without this the client's own read timeout applies, so a single
                 # hung poll eats the whole ``timeout`` -- and, because GET is
                 # still retryable at the transport layer, up to
-                # ``DEFAULT_RETRY_TOTAL`` times that (BUG-1097).
+                # ``retry_total + 1`` times that. ``poll`` divides by that factor
+                # so the wall-clock budget actually holds (BUG-1097).
                 if poll_accepts_timeout:
                     result = self.poll(poll_url, timeout=remaining)
                 else:
@@ -1784,6 +1815,10 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                 if timeout - (time.time() - start_time) > 0:
                     raise
                 logger.warning(f"Final poll failed as the {timeout}s budget expired: {e}")
+                # Kept so the TimeoutError raised below chains it: a real 401 or
+                # 403 on the last poll must stay visible, not be flattened into
+                # "Operation timed out".
+                last_error = e
                 break
             except Exception as e:
                 # Log other errors but continue polling
@@ -1800,4 +1835,4 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
 
         if show_progress:
             logger.error(f"Operation timeout - No response after {timeout}s")
-        raise TimeoutError(f"Operation timed out after {timeout} seconds")
+        raise TimeoutError(f"Operation timed out after {timeout} seconds") from last_error

--- a/aixplain/v2/rlm.py
+++ b/aixplain/v2/rlm.py
@@ -1460,9 +1460,10 @@ del _url, _r
         """
         if not (isinstance(context, str) and (context.startswith("http://") or context.startswith("https://"))):
             return context
-        import requests
+        from aixplain.utils.url_safety import safe_get
 
-        r = requests.get(context, timeout=60)
+        # ``context`` is caller-supplied, so the fetch is SSRF-gated (BUG-939).
+        r = safe_get(context, timeout=60)
         r.raise_for_status()
         ct = r.headers.get("Content-Type", "")
         url_path = context.split("?")[0].lower()

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -485,8 +485,13 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             data = kwargs.get("data", {})
             action_errors = action_obj.inputs.validate(data)
             errors.extend(action_errors)
-        except Exception:
-            pass
+        except Exception as e:
+            # A crashed validation is not a pass (BUG-946). An unknown action name
+            # reaches here as a ValueError from the lazy input loader -- Actions
+            # fabricates an ActionView rather than raising on __getitem__ -- and the
+            # empty list this used to return was indistinguishable from
+            # "validated clean", so the run proceeded to the backend unchecked.
+            errors.append(f"Could not validate inputs for '{action}': {e}")
 
         return errors
 

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -1,6 +1,7 @@
 """Tool resource module for managing tools and their integrations."""
 
 import ast
+import logging
 import re
 import warnings
 from typing import Union, List, Optional, Any
@@ -9,15 +10,41 @@ from dataclasses_json import dataclass_json, config as dj_config
 from dataclasses import dataclass, field
 from functools import cached_property
 
+import requests
+
 from .resource import (
     Result,
     DeleteResourceMixin,
     BaseDeleteParams,
     DeleteResult,
 )
+from .exceptions import APIError
 from .model import Model, ModelRunParams
 from .integration import Integration, ActionSpec, ActionMixin
 from .actions import Actions
+
+logger = logging.getLogger(__name__)
+
+
+def _is_transport_failure(exc: BaseException) -> bool:
+    """True when *exc* is the network or the backend failing, not the payload.
+
+    ``Action.inputs`` loads lazily over the network (``LIST_INPUTS``), so the
+    validation branch below can fail for two very different reasons. An unknown
+    action name or a malformed payload is a caller error and must still be
+    reported (BUG-946); a dropped connection or a backend 5xx says nothing about
+    the call and must not turn a previously working ``tool.run()`` into a
+    client-side validation failure.
+
+    A 4xx keeps blocking: that is the backend rejecting *this* action or payload.
+    ``status_code == 0`` is the SDK's sentinel for "no HTTP response at all".
+    """
+    if isinstance(exc, requests.RequestException):
+        return True
+    if isinstance(exc, APIError):
+        status = getattr(exc, "status_code", 0) or 0
+        return status == 0 or status == 429 or status >= 500
+    return False
 
 
 @dataclass_json
@@ -495,7 +522,15 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             # fabricates an ActionView rather than raising on __getitem__ -- and the
             # empty list this used to return was indistinguishable from
             # "validated clean", so the run proceeded to the backend unchecked.
-            errors.append(f"Could not validate inputs for '{action}': {e}")
+            #
+            # A transport failure is the exception: the loader is a network call,
+            # so a backend blip would otherwise block a run whose payload was
+            # never in question. Validation is skipped and the backend, which is
+            # authoritative anyway, has the last word.
+            if _is_transport_failure(e):
+                logger.warning(f"Skipping input validation for '{action}'; the action lookup failed: {e}")
+            else:
+                errors.append(f"Could not validate inputs for '{action}': {e}")
 
         return errors
 

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -175,8 +175,12 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             if self._ensure_integration():
                 try:
                     return self.integration._list_inputs(*actions)
-                except Exception:
-                    pass
+                except Exception as fallback_error:
+                    # Returning [] below makes the lazy input loader raise
+                    # "not found or has no input parameters defined", which
+                    # _validate_params now surfaces as a run failure (BUG-946).
+                    # Without this the real cause never reaches the caller.
+                    warnings.warn(f"Error listing inputs via the integration fallback: {fallback_error}.")
 
             return []
 

--- a/aixplain/v2/upload_utils.py
+++ b/aixplain/v2/upload_utils.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Optional, Union, Any
 from urllib.parse import urljoin
 import requests
 
+from aixplain.utils.url_safety import validate_upload_url
+
 from .exceptions import FileUploadError
 
 
@@ -196,7 +198,19 @@ class S3Uploader:
 
     @classmethod
     def upload_file(cls, file_path: str, presigned_url: str, content_type: str) -> None:
-        """Upload file to S3 using pre-signed URL."""
+        """Upload file to S3 using pre-signed URL.
+
+        Raises:
+            UnsafeURLError: If ``presigned_url`` does not point at an allowed
+                upload host. The check sits *outside* the ``try`` below so the
+                generic ``FileUploadError`` wrapper cannot mask why the upload
+                was refused (BUG-939).
+        """
+        # The URL comes straight from a backend response; a compromised or
+        # redirected backend would otherwise receive the file while the SDK
+        # reported success.
+        validate_upload_url(presigned_url)
+
         headers = {"Content-Type": content_type}
 
         try:

--- a/aixplain/v2/upload_utils.py
+++ b/aixplain/v2/upload_utils.py
@@ -6,6 +6,7 @@ logic from the legacy FileFactory while maintaining a clean, modular architectur
 
 import os
 import re
+import threading
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
 from urllib.parse import urljoin
@@ -108,12 +109,24 @@ class MimeTypeDetector:
 class RequestManager:
     """Handles HTTP requests with retry logic."""
 
+    # One shared session for the process instead of one per request. A
+    # per-request session pays a fresh TLS handshake every time and pools
+    # nothing, which is the cost BUG-942 item 3 is about. Safe to share: the
+    # session carries no credentials (auth headers are passed per request), so
+    # nothing leaks across ``Aixplain()`` instances.
+    _session: Optional[requests.Session] = None
+    _session_lock = threading.Lock()
+
     @classmethod
     def create_session(cls) -> requests.Session:
-        """Create a requests session with retry configuration."""
-        from .client import create_retry_session
+        """Return the shared retry session, creating it on first use."""
+        if cls._session is None:
+            with cls._session_lock:
+                if cls._session is None:
+                    from .client import create_retry_session
 
-        return create_retry_session()
+                    cls._session = create_retry_session()
+        return cls._session
 
     @classmethod
     def request_with_retry(cls, method: str, url: str, **kwargs) -> requests.Response:

--- a/aixplain/v2/upload_utils.py
+++ b/aixplain/v2/upload_utils.py
@@ -217,7 +217,12 @@ class S3Uploader:
             with open(file_path, "rb") as f:
                 file_data = f.read()
 
-            response = RequestManager.request_with_retry("put", presigned_url, headers=headers, data=file_data)
+            # A presigned S3 PUT never legitimately redirects; following a 307
+            # would re-send the bytes to a host ``validate_upload_url`` never
+            # saw (BUG-939).
+            response = RequestManager.request_with_retry(
+                "put", presigned_url, headers=headers, data=file_data, allow_redirects=False
+            )
 
             if response.status_code != 200:
                 raise FileUploadError("File Uploading Error: Failure on Uploading to S3.")

--- a/tests/unit/team_agent/test_progress_verbosity_passthrough.py
+++ b/tests/unit/team_agent/test_progress_verbosity_passthrough.py
@@ -1,0 +1,121 @@
+"""Guard: ``TeamAgent.run`` must forward ``progress_verbosity`` to ``sync_poll``.
+
+``run`` accepts and documents ``progress_verbosity`` -- *"full" (detailed),
+"compact" (brief), or None (no progress)"* -- but dropped it on the call to
+``sync_poll``, which defaults it to ``"compact"``. So ``run(progress_verbosity=None)``
+still printed progress to stdout (unsuppressable library output for anyone
+embedding the SDK in a service) and ``"full"`` still rendered compact (BUG-946).
+
+The sibling ``Agent.run`` has always passed it through correctly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from aixplain.modules.team_agent import TeamAgent
+from aixplain.modules.agent.agent_response import AgentResponse
+from aixplain.modules.agent.agent_response_data import AgentResponseData
+from aixplain.enums import ResponseStatus
+
+
+def _completed_response(**kwargs):
+    return AgentResponse(
+        status=ResponseStatus.SUCCESS,
+        completed=True,
+        data=AgentResponseData(input="hi", output="done"),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("verbosity", [None, "full", "compact"])
+def test_run_forwards_progress_verbosity_to_sync_poll(verbosity):
+    """Whatever the caller passes to ``run`` must reach ``sync_poll``."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "sync_poll", return_value=_completed_response()) as mock_sync_poll,
+    ):
+        team_agent.run(query="hi", progress_verbosity=verbosity)
+
+    assert mock_sync_poll.call_args.kwargs["progress_verbosity"] == verbosity
+
+
+def test_run_defaults_to_compact():
+    """The documented default must survive the passthrough."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "sync_poll", return_value=_completed_response()) as mock_sync_poll,
+    ):
+        team_agent.run(query="hi")
+
+    assert mock_sync_poll.call_args.kwargs["progress_verbosity"] == "compact"
+
+
+PROGRESS = {
+    "stage": "planning",
+    "message": "Breaking the task down",
+    "current_step": 1,
+    "total_steps": 3,
+}
+
+
+def _poll_sequence():
+    """One in-progress poll carrying progress data, then a completed one."""
+    in_progress = AgentResponse(
+        status=ResponseStatus.IN_PROGRESS,
+        completed=False,
+        data=AgentResponseData(input="hi"),
+        progress=dict(PROGRESS),
+    )
+    return [in_progress, _completed_response()]
+
+
+def test_sync_poll_none_produces_no_stdout(capsys):
+    """``progress_verbosity=None`` must suppress *all* stdout.
+
+    That includes the completion line printed after the polling loop.
+    """
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with patch.object(TeamAgent, "poll", side_effect=_poll_sequence()):
+        team_agent.sync_poll("http://poll", wait_time=0.01, progress_verbosity=None)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_sync_poll_full_renders_full(capsys):
+    """``"full"`` must render the detailed format, not the compact one."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with patch.object(TeamAgent, "poll", side_effect=_poll_sequence()):
+        team_agent.sync_poll("http://poll", wait_time=0.01, progress_verbosity="full")
+
+    out = capsys.readouterr().out
+    assert out, "'full' must produce progress output"
+
+    full_msg = team_agent._format_team_progress(PROGRESS, "full")
+    compact_msg = team_agent._format_team_progress(PROGRESS, "compact")
+    assert full_msg != compact_msg, "fixture must distinguish the two formats"
+    assert full_msg in out
+    assert compact_msg not in out
+
+
+def test_run_none_produces_no_stdout(capsys):
+    """End to end: ``run(progress_verbosity=None)`` must print nothing.
+
+    This is the acceptance criterion; it failed before the passthrough because
+    ``sync_poll`` fell back to its ``"compact"`` default.
+    """
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "poll", side_effect=_poll_sequence()),
+    ):
+        team_agent.run(query="hi", wait_time=0.01, progress_verbosity=None)
+
+    assert capsys.readouterr().out == ""

--- a/tests/unit/test_v1_poll_load_fixes.py
+++ b/tests/unit/test_v1_poll_load_fixes.py
@@ -1,0 +1,195 @@
+"""Unit tests for the minimal v1 load fixes (BUG-942 items 1, 3 and 5).
+
+v1 is no longer maintained, so these fixes are line-level only:
+
+* jitter on the four v1 poll sleeps -- a deterministic interval keeps every
+  client launched together phase-locked for the whole run;
+* a pipeline poll budget measured in minutes rather than 5h33m;
+* a poll log that never interpolates the response body, lazily.
+
+Connection reuse (item 3) is covered in ``tests/unit/utils/request_utils_test.py``.
+"""
+
+import ast
+import logging
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The four v1 poll loops named in BUG-942. ``rlm.py``'s loop is deliberately
+# excluded: it lives inside a Python source *string* injected into a remote
+# sandbox, where one sandbox runs one job and there is no fleet to decorrelate.
+V1_POLL_LOOPS = [
+    "aixplain/v1/modules/model/__init__.py",
+    "aixplain/v1/modules/agent/__init__.py",
+    "aixplain/v1/modules/team_agent/__init__.py",
+    "aixplain/v1/modules/pipeline/asset.py",
+]
+
+
+def _sleep_calls(path):
+    """Every ``time.sleep(...)`` call node in *path*, ignoring strings/comments."""
+    tree = ast.parse((REPO_ROOT / path).read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "sleep"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "time"
+    ]
+
+
+class TestV1PollJitter:
+    """Every v1 poll sleep must be jittered."""
+
+    @pytest.mark.parametrize("path", V1_POLL_LOOPS)
+    def test_every_poll_sleep_is_jittered(self, path):
+        """AST-checked so a comment or docstring can't satisfy the assertion."""
+        calls = _sleep_calls(path)
+
+        assert calls, f"no time.sleep found in {path}"
+        for call in calls:
+            source = ast.dump(call)
+            assert "random" in source and "uniform" in source, f"{path}:{call.lineno} sleeps without jitter"
+
+    @pytest.mark.parametrize("path", V1_POLL_LOOPS)
+    def test_random_is_imported(self, path):
+        assert "\nimport random\n" in (REPO_ROOT / path).read_text()
+
+    def test_model_sync_poll_jitters_its_sleep(self):
+        """Behavioural check on one loop: the delay is not the nominal interval."""
+        from aixplain.v1.modules.model import Model
+
+        model = Model(id="m-1", name="m", api_key="k")
+        polls = [
+            {"completed": False, "status": "IN_PROGRESS"},
+            {"completed": True, "status": "SUCCESS", "data": ""},
+        ]
+        delays = []
+
+        with patch.object(Model, "poll", side_effect=polls):
+            with patch("aixplain.v1.modules.model.time.sleep", side_effect=delays.append):
+                model.sync_poll("https://example.com/poll", wait_time=1.0, timeout=60)
+
+        assert len(delays) == 1
+        assert delays[0] != 1.0
+        assert 0.8 <= delays[0] <= 1.2
+
+    def test_model_sync_poll_delays_differ_across_runs(self):
+        """Two clients started together must not sleep in lockstep."""
+        from aixplain.v1.modules.model import Model
+
+        observed = []
+        for _ in range(2):
+            model = Model(id="m-1", name="m", api_key="k")
+            polls = [{"completed": False, "status": "IN_PROGRESS"}] * 3 + [
+                {"completed": True, "status": "SUCCESS", "data": ""}
+            ]
+            delays = []
+            with patch.object(Model, "poll", side_effect=polls):
+                with patch("aixplain.v1.modules.model.time.sleep", side_effect=delays.append):
+                    model.sync_poll("https://example.com/poll", wait_time=1.0, timeout=60)
+            observed.append(delays)
+
+        assert observed[0] != observed[1]
+
+    def test_backoff_ladder_is_preserved(self):
+        """Jitter replaces the constant; the x1.1 growth must survive."""
+        from aixplain.v1.modules.model import Model
+
+        model = Model(id="m-1", name="m", api_key="k")
+        polls = [{"completed": False, "status": "IN_PROGRESS"}] * 8 + [
+            {"completed": True, "status": "SUCCESS", "data": ""}
+        ]
+        delays = []
+
+        with patch.object(Model, "poll", side_effect=polls):
+            with patch("aixplain.v1.modules.model.random.uniform", return_value=1.0):
+                with patch("aixplain.v1.modules.model.time.sleep", side_effect=delays.append):
+                    model.sync_poll("https://example.com/poll", wait_time=1.0, timeout=600)
+
+        assert delays == sorted(delays)
+        assert delays[-1] > delays[0]
+        assert delays[1] == pytest.approx(1.1)
+
+
+class TestPipelineTimeoutDefault:
+    """BUG-942 item 5a: the default budget was 20,000s (5h33m)."""
+
+    def test_run_default_timeout_is_measured_in_minutes(self):
+        import inspect
+
+        from aixplain.v1.modules.pipeline.asset import Pipeline
+
+        default = inspect.signature(Pipeline.run).parameters["timeout"].default
+
+        assert default == 1800.0
+        assert default / 60 <= 60, "default budget should be under an hour"
+
+    def test_polling_default_timeout_matches_run(self):
+        import inspect
+
+        from aixplain.v1.modules.pipeline.asset import Pipeline
+
+        polling = getattr(Pipeline, "_Pipeline__polling")
+        assert inspect.signature(polling).parameters["timeout"].default == 1800.0
+
+    def test_no_twenty_thousand_second_default_remains(self):
+        source = (REPO_ROOT / "aixplain/v1/modules/pipeline/asset.py").read_text()
+
+        assert "20000.0" not in source
+
+
+class TestPipelinePollLogging:
+    """BUG-942 item 5b: the full response body was logged at INFO every poll."""
+
+    @staticmethod
+    def _poll(caplog, body):
+        from aixplain.v1.modules.pipeline.asset import Pipeline
+
+        pipeline = Pipeline(id="p-1", name="p", api_key="k", nodes=[])
+        response = Mock()
+        response.json.return_value = body
+
+        with patch("aixplain.v1.modules.pipeline.asset._request_with_retry", return_value=response):
+            with caplog.at_level(logging.DEBUG, logger="root"):
+                pipeline.poll("https://example.com/poll", response_version="v1")
+        return caplog.records
+
+    def test_poll_does_not_log_the_response_body(self, caplog):
+        """A 500KB transcript used to be emitted on every poll."""
+        secret_body = "x" * 5000
+        records = self._poll(caplog, {"status": "IN_PROGRESS", "completed": False, "transcript": secret_body})
+
+        for record in records:
+            assert secret_body not in record.getMessage()
+
+    def test_poll_log_uses_lazy_percent_args(self, caplog):
+        """Eager f-strings stringify the payload even when the level is off."""
+        records = self._poll(caplog, {"status": "IN_PROGRESS", "completed": False})
+        poll_records = [r for r in records if "Single Poll for Pipeline" in r.getMessage()]
+
+        assert poll_records, records
+        record = poll_records[0]
+        assert "%s" in record.msg
+        assert record.args == ("p-1", "pipeline_process", "https://example.com/poll", "IN_PROGRESS")
+
+    def test_poll_log_is_no_longer_at_info(self, caplog):
+        """One line per poll at INFO is noise even without the body."""
+        records = self._poll(caplog, {"status": "IN_PROGRESS", "completed": False})
+        poll_records = [r for r in records if "Single Poll for Pipeline" in r.getMessage()]
+
+        assert poll_records
+        assert all(r.levelno == logging.DEBUG for r in poll_records)
+
+    def test_no_eager_body_interpolation_left_in_the_poll_path(self):
+        """Guard: no f-string logging call in ``poll`` mentions ``{resp}``."""
+        source = (REPO_ROOT / "aixplain/v1/modules/pipeline/asset.py").read_text()
+
+        assert 'logging.info(f"Single Poll' not in source
+        assert "): {resp}" not in source

--- a/tests/unit/test_v1_poll_load_fixes.py
+++ b/tests/unit/test_v1_poll_load_fixes.py
@@ -193,3 +193,101 @@ class TestPipelinePollLogging:
 
         assert 'logging.info(f"Single Poll' not in source
         assert "): {resp}" not in source
+
+
+# Functions that run once per poll, i.e. up to ~44 times per job.
+POLL_FUNCTIONS = frozenset({"poll", "sync_poll", "_Pipeline__polling", "__polling"})
+
+# Names holding a full response body in those functions.
+BODY_NAMES = frozenset({"resp", "response_body"})
+
+
+def _poll_path_logs_with_body(path):
+    """``logging.*(f"... {resp} ...")`` calls inside a per-poll function."""
+    tree = ast.parse((REPO_ROOT / path).read_text())
+    offenders = []
+
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if func.name.lstrip("_") not in {name.lstrip("_") for name in POLL_FUNCTIONS}:
+            continue
+        for node in ast.walk(func):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            if not (isinstance(node.func.value, ast.Name) and node.func.value.id == "logging"):
+                continue
+            first = node.args[0] if node.args else None
+            if not isinstance(first, ast.JoinedStr):
+                continue
+            for part in ast.walk(first):
+                if isinstance(part, ast.Name) and part.id in BODY_NAMES:
+                    offenders.append((func.name, node.lineno))
+    return offenders
+
+
+class TestNoResponseBodyInPollLogs:
+    """BUG-942 item 5b acceptance criterion, across every v1 poll path.
+
+    An eager f-string stringifies the payload even when the level is disabled,
+    so a 500KB transcript is built ~44 times per job whether or not anything
+    consumes it.
+    """
+
+    @pytest.mark.parametrize("path", V1_POLL_LOOPS)
+    def test_no_poll_log_interpolates_the_response_body(self, path):
+        offenders = _poll_path_logs_with_body(path)
+
+        assert not offenders, f"{path} logs a full response body at {offenders}"
+
+    def test_the_guard_detects_a_regression(self):
+        """Meta-test: the AST walk really does flag an eager body log."""
+        tree = ast.parse('import logging\ndef poll(self):\n    logging.debug(f"x {resp}")\n')
+        found = [
+            node.lineno
+            for func in ast.walk(tree)
+            if isinstance(func, ast.FunctionDef) and func.name == "poll"
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "logging"
+            and node.args
+            and isinstance(node.args[0], ast.JoinedStr)
+            and any(isinstance(p, ast.Name) and p.id in BODY_NAMES for p in ast.walk(node.args[0]))
+        ]
+
+        assert found == [3]
+
+    def test_model_single_poll_logs_status_only(self, caplog):
+        from aixplain.v1.modules.model import Model
+
+        model = Model(id="m-1", name="m", api_key="k")
+        secret_body = "y" * 5000
+        response = Mock()
+        response.json.return_value = {"completed": False, "status": "IN_PROGRESS", "transcript": secret_body}
+
+        with patch("aixplain.v1.modules.model._request_with_retry", return_value=response):
+            with caplog.at_level(logging.DEBUG):
+                model.poll("https://example.com/poll")
+
+        records = [r for r in caplog.records if "Single Poll for Model" in r.getMessage()]
+        assert records
+        assert records[0].args == ("model_process", "IN_PROGRESS")
+        assert all(secret_body not in r.getMessage() for r in caplog.records)
+
+    def test_pipeline_polling_loop_logs_status_only(self, caplog):
+        from aixplain.v1.modules.pipeline.asset import Pipeline
+
+        pipeline = Pipeline(id="p-1", name="p", api_key="k", nodes=[])
+        secret_body = "z" * 5000
+        polled = {"completed": True, "status": "SUCCESS", "transcript": secret_body}
+
+        with patch.object(Pipeline, "poll", return_value=polled):
+            with caplog.at_level(logging.DEBUG):
+                pipeline._Pipeline__polling("https://example.com/poll", timeout=5)
+
+        records = [r for r in caplog.records if "Polling for Pipeline: Status" in r.getMessage()]
+        assert records
+        assert records[0].args == ("pipeline_process", "SUCCESS")
+        assert all(secret_body not in r.getMessage() for r in caplog.records)

--- a/tests/unit/test_v1_unbound_local_fixes.py
+++ b/tests/unit/test_v1_unbound_local_fixes.py
@@ -20,6 +20,7 @@ The non-2xx + non-JSON path already worked (the sentinel flows into
 guards it against regression.
 """
 
+import json
 import threading
 from unittest.mock import Mock, patch
 
@@ -112,21 +113,34 @@ class TestCallRunEndpointNonJsonBody:
         assert result == {"status": "IN_PROGRESS", "url": "https://example.com/poll/1", "completed": False}
 
 
+class _NonCopyableDict(dict):
+    """JSON-serializable, but ``copy.deepcopy`` refuses it.
+
+    Separates the two failure modes ``threading.Lock`` conflates: a lock breaks
+    *both* ``deepcopy`` and ``json.dumps``, so it can only show that the fallback
+    does not crash. This one breaks ``deepcopy`` alone, so the fallback has to
+    run to completion and produce the real payload.
+    """
+
+    def __deepcopy__(self, memo):
+        raise TypeError("cannot deepcopy")
+
+
 class TestBuildPayloadDeepcopyFailure:
     """``copy.deepcopy`` raising must not take out the serialization fallback."""
 
-    def test_non_copyable_parameter_still_builds_payload(self):
-        """A non-copyable parameter must not raise UnboundLocalError."""
-        try:
-            payload = build_payload("some data", {"lock": threading.Lock()})
-        except UnboundLocalError:  # pragma: no cover - the bug under test
-            pytest.fail("build_payload raised UnboundLocalError from its fallback")
-        except TypeError:
-            # json.dumps legitimately cannot serialize a lock; that error is the
-            # caller's to see. Only UnboundLocalError is the defect.
-            pass
-        else:
-            assert isinstance(payload, str)
+    def test_deepcopy_failure_still_produces_the_full_payload(self):
+        """The fallback must emit the real payload, not merely avoid a crash."""
+        payload = build_payload("some data", {"cfg": _NonCopyableDict({"a": 1})})
+        # ``data`` is folded into ``parameters`` upstream when it is not JSON, so
+        # the fallback's ``_serialize_value(parametersTemp)`` must carry it too --
+        # aliasing ``parametersTemp`` to ``parameters`` keeps that true.
+        assert json.loads(payload) == {"cfg": {"a": 1}, "data": "some data"}
+
+    def test_wholly_unserializable_parameter_raises_the_honest_error(self):
+        """A lock cannot be serialized; the caller must see that, not UnboundLocalError."""
+        with pytest.raises(TypeError):
+            build_payload("some data", {"lock": threading.Lock()})
 
 
 class TestPipelinePollNonJsonBody:

--- a/tests/unit/test_v1_unbound_local_fixes.py
+++ b/tests/unit/test_v1_unbound_local_fixes.py
@@ -1,0 +1,172 @@
+"""Unit tests for the minimal v1 ``UnboundLocalError`` fixes (BUG-941).
+
+v1 is no longer maintained, so these fixes are line-level only: a handler that
+already builds the documented failure value is made to *return* it, and every
+name an ``except`` block reads is bound before its ``try``.
+
+Four sites, all reproduced before the fix:
+
+* ``call_run_endpoint`` -- the request handler fell through to ``r.status_code``,
+  which is unbound when the request itself raised (``UnboundLocalError: 'r'``);
+* ``call_run_endpoint`` -- a 2xx body that is not JSON left ``resp`` on its
+  ``"unspecified error"`` sentinel, and ``resp.get`` then raised ``AttributeError``;
+* ``build_payload`` -- ``copy.deepcopy`` is the first statement in its ``try`` and
+  can itself raise ``TypeError`` (``UnboundLocalError: 'parametersTemp'``);
+* ``Pipeline.poll`` -- ``resp = r.json()`` is the first statement in its ``try``
+  and the handler reads ``resp`` (``UnboundLocalError: 'resp'``).
+
+The non-2xx + non-JSON path already worked (the sentinel flows into
+``get_error_from_status_code``); ``test_502_non_json_body_keeps_status_code_message``
+guards it against regression.
+"""
+
+import threading
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from aixplain.enums import ResponseStatus
+from aixplain.v1.modules.model.utils import build_payload, call_run_endpoint
+from aixplain.v1.modules.pipeline.asset import Pipeline
+from aixplain.v1.modules.pipeline.response import PipelineResponse
+
+UTILS_REQUEST = "aixplain.v1.modules.model.utils._request_with_retry"
+PIPELINE_REQUEST = "aixplain.v1.modules.pipeline.asset._request_with_retry"
+
+
+def _assert_failed_shape(response):
+    """The failure contract ``call_run_endpoint``'s docstring promises."""
+    assert isinstance(response, dict)
+    assert response["status"] == "FAILED"
+    assert response["completed"] is True
+    assert isinstance(response["error_message"], str)
+    assert response["error_message"]
+
+
+def _json_error_response(status_code):
+    """A response whose body cannot be decoded, as a 502 HTML page cannot."""
+    response = Mock(status_code=status_code)
+    response.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    return response
+
+
+class TestCallRunEndpointRequestFailure:
+    """The request itself raises: the documented FAILED dict, never a crash."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            # The ticket's own repro uses the *builtin* ConnectionError, which is
+            # not a requests.exceptions.RequestException.
+            ConnectionError("boom"),
+            requests.exceptions.ConnectionError("connection reset"),
+            requests.exceptions.Timeout("read timed out"),
+            requests.exceptions.SSLError("certificate verify failed"),
+            OSError("dns lookup failed"),
+        ],
+        ids=["builtin-connection", "requests-connection", "timeout", "ssl", "oserror"],
+    )
+    def test_transport_error_returns_failed(self, error):
+        """Every transport failure yields the documented FAILED dict."""
+        with patch(UTILS_REQUEST, side_effect=error):
+            response = call_run_endpoint("https://example.com/run", "api-key", {"data": "x"})
+        _assert_failed_shape(response)
+
+    def test_programming_errors_still_propagate(self):
+        """A genuine bug in our own code must not be laundered into FAILED."""
+        with patch(UTILS_REQUEST, side_effect=AttributeError("typo")):
+            with pytest.raises(AttributeError):
+                call_run_endpoint("https://example.com/run", "api-key", {"data": "x"})
+
+
+class TestCallRunEndpointNonJsonBody:
+    """The request succeeds but the body is not JSON."""
+
+    def test_2xx_non_json_body_returns_failed(self):
+        """A 2xx body we cannot decode is a failure, not an AttributeError."""
+        with patch(UTILS_REQUEST, return_value=_json_error_response(200)):
+            response = call_run_endpoint("https://example.com/run", "api-key", {"data": "x"})
+        _assert_failed_shape(response)
+
+    def test_502_non_json_body_keeps_status_code_message(self):
+        """Regression guard: the status-code-mapped message must survive."""
+        with patch(UTILS_REQUEST, return_value=_json_error_response(502)):
+            response = call_run_endpoint("https://example.com/run", "api-key", {"data": "x"})
+        _assert_failed_shape(response)
+        assert "502" in response["error_message"]
+
+    def test_real_non_json_response_via_requests_mock(self, requests_mock):
+        """Exercises requests' own JSONDecodeError, not a Mock's ValueError."""
+        url = "https://example.com/run"
+        requests_mock.post(url, status_code=200, text="<html>502 Bad Gateway</html>")
+        response = call_run_endpoint(url, "api-key", {"data": "x"})
+        _assert_failed_shape(response)
+
+    def test_2xx_json_body_still_succeeds(self):
+        """The happy path is untouched."""
+        response = Mock(status_code=200)
+        response.json.return_value = {"status": "IN_PROGRESS", "data": "https://example.com/poll/1"}
+        with patch(UTILS_REQUEST, return_value=response):
+            result = call_run_endpoint("https://example.com/run", "api-key", {"data": "x"})
+        assert result == {"status": "IN_PROGRESS", "url": "https://example.com/poll/1", "completed": False}
+
+
+class TestBuildPayloadDeepcopyFailure:
+    """``copy.deepcopy`` raising must not take out the serialization fallback."""
+
+    def test_non_copyable_parameter_still_builds_payload(self):
+        """A non-copyable parameter must not raise UnboundLocalError."""
+        try:
+            payload = build_payload("some data", {"lock": threading.Lock()})
+        except UnboundLocalError:  # pragma: no cover - the bug under test
+            pytest.fail("build_payload raised UnboundLocalError from its fallback")
+        except TypeError:
+            # json.dumps legitimately cannot serialize a lock; that error is the
+            # caller's to see. Only UnboundLocalError is the defect.
+            pass
+        else:
+            assert isinstance(payload, str)
+
+
+class TestPipelinePollNonJsonBody:
+    """``Pipeline.poll`` returns a FAILED PipelineResponse for an undecodable body."""
+
+    @staticmethod
+    def _pipeline():
+        pipeline = Pipeline.__new__(Pipeline)
+        pipeline.api_key = "api-key"
+        pipeline.id = "pipeline-id"
+        return pipeline
+
+    def test_non_json_body_returns_failed_pipeline_response(self):
+        """An undecodable poll body yields PipelineResponse(FAILED)."""
+        with patch(PIPELINE_REQUEST, return_value=_json_error_response(502)):
+            response = self._pipeline().poll("https://example.com/poll/1")
+        assert isinstance(response, PipelineResponse)
+        assert response.status is ResponseStatus.FAILED
+
+    def test_json_array_body_returns_failed_pipeline_response(self):
+        """A JSON array binds ``resp`` to a non-dict; ``.pop`` then raised TypeError."""
+        response = Mock(status_code=200)
+        response.json.return_value = ["a", "b"]
+        with patch(PIPELINE_REQUEST, return_value=response):
+            result = self._pipeline().poll("https://example.com/poll/1")
+        assert isinstance(result, PipelineResponse)
+        assert result.status is ResponseStatus.FAILED
+
+    def test_successful_poll_unaffected(self):
+        """The happy path still maps onto the SUCCESS status."""
+        response = Mock(status_code=200)
+        response.json.return_value = {"status": "SUCCESS", "elapsed_time": 12, "data": []}
+        with patch(PIPELINE_REQUEST, return_value=response):
+            result = self._pipeline().poll("https://example.com/poll/1")
+        assert result.status is ResponseStatus.SUCCESS
+
+    def test_v1_response_version_returns_raw_dict(self):
+        """``response_version="v1"`` still returns the raw dict."""
+        response = Mock(status_code=200)
+        response.json.return_value = {"status": "SUCCESS", "data": []}
+        with patch(PIPELINE_REQUEST, return_value=response):
+            result = self._pipeline().poll("https://example.com/poll/1", response_version="v1")
+        assert result == {"status": "SUCCESS", "data": []}

--- a/tests/unit/utils/request_utils_test.py
+++ b/tests/unit/utils/request_utils_test.py
@@ -1,0 +1,82 @@
+"""Unit tests for v1 connection reuse in ``_request_with_retry`` (BUG-942 item 3).
+
+``_request_with_retry`` used to build a fresh ``requests.Session`` inside the
+per-request function, use it once and drop it (never ``close()``d), so every one
+of the ~105 v1 call sites paid a full TLS handshake. A 5-minute v1 job polls ~44
+times: ~44 handshakes where keep-alive needs one.
+
+There is no socket here, so the offline proxy for "~1 TLS handshake, not ~100"
+is "~1 ``Session``, not ~100" -- a session is what owns the connection pool.
+"""
+
+from unittest.mock import Mock, patch
+
+import requests
+
+from aixplain.utils import request_utils
+from aixplain.utils.request_utils import _request_with_retry
+
+
+class TestSessionReuse:
+    """One session for the process, reused by every call."""
+
+    def test_module_level_session_exists(self):
+        assert isinstance(request_utils._SESSION, requests.Session)
+
+    def test_a_hundred_calls_construct_no_new_session(self):
+        """The acceptance criterion: ~1 pooled connection, not ~100."""
+        with patch.object(request_utils._SESSION, "request", return_value=Mock()) as request:
+            with patch("requests.Session") as session_ctor:
+                for index in range(100):
+                    _request_with_retry("get", f"https://example.com/poll/{index}")
+
+        assert request.call_count == 100
+        session_ctor.assert_not_called()
+
+    def test_every_call_uses_the_same_session_object(self):
+        # Session identity, observed through the public entry point.
+        seen = []
+
+        def capture(self, **kwargs):
+            seen.append(id(self))
+            return Mock()
+
+        with patch.object(requests.Session, "request", capture):
+            _request_with_retry("get", "https://example.com/a")
+            _request_with_retry("get", "https://example.com/b")
+
+        assert len(set(seen)) == 1
+
+
+class TestRetryConfigPreserved:
+    """The change is connection reuse only -- retry behaviour is untouched."""
+
+    def test_https_adapter_carries_the_same_retry_config(self):
+        adapter = request_utils._SESSION.get_adapter("https://example.com")
+
+        assert adapter.max_retries.total == 5
+        assert adapter.max_retries.backoff_factor == 0.1
+        assert set(adapter.max_retries.status_forcelist) == {500, 502, 503, 504}
+
+    def test_method_and_params_are_forwarded_unchanged(self):
+        with patch.object(request_utils._SESSION, "request", return_value=Mock()) as request:
+            _request_with_retry("post", "https://example.com/x", headers={"a": "b"}, data="payload")
+
+        assert request.call_args.kwargs == {
+            "method": "POST",
+            "url": "https://example.com/x",
+            "headers": {"a": "b"},
+            "data": "payload",
+        }
+
+    def test_method_is_upper_cased(self):
+        with patch.object(request_utils._SESSION, "request", return_value=Mock()) as request:
+            _request_with_retry("get", "https://example.com/x")
+
+        assert request.call_args.kwargs["method"] == "GET"
+
+    def test_response_is_returned_unchanged(self):
+        sentinel = Mock()
+
+        with patch.object(request_utils._SESSION, "request", return_value=sentinel):
+            assert _request_with_retry("get", "https://example.com/x") is sentinel

--- a/tests/unit/utils/request_utils_test.py
+++ b/tests/unit/utils/request_utils_test.py
@@ -48,6 +48,55 @@ class TestSessionReuse:
         assert len(set(seen)) == 1
 
 
+class TestPoolSizing:
+    """A shared session needs a sized pool, or reuse is cancelled out.
+
+    urllib3 defaults to 10/10 with ``block=False``: above 10 in-flight requests
+    the adapter opens a connection, uses it once and *discards* it, logging
+    "Connection pool is full" each time. Per-call sessions never hit that
+    because each had its own pool; the shared one would.
+    """
+
+    def test_adapter_pool_is_sized_explicitly(self):
+        adapter = request_utils._SESSION.get_adapter("https://example.com")
+
+        assert adapter._pool_connections == request_utils._POOL_CONNECTIONS
+        assert adapter._pool_maxsize == request_utils._POOL_MAXSIZE
+
+    def test_pool_is_larger_than_the_urllib3_default(self):
+        assert request_utils._POOL_CONNECTIONS > 10
+        assert request_utils._POOL_MAXSIZE > 10
+
+    def test_value_reaches_urllib3(self):
+        adapter = request_utils._SESSION.get_adapter("https://example.com")
+        pool = adapter.poolmanager.connection_from_url("https://example.com")
+
+        assert pool.pool.maxsize == request_utils._POOL_MAXSIZE
+
+    def test_fifty_concurrent_checkouts_do_not_warn_about_a_full_pool(self, caplog):
+        import threading
+
+        adapter = request_utils._SESSION.get_adapter("https://example.com")
+        pool = adapter.poolmanager.connection_from_url("https://example.com")
+
+        barrier = threading.Barrier(50)
+        conns = [None] * 50
+
+        def hold(index):
+            conns[index] = pool._get_conn()
+            barrier.wait()  # all 50 out at once
+            pool._put_conn(conns[index])
+
+        threads = [threading.Thread(target=hold, args=(i,)) for i in range(50)]
+        with caplog.at_level("WARNING", logger="urllib3.connectionpool"):
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert not [r for r in caplog.records if "pool is full" in r.getMessage().lower()]
+
+
 class TestRetryConfigPreserved:
     """The change is connection reuse only -- retry behaviour is untouched."""
 

--- a/tests/unit/utils/request_utils_test.py
+++ b/tests/unit/utils/request_utils_test.py
@@ -7,25 +7,33 @@ times: ~44 handshakes where keep-alive needs one.
 
 There is no socket here, so the offline proxy for "~1 TLS handshake, not ~100"
 is "~1 ``Session``, not ~100" -- a session is what owns the connection pool.
+
+The session is per *thread*, not per process: ``requests`` documents ``Session``
+as not thread-safe, and v1 reaches this module from ``ThreadPoolExecutor`` pools.
+A shared session would also share ``session.cookies``, so a ``Set-Cookie`` from
+any host would persist process-wide.
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock, patch
 
 import requests
 
 from aixplain.utils import request_utils
-from aixplain.utils.request_utils import _request_with_retry
+from aixplain.utils.request_utils import _request_with_retry, get_session
 
 
 class TestSessionReuse:
-    """One session for the process, reused by every call."""
+    """One session per thread, reused by every call on that thread."""
 
-    def test_module_level_session_exists(self):
-        assert isinstance(request_utils._SESSION, requests.Session)
+    def test_thread_session_exists(self):
+        assert isinstance(get_session(), requests.Session)
 
     def test_a_hundred_calls_construct_no_new_session(self):
         """The acceptance criterion: ~1 pooled connection, not ~100."""
-        with patch.object(request_utils._SESSION, "request", return_value=Mock()) as request:
+        session = get_session()
+        with patch.object(session, "request", return_value=Mock()) as request:
             with patch("requests.Session") as session_ctor:
                 for index in range(100):
                     _request_with_retry("get", f"https://example.com/poll/{index}")
@@ -48,17 +56,61 @@ class TestSessionReuse:
         assert len(set(seen)) == 1
 
 
+class TestThreadIsolation:
+    """No mutable session state is shared across threads."""
+
+    def test_each_thread_gets_its_own_session(self):
+        sessions = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(8)
+
+        def collect():
+            session = get_session()
+            with lock:
+                sessions.append(session)
+            barrier.wait()  # keep all eight threads alive at once
+
+        threads = [threading.Thread(target=collect) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(sessions) == 8
+        assert len({id(session) for session in sessions}) == 8
+        assert all(session is not get_session() for session in sessions)
+
+    def test_a_worker_thread_reuses_its_own_session(self):
+        """Pool workers are long-lived, so the reuse win survives per-thread state."""
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            first = pool.submit(get_session).result()
+            second = pool.submit(get_session).result()
+
+        assert first is second
+
+    def test_a_cookie_set_on_one_thread_does_not_leak_to_another(self):
+        """A ``Set-Cookie`` from any host used to persist process-wide."""
+
+        def set_cookie():
+            get_session().cookies.set("session", "leaked", domain="evil.example.com")
+
+        thread = threading.Thread(target=set_cookie)
+        thread.start()
+        thread.join()
+
+        assert "session" not in get_session().cookies
+
+
 class TestPoolSizing:
-    """A shared session needs a sized pool, or reuse is cancelled out.
+    """A reused session needs a sized pool, or reuse is cancelled out.
 
     urllib3 defaults to 10/10 with ``block=False``: above 10 in-flight requests
     the adapter opens a connection, uses it once and *discards* it, logging
-    "Connection pool is full" each time. Per-call sessions never hit that
-    because each had its own pool; the shared one would.
+    "Connection pool is full" each time.
     """
 
     def test_adapter_pool_is_sized_explicitly(self):
-        adapter = request_utils._SESSION.get_adapter("https://example.com")
+        adapter = get_session().get_adapter("https://example.com")
 
         assert adapter._pool_connections == request_utils._POOL_CONNECTIONS
         assert adapter._pool_maxsize == request_utils._POOL_MAXSIZE
@@ -68,15 +120,13 @@ class TestPoolSizing:
         assert request_utils._POOL_MAXSIZE > 10
 
     def test_value_reaches_urllib3(self):
-        adapter = request_utils._SESSION.get_adapter("https://example.com")
+        adapter = get_session().get_adapter("https://example.com")
         pool = adapter.poolmanager.connection_from_url("https://example.com")
 
         assert pool.pool.maxsize == request_utils._POOL_MAXSIZE
 
     def test_fifty_concurrent_checkouts_do_not_warn_about_a_full_pool(self, caplog):
-        import threading
-
-        adapter = request_utils._SESSION.get_adapter("https://example.com")
+        adapter = get_session().get_adapter("https://example.com")
         pool = adapter.poolmanager.connection_from_url("https://example.com")
 
         barrier = threading.Barrier(50)
@@ -101,14 +151,14 @@ class TestRetryConfigPreserved:
     """The change is connection reuse only -- retry behaviour is untouched."""
 
     def test_https_adapter_carries_the_same_retry_config(self):
-        adapter = request_utils._SESSION.get_adapter("https://example.com")
+        adapter = get_session().get_adapter("https://example.com")
 
         assert adapter.max_retries.total == 5
         assert adapter.max_retries.backoff_factor == 0.1
         assert set(adapter.max_retries.status_forcelist) == {500, 502, 503, 504}
 
     def test_method_and_params_are_forwarded_unchanged(self):
-        with patch.object(request_utils._SESSION, "request", return_value=Mock()) as request:
+        with patch.object(get_session(), "request", return_value=Mock()) as request:
             _request_with_retry("post", "https://example.com/x", headers={"a": "b"}, data="payload")
 
         assert request.call_args.kwargs == {
@@ -119,7 +169,7 @@ class TestRetryConfigPreserved:
         }
 
     def test_method_is_upper_cased(self):
-        with patch.object(request_utils._SESSION, "request", return_value=Mock()) as request:
+        with patch.object(get_session(), "request", return_value=Mock()) as request:
             _request_with_retry("get", "https://example.com/x")
 
         assert request.call_args.kwargs["method"] == "GET"
@@ -127,5 +177,5 @@ class TestRetryConfigPreserved:
     def test_response_is_returned_unchanged(self):
         sentinel = Mock()
 
-        with patch.object(request_utils._SESSION, "request", return_value=sentinel):
+        with patch.object(get_session(), "request", return_value=sentinel):
             assert _request_with_retry("get", "https://example.com/x") is sentinel

--- a/tests/unit/utils/test_config_url_policy.py
+++ b/tests/unit/utils/test_config_url_policy.py
@@ -1,0 +1,89 @@
+"""Tests that the configured endpoint URLs are validated (BUG-939).
+
+``BACKEND_URL``, ``MODELS_RUN_URL`` and ``PIPELINES_RUN_URL`` are read straight
+from the environment and decide where the team API key is sent, so both entry
+points that resolve them -- importing ``aixplain.utils.config`` and constructing
+``Aixplain()`` -- have to apply the policy.
+"""
+
+import importlib
+
+import pytest
+
+from aixplain.utils import config, url_safety
+from aixplain.utils.url_safety import INSECURE_OPT_IN_ENV_VAR, UnsafeURLError
+from aixplain.v2.core import Aixplain
+
+
+@pytest.fixture(autouse=True)
+def no_remembered_warnings():
+    """Clear the once-per-host warning memo so each test sees a fresh state."""
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+    yield
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+
+
+@pytest.fixture
+def reload_config(monkeypatch):
+    """Reload ``aixplain.utils.config`` under a chosen ``BACKEND_URL``.
+
+    Restores the module afterwards so the rest of the session is unaffected.
+    """
+    original = config.BACKEND_URL
+
+    def _reload(backend_url):
+        monkeypatch.setenv("BACKEND_URL", backend_url)
+        return importlib.reload(config)
+
+    yield _reload
+
+    monkeypatch.setenv("BACKEND_URL", original)
+    importlib.reload(config)
+
+
+def test_import_rejects_http_backend_url(reload_config):
+    """Importing the config module fails closed on an http endpoint."""
+    with pytest.raises(UnsafeURLError):
+        reload_config("http://platform-api.aixplain.com")
+
+
+def test_import_accepts_the_dev_backend(reload_config):
+    """The dev host must keep working exactly as before."""
+    reloaded = reload_config("https://dev-platform-api.aixplain.com")
+    assert reloaded.BACKEND_URL == "https://dev-platform-api.aixplain.com"
+    assert reloaded.ENV == "dev"
+
+
+def test_import_accepts_the_test_backend(reload_config):
+    """The test host must keep working exactly as before."""
+    reloaded = reload_config("https://test-platform-api.aixplain.com")
+    assert reloaded.ENV == "test"
+
+
+def test_import_allows_http_with_the_opt_in(reload_config, monkeypatch):
+    """A local backend is supported through the documented opt-in."""
+    monkeypatch.setenv(INSECURE_OPT_IN_ENV_VAR, "1")
+    reloaded = reload_config("http://localhost:8000")
+    assert reloaded.BACKEND_URL == "http://localhost:8000"
+
+
+def test_aixplain_rejects_an_http_pipeline_url(monkeypatch):
+    """``PIPELINES_RUN_URL`` is read nowhere else, so ``Aixplain()`` is its check."""
+    monkeypatch.delenv(INSECURE_OPT_IN_ENV_VAR, raising=False)
+    with pytest.raises(UnsafeURLError):
+        Aixplain(api_key="dummy", pipeline_url="http://evil.example.com/run")
+
+
+def test_aixplain_rejects_a_non_http_model_url(monkeypatch):
+    """A non-http(s) run URL is refused before a client is built."""
+    monkeypatch.delenv(INSECURE_OPT_IN_ENV_VAR, raising=False)
+    with pytest.raises(UnsafeURLError):
+        Aixplain(api_key="dummy", model_url="file:///etc/passwd")
+
+
+def test_aixplain_accepts_the_production_defaults():
+    """The default configuration is unaffected."""
+    instance = Aixplain(api_key="dummy")
+    assert instance.backend_url.startswith("https://")
+    assert instance.model_url.startswith("https://")
+    assert instance.pipeline_url.startswith("https://")

--- a/tests/unit/utils/test_config_url_policy.py
+++ b/tests/unit/utils/test_config_url_policy.py
@@ -4,13 +4,20 @@
 from the environment and decide where the team API key is sent, so both entry
 points that resolve them -- importing ``aixplain.utils.config`` and constructing
 ``Aixplain()`` -- have to apply the policy.
+
+Importing the config module only *warns*: it is on the ``import aixplain`` path,
+so raising there would break ``aixplain --help`` and unit test collection on a
+machine with no valid environment (BUG-946). The refusal happens instead at the
+v1 request choke point, before any socket is opened.
 """
 
 import importlib
+import socket
 
 import pytest
+import requests
 
-from aixplain.utils import config, url_safety
+from aixplain.utils import config, request_utils, url_safety
 from aixplain.utils.url_safety import INSECURE_OPT_IN_ENV_VAR, UnsafeURLError
 from aixplain.v2.core import Aixplain
 
@@ -41,10 +48,40 @@ def reload_config(monkeypatch):
     importlib.reload(config)
 
 
-def test_import_rejects_http_backend_url(reload_config):
-    """Importing the config module fails closed on an http endpoint."""
+def test_import_warns_but_does_not_raise_on_http_backend_url(reload_config, caplog):
+    """Importing the config module warns instead of breaking ``import aixplain``."""
+    with caplog.at_level("WARNING", logger="aixplain.utils.config"):
+        reloaded = reload_config("http://platform-api.aixplain.com")
+    assert reloaded.BACKEND_URL == "http://platform-api.aixplain.com"
+    assert any("BACKEND_URL must use https" in record.message for record in caplog.records)
+
+
+def test_a_rejected_backend_url_still_blocks_the_first_request(reload_config, monkeypatch):
+    """The deferred failure becomes a refusal before any socket is opened."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("an outbound request was attempted")
+
+    monkeypatch.setattr(requests.Session, "request", explode)
+    monkeypatch.setattr(socket, "create_connection", explode)
+
+    reload_config("http://platform-api.aixplain.com")
     with pytest.raises(UnsafeURLError):
-        reload_config("http://platform-api.aixplain.com")
+        request_utils._request_with_retry("get", "https://platform-api.aixplain.com/sdk/models")
+
+
+def test_a_valid_backend_url_leaves_requests_alone(reload_config, monkeypatch):
+    """The gate is inert once the configured endpoints satisfy the policy."""
+    sent = []
+
+    def record(self, method, url, **kwargs):
+        sent.append((method, url))
+        return "response"
+
+    monkeypatch.setattr(requests.Session, "request", record)
+    reload_config("https://platform-api.aixplain.com")
+    assert request_utils._request_with_retry("get", "https://platform-api.aixplain.com/x") == "response"
+    assert sent == [("GET", "https://platform-api.aixplain.com/x")]
 
 
 def test_import_accepts_the_dev_backend(reload_config):

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -86,3 +86,31 @@ def test_dotenv_neutralisation_actually_works(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "''", f"a credential leaked into the subprocess: {result.stdout!r}"
+
+
+def test_cli_help_without_api_key(tmp_path):
+    """`aixplain --help` must render usage and exit 0 with no credential set.
+
+    The eight CLI commands each declare `--api-key`, which can only be the sole
+    source of the key if the process survives long enough for click to parse
+    argv. The import-time `validate_api_keys()` call killed it first (BUG-946),
+    so a first-run user got a traceback instead of usage text.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from aixplain.cli_groups import cli; cli(['--help'])",
+        ],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert "has been set" not in output, f"--help still requires a credential:\n{output[-4000:]}"
+    assert "Usage:" in result.stdout, f"no usage text:\n{output[-4000:]}"
+    assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -114,3 +114,50 @@ def test_cli_help_without_api_key(tmp_path):
     assert "has been set" not in output, f"--help still requires a credential:\n{output[-4000:]}"
     assert "Usage:" in result.stdout, f"no usage text:\n{output[-4000:]}"
     assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"
+
+
+def test_cli_api_key_flag_is_the_sole_key_source(tmp_path):
+    """`--api-key K` must authenticate the request with no key in the environment.
+
+    All eight CLI commands declare the flag, but the import-time
+    `validate_api_keys()` call killed the process before click ever parsed argv,
+    so the flag could never be the only source of the credential (BUG-946). This
+    drives one command end to end and asserts the key reaches the outgoing
+    `x-api-key` header.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    child = """
+from unittest.mock import patch, Mock
+from click.testing import CliRunner
+from aixplain.cli_groups import cli
+
+captured = {}
+
+
+def fake_request(method, url, **kwargs):
+    captured["headers"] = kwargs.get("headers")
+    response = Mock()
+    response.text = "[]"
+    return response
+
+
+with patch("aixplain.factories.model_factory._request_with_retry", fake_request):
+    result = CliRunner().invoke(cli, ["list", "hosts", "--api-key", "cli-only-key"])
+
+print("EXIT", result.exit_code)
+print("EXC", repr(result.exception))
+print("KEY", (captured.get("headers") or {}).get("x-api-key"))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "EXIT 0" in result.stdout, f"CLI command failed:\n{result.stdout}\n{result.stderr[-2000:]}"
+    assert "KEY cli-only-key" in result.stdout, f"--api-key never reached the request:\n{result.stdout}"

--- a/tests/unit/utils/test_dotenv_scope.py
+++ b/tests/unit/utils/test_dotenv_scope.py
@@ -1,0 +1,89 @@
+"""Tests that ``.env`` loading is scoped to the working directory (BUG-939).
+
+A bare ``load_dotenv()`` walks *up* from the CWD, so a ``.env`` shipped inside a
+cloned sample project or a bug-report attachment could hand a user's own script a
+different ``BACKEND_URL`` and pick the ``TEAM_API_KEY`` out of the ancestor file.
+``find_dotenv(usecwd=True)`` is not a fix -- it still walks up when the CWD has no
+``.env`` of its own -- so these tests pin the explicit-path behaviour.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import aixplain
+
+PARENT_ENV = "BACKEND_URL=https://evil.example.com\nTEAM_API_KEY=STOLEN\n"
+
+
+@pytest.fixture
+def nested_tree(tmp_path):
+    """Create ``tmp_path/.env`` plus an empty ``tmp_path/child`` directory."""
+    (tmp_path / ".env").write_text(PARENT_ENV)
+    child = tmp_path / "child"
+    child.mkdir()
+    return tmp_path, child
+
+
+def test_parent_dotenv_is_not_loaded(nested_tree, monkeypatch):
+    """A ``.env`` one directory up must not reach the process environment."""
+    _, child = nested_tree
+    monkeypatch.chdir(child)
+    monkeypatch.delenv("BACKEND_URL", raising=False)
+    monkeypatch.delenv("TEAM_API_KEY", raising=False)
+
+    assert aixplain._load_cwd_dotenv() is False
+    assert os.environ.get("BACKEND_URL") is None
+    assert os.environ.get("TEAM_API_KEY") is None
+
+
+def test_cwd_dotenv_is_still_loaded(nested_tree, monkeypatch):
+    """The documented behaviour -- a ``.env`` in the working directory -- is kept."""
+    parent, _ = nested_tree
+    monkeypatch.chdir(parent)
+    monkeypatch.delenv("BACKEND_URL", raising=False)
+    monkeypatch.delenv("TEAM_API_KEY", raising=False)
+
+    assert aixplain._load_cwd_dotenv() is True
+    assert os.environ["BACKEND_URL"] == "https://evil.example.com"
+
+
+def test_existing_environment_wins(nested_tree, monkeypatch):
+    """``override=False`` is preserved: an exported value beats the file."""
+    parent, _ = nested_tree
+    monkeypatch.chdir(parent)
+    monkeypatch.setenv("BACKEND_URL", "https://platform-api.aixplain.com")
+
+    aixplain._load_cwd_dotenv()
+    assert os.environ["BACKEND_URL"] == "https://platform-api.aixplain.com"
+
+
+def test_import_from_nested_cwd_ignores_parent_dotenv(nested_tree):
+    """End-to-end: ``import aixplain`` from a subdirectory ignores the ancestor.
+
+    Exercises the real import path in a fresh interpreter rather than just the
+    helper, because the walk-up used to happen at import time.
+    """
+    _, child = nested_tree
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in ("BACKEND_URL", "TEAM_API_KEY", "AIXPLAIN_API_KEY", "MODELS_RUN_URL", "PIPELINES_RUN_URL")
+    }
+    # Point at *this* checkout, not whatever copy of the SDK happens to be
+    # installed, since the subprocess runs from a temporary directory.
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
+    result = subprocess.run(
+        [sys.executable, "-c", "import aixplain, os; print(os.environ.get('BACKEND_URL'))"],
+        cwd=str(child),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "evil.example.com" not in result.stdout
+    assert result.stdout.strip() == "None"

--- a/tests/unit/utils/test_upload_url_validation.py
+++ b/tests/unit/utils/test_upload_url_validation.py
@@ -1,0 +1,74 @@
+"""Tests that the presigned ``uploadUrl`` host is validated before the PUT (BUG-939).
+
+The URL comes straight out of a backend response. If the backend is compromised
+-- or ``BACKEND_URL`` was redirected by an ambient ``.env`` -- every dataset,
+database file, skill bundle and attachment would be PUT to the attacker while the
+SDK reported success, because ``_build_s3_link_from_presigned_url`` infers the
+bucket by regex and falls back to ``"aixplain-uploads"`` rather than raising.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aixplain.utils import file_utils
+from aixplain.utils.url_safety import UnsafeURLError
+from aixplain.v2.upload_utils import S3Uploader
+
+FOREIGN_URL = "https://evil.example.com/upload"
+GOOD_URL = "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc"
+
+
+def test_v2_uploader_refuses_a_foreign_host(tmp_path):
+    """``S3Uploader.upload_file`` raises before opening or sending the file."""
+    target = tmp_path / "data.csv"
+    target.write_text("a,b\n1,2\n")
+
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry") as request:
+        with pytest.raises(UnsafeURLError):
+            S3Uploader.upload_file(str(target), FOREIGN_URL, "text/csv")
+    request.assert_not_called()
+
+
+def test_v2_uploader_error_is_not_masked_as_a_generic_failure(tmp_path):
+    """The refusal must survive the ``except Exception -> FileUploadError`` wrapper."""
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry"):
+        with pytest.raises(UnsafeURLError) as excinfo:
+            S3Uploader.upload_file(str(target), FOREIGN_URL, "text/csv")
+    assert "evil.example.com" in str(excinfo.value)
+
+
+def test_v2_uploader_accepts_a_presigned_s3_url(tmp_path):
+    """The ordinary S3 target still works end to end."""
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    response = MagicMock(status_code=200)
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry", return_value=response) as request:
+        S3Uploader.upload_file(str(target), GOOD_URL, "text/csv")
+    request.assert_called_once()
+
+
+def test_upload_data_refuses_a_foreign_host_without_retrying(tmp_path):
+    """``file_utils.upload_data`` raises immediately and issues no PUT.
+
+    The generic handler in ``upload_data`` retries ``nattempts`` times and masks
+    the cause; a refused host is not transient, so it must bypass that path.
+    """
+    target = tmp_path / "data.csv"
+    target.write_text("a,b\n1,2\n")
+
+    post_response = MagicMock()
+    post_response.json.return_value = {"key": "some/key", "uploadUrl": FOREIGN_URL}
+
+    with patch.object(file_utils, "_request_with_retry", return_value=post_response) as request:
+        with pytest.raises(UnsafeURLError):
+            file_utils.upload_data(file_name=str(target), nattempts=2)
+
+    # Exactly one call: the POST that fetched the presigned URL. No PUT, and no
+    # recursive retry of the whole upload.
+    assert request.call_count == 1
+    assert request.call_args[0][0] == "post"

--- a/tests/unit/utils/test_upload_url_validation.py
+++ b/tests/unit/utils/test_upload_url_validation.py
@@ -72,3 +72,65 @@ def test_upload_data_refuses_a_foreign_host_without_retrying(tmp_path):
     # recursive retry of the whole upload.
     assert request.call_count == 1
     assert request.call_args[0][0] == "post"
+
+
+# --------------------------------------------------------------------------
+# Redirects
+#
+# ``validate_upload_url`` checks the host the SDK is about to PUT to. Leaving
+# ``allow_redirects`` at its ``requests`` default of True meant an allowed host
+# answering 307 could re-send the file bytes to a host that never passed the
+# check. A presigned S3 PUT never legitimately redirects (BUG-939).
+# --------------------------------------------------------------------------
+
+
+def test_v2_uploader_does_not_follow_redirects(tmp_path):
+    """``S3Uploader`` PUTs with redirects disabled."""
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    response = MagicMock(status_code=200)
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry", return_value=response) as request:
+        S3Uploader.upload_file(str(target), GOOD_URL, "text/csv")
+    assert request.call_args.kwargs["allow_redirects"] is False
+
+
+def test_upload_data_does_not_follow_redirects(tmp_path):
+    """``file_utils.upload_data`` PUTs with redirects disabled."""
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    post_response = MagicMock()
+    post_response.json.return_value = {"key": "some/key", "uploadUrl": GOOD_URL, "downloadUrl": "https://d/x"}
+    put_response = MagicMock(status_code=200)
+
+    def dispatch(method, *args, **kwargs):
+        return post_response if method == "post" else put_response
+
+    with patch.object(file_utils, "_request_with_retry", side_effect=dispatch) as request:
+        file_utils.upload_data(file_name=str(target))
+
+    put_call = [call for call in request.call_args_list if call[0][0] == "put"][0]
+    assert put_call.kwargs["allow_redirects"] is False
+
+
+def test_v2_file_upload_does_not_follow_redirects(tmp_path):
+    """``File._upload_local_file`` PUTs with redirects disabled."""
+    from types import SimpleNamespace
+
+    from aixplain.v2.file import File
+
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    client = MagicMock()
+    client.timeout = (1, 1)
+    client.get.return_value = {"allowed": True}
+    client.post.return_value = {"uploadUrl": GOOD_URL, "downloadUrl": "https://d/x"}
+
+    file = File(source=str(target))
+    file.context = SimpleNamespace(client=client)
+
+    with patch("aixplain.v2.file.requests.put", return_value=MagicMock(ok=True)) as put:
+        file._upload_local_file(str(target))
+    assert put.call_args.kwargs["allow_redirects"] is False

--- a/tests/unit/utils/test_url_safety.py
+++ b/tests/unit/utils/test_url_safety.py
@@ -221,6 +221,32 @@ def test_private_fetch_opt_in(resolver, monkeypatch):
     assert validate_fetch_url("http://10.0.0.1/code.py") == "http://10.0.0.1/code.py"
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "http://metadata.google.internal/computeMetadata/v1/",
+    ],
+)
+def test_private_fetch_opt_in_does_not_reopen_cloud_metadata(url, resolver, monkeypatch):
+    """The on-prem opt-in relaxes private ranges, not the credential endpoints.
+
+    An agent container running with the flag set would otherwise let a
+    model-generated URL read its own instance credentials and upload them.
+    """
+    monkeypatch.setenv(ALLOW_PRIVATE_FETCH_ENV_VAR, "1")
+    resolver({"metadata.google.internal": ["169.254.169.254"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url(url)
+
+
+def test_private_fetch_opt_in_still_allows_an_internal_name(resolver, monkeypatch):
+    """The flag's actual purpose keeps working: a private artifact host by name."""
+    monkeypatch.setenv(ALLOW_PRIVATE_FETCH_ENV_VAR, "1")
+    resolver({"artifacts.internal": ["10.1.2.3"]})
+    assert validate_fetch_url("http://artifacts.internal/code.py") == "http://artifacts.internal/code.py"
+
+
 # --------------------------------------------------------------------------
 # safe_get
 # --------------------------------------------------------------------------
@@ -318,6 +344,41 @@ def test_safe_get_follows_a_safe_redirect(resolver):
     )
     assert safe_get("https://example.com/x", session=session).text == "payload"
     assert adapter.requests == ["https://example.com/x", "https://cdn.example.com/y"]
+
+
+def test_safe_get_drops_headers_on_a_cross_host_redirect(resolver):
+    """Caller headers must not follow a redirect onto a different host."""
+    resolver({"example.com": ["93.184.216.34"], "cdn.example.net": ["93.184.216.35"]})
+    session, _ = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "https://cdn.example.net/y"}, b""),
+            "https://cdn.example.net/y": (200, {}, b"payload"),
+        }
+    )
+    seen = []
+    original = session.get
+    session.get = lambda url, **kwargs: (seen.append((url, kwargs.get("headers"))), original(url, **kwargs))[1]
+
+    safe_get("https://example.com/x", session=session, headers={"Authorization": "token SECRET"})
+    assert seen[0][1] == {"Authorization": "token SECRET"}
+    assert seen[1][1] is None
+
+
+def test_safe_get_keeps_headers_on_a_same_host_redirect(resolver):
+    """A redirect within the same host is not a credential boundary."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "https://example.com/y"}, b""),
+            "https://example.com/y": (200, {}, b"payload"),
+        }
+    )
+    seen = []
+    original = session.get
+    session.get = lambda url, **kwargs: (seen.append(kwargs.get("headers")), original(url, **kwargs))[1]
+
+    safe_get("https://example.com/x", session=session, headers={"Authorization": "token SECRET"})
+    assert seen == [{"Authorization": "token SECRET"}, {"Authorization": "token SECRET"}]
 
 
 def test_safe_get_caps_redirects(resolver):

--- a/tests/unit/utils/test_url_safety.py
+++ b/tests/unit/utils/test_url_safety.py
@@ -381,6 +381,29 @@ def test_safe_get_keeps_headers_on_a_same_host_redirect(resolver):
     assert seen == [{"Authorization": "token SECRET"}, {"Authorization": "token SECRET"}]
 
 
+def test_safe_get_drops_headers_on_an_https_to_http_downgrade(resolver):
+    """The netloc is unchanged, but the credential would go out in clear text.
+
+    ``validate_fetch_url`` permits ``http``, so ``https://host/x -> http://host/x``
+    passes the policy while turning the caller's ``Authorization`` header into
+    plaintext on the wire. The scheme is therefore part of the header scope.
+    """
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "http://example.com/x"}, b""),
+            "http://example.com/x": (200, {}, b"payload"),
+        }
+    )
+    seen = []
+    original = session.get
+    session.get = lambda url, **kwargs: (seen.append((url, kwargs.get("headers"))), original(url, **kwargs))[1]
+
+    safe_get("https://example.com/x", session=session, headers={"Authorization": "token SECRET"})
+    assert seen[0] == ("https://example.com/x", {"Authorization": "token SECRET"})
+    assert seen[1] == ("http://example.com/x", None)
+
+
 def test_safe_get_caps_redirects(resolver):
     """A redirect loop terminates instead of spinning."""
     resolver({"example.com": ["93.184.216.34"]})
@@ -396,6 +419,44 @@ def test_safe_get_enforces_max_bytes(resolver):
     session, _ = _session_with({"https://example.com/big": (200, {}, b"x" * 4096)})
     with pytest.raises(UnsafeURLError):
         safe_get("https://example.com/big", session=session, max_bytes=1024)
+
+
+def test_save_file_revalidates_redirect_targets(resolver, tmp_path, monkeypatch):
+    """``save_file`` is the v1 benchmark-report download sink (BUG-939).
+
+    ``benchmark_job`` validates ``reportUrl`` and then hands it to ``save_file``;
+    following a 302 from that host unvalidated would put the metadata endpoint's
+    body on disk (and, for the benchmark path, into a DataFrame).
+    """
+    from aixplain.utils import file_utils
+
+    resolver({"example.com": ["93.184.216.34"]})
+    session, adapter = _session_with(
+        {"https://example.com/report.csv": (302, {"Location": "http://169.254.169.254/latest/meta-data/"}, b"")}
+    )
+    monkeypatch.setattr(file_utils, "get_session", lambda: session)
+
+    with pytest.raises(UnsafeURLError):
+        file_utils.save_file("https://example.com/report.csv", tmp_path / "report.csv")
+    assert adapter.requests == ["https://example.com/report.csv"]
+
+
+def test_save_file_follows_a_safe_redirect(resolver, tmp_path, monkeypatch):
+    """An ordinary CDN redirect still downloads."""
+    from aixplain.utils import file_utils
+
+    resolver({"example.com": ["93.184.216.34"], "cdn.example.com": ["93.184.216.35"]})
+    session, _ = _session_with(
+        {
+            "https://example.com/report.csv": (302, {"Location": "https://cdn.example.com/report.csv"}, b""),
+            "https://cdn.example.com/report.csv": (200, {}, b"a,b\n1,2\n"),
+        }
+    )
+    monkeypatch.setattr(file_utils, "get_session", lambda: session)
+
+    target = tmp_path / "report.csv"
+    assert file_utils.save_file("https://example.com/report.csv", target) == target
+    assert target.read_bytes() == b"a,b\n1,2\n"
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/utils/test_url_safety.py
+++ b/tests/unit/utils/test_url_safety.py
@@ -1,0 +1,381 @@
+"""Tests for the central URL trust policy (BUG-939).
+
+Covers the three decisions in ``aixplain.utils.url_safety``: the configured
+endpoint policy, the SSRF guard applied to caller/response URLs (including the
+redirect re-check), and the presigned upload host allowlist.
+
+No test opens a non-loopback socket: ``socket.getaddrinfo`` is patched so the
+resolved-IP blocklist can be exercised deterministically and offline.
+"""
+
+import io
+import logging
+import socket
+
+import pytest
+import requests
+from urllib3.response import HTTPResponse
+
+from aixplain.utils import url_safety
+from aixplain.utils.url_safety import (
+    ALLOW_PRIVATE_FETCH_ENV_VAR,
+    INSECURE_OPT_IN_ENV_VAR,
+    UPLOAD_ALLOWLIST_ENV_VAR,
+    UnsafeURLError,
+    safe_get,
+    validate_config_url,
+    validate_fetch_url,
+    validate_upload_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Run every test with the security opt-ins off and no remembered warnings."""
+    for name in (INSECURE_OPT_IN_ENV_VAR, ALLOW_PRIVATE_FETCH_ENV_VAR, UPLOAD_ALLOWLIST_ENV_VAR):
+        monkeypatch.delenv(name, raising=False)
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+    yield
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+
+
+@pytest.fixture
+def resolver(monkeypatch):
+    """Patch ``socket.getaddrinfo`` with a host -> addresses mapping.
+
+    Returns a callable that installs the mapping; unknown hosts are treated as
+    literal addresses, which is what ``getaddrinfo`` does for an IP host anyway.
+    """
+
+    def _install(mapping):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            addresses = mapping.get(host)
+            if addresses is None:
+                try:
+                    socket.inet_pton(socket.AF_INET6 if ":" in host else socket.AF_INET, host)
+                except OSError:
+                    raise socket.gaierror(8, "nodename nor servname provided")
+                addresses = [host]
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port)) for address in addresses]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    return _install
+
+
+# --------------------------------------------------------------------------
+# validate_config_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://platform-api.aixplain.com",
+        "https://dev-platform-api.aixplain.com",
+        "https://test-platform-api.aixplain.com",
+        "https://models.aixplain.com/api/v2/execute",
+        "https://platform-api.aixplain.com/assets/pipeline/execution/run",
+    ],
+)
+def test_real_backends_validate_silently(url, caplog):
+    """Production, dev and test endpoints must pass with no warning at all."""
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        assert validate_config_url(url, "BACKEND_URL") == url
+    assert caplog.records == []
+
+
+def test_http_config_url_is_rejected_without_opt_in():
+    """Plain http would put the API key on the wire, so it fails closed."""
+    with pytest.raises(UnsafeURLError) as excinfo:
+        validate_config_url("http://platform-api.aixplain.com", "BACKEND_URL")
+    assert INSECURE_OPT_IN_ENV_VAR in str(excinfo.value)
+
+
+@pytest.mark.parametrize("url", ["http://platform-api.aixplain.com", "http://localhost:8000", "http://127.0.0.1:8000"])
+def test_http_config_url_is_allowed_with_opt_in(url, monkeypatch):
+    """The documented opt-in restores http, which is what local dev needs."""
+    monkeypatch.setenv(INSECURE_OPT_IN_ENV_VAR, "1")
+    assert validate_config_url(url, "BACKEND_URL") == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://platform-api.aixplain.com",
+        "file:///etc/passwd",
+        "https://",
+        "https://user:pw@evil.example.com/",
+        "not a url",
+        "",
+    ],
+)
+def test_structurally_invalid_config_urls_are_rejected(url):
+    """Non-http(s) schemes, missing hosts and embedded credentials all fail."""
+    with pytest.raises(UnsafeURLError):
+        validate_config_url(url, "BACKEND_URL")
+
+
+def test_foreign_host_warns_exactly_once(caplog):
+    """A non-aiXplain host is allowed but warned about, and only once."""
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        validate_config_url("https://evil.example.com", "BACKEND_URL")
+        validate_config_url("https://evil.example.com/other/path", "BACKEND_URL")
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "evil.example.com" in warnings[0].getMessage()
+
+
+def test_lookalike_host_is_not_treated_as_aixplain(caplog):
+    """``evil-aixplain.com`` must not match the ``aixplain.com`` suffix."""
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        validate_config_url("https://evil-aixplain.com", "BACKEND_URL")
+    assert len(caplog.records) == 1
+
+
+def test_loopback_under_opt_in_does_not_warn(caplog, monkeypatch):
+    """A local-dev endpoint is obviously not aiXplain; warning about it is noise."""
+    monkeypatch.setenv(INSECURE_OPT_IN_ENV_VAR, "1")
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        validate_config_url("http://localhost:8000", "BACKEND_URL")
+    assert caplog.records == []
+
+
+# --------------------------------------------------------------------------
+# validate_fetch_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://x/1", "ftp://example.com/x", "ldap://x/"])
+def test_non_http_schemes_are_rejected(url):
+    """``validators.url()`` rejects some of these; the guard rejects all of them."""
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1:8080/x",
+        "http://10.0.0.1/",
+        "http://172.16.0.1/",
+        "http://192.168.1.1/",
+        "http://0.0.0.0/",
+        "http://[::1]/",
+        "http://[fe80::1]/",
+    ],
+)
+def test_private_and_metadata_literals_are_rejected(url, resolver):
+    """Exactly the addresses ``validators.url()`` waves through (BUG-939)."""
+    resolver({})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url(url)
+
+
+def test_metadata_hostname_is_rejected(resolver):
+    """``metadata.google.internal`` is refused by name, before any resolution."""
+    resolver({"metadata.google.internal": ["93.184.216.34"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://metadata.google.internal/computeMetadata/v1/")
+
+
+def test_private_address_behind_a_public_name_is_rejected(resolver):
+    """The check is on the resolved address, not on how public the name looks."""
+    resolver({"internal.example.com": ["127.0.0.1"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://internal.example.com/x")
+
+
+def test_ipv4_mapped_ipv6_loopback_is_rejected(resolver):
+    """``::ffff:127.0.0.1`` is loopback and must be unwrapped before classifying."""
+    resolver({"sneaky.example.com": ["::ffff:127.0.0.1"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://sneaky.example.com/x")
+
+
+def test_any_private_answer_rejects_the_whole_host(resolver):
+    """A host with one public and one private record cannot be trusted."""
+    resolver({"split.example.com": ["93.184.216.34", "192.168.1.5"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://split.example.com/x")
+
+
+def test_unresolvable_host_is_rejected(resolver):
+    """A resolver failure must never read as a passed check."""
+    resolver({})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://does-not-exist.example/x")
+
+
+def test_public_host_is_accepted(resolver):
+    """The ordinary case still works."""
+    resolver({"example.com": ["93.184.216.34"]})
+    assert validate_fetch_url("https://example.com/code.py") == "https://example.com/code.py"
+
+
+def test_private_fetch_opt_in(resolver, monkeypatch):
+    """On-prem deployments can re-enable private targets deliberately."""
+    monkeypatch.setenv(ALLOW_PRIVATE_FETCH_ENV_VAR, "1")
+    resolver({})
+    assert validate_fetch_url("http://10.0.0.1/code.py") == "http://10.0.0.1/code.py"
+
+
+# --------------------------------------------------------------------------
+# safe_get
+# --------------------------------------------------------------------------
+
+
+class _RecordingAdapter(requests.adapters.BaseAdapter):
+    """Adapter that records every request and replies from a scripted map."""
+
+    def __init__(self, responses):
+        """Store the ``url -> (status, headers, body)`` script."""
+        super().__init__()
+        self.responses = responses
+        self.requests = []
+
+    def send(self, request, **kwargs):
+        """Record *request* and return the scripted response.
+
+        The body is served through a real ``urllib3`` response so that
+        ``iter_content`` -- the path ``safe_get`` uses to bound a download --
+        is exercised rather than bypassed.
+        """
+        self.requests.append(request.url)
+        status, headers, body = self.responses[request.url]
+        response = requests.Response()
+        response.status_code = status
+        response.headers.update(headers)
+        response.raw = HTTPResponse(
+            body=io.BytesIO(body),
+            headers=headers,
+            status=status,
+            preload_content=False,
+        )
+        response.url = request.url
+        response.request = request
+        return response
+
+    def close(self):
+        """No-op: nothing to release."""
+
+
+def _session_with(responses):
+    """Return a session whose http(s) traffic is served by a recording adapter."""
+    adapter = _RecordingAdapter(responses)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session, adapter
+
+
+def test_safe_get_returns_the_body(resolver):
+    """The happy path behaves like ``requests.get``."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with({"https://example.com/code.py": (200, {}, b"def main():\n    pass\n")})
+    response = safe_get("https://example.com/code.py", session=session)
+    assert response.text.startswith("def main()")
+
+
+def test_safe_get_passes_a_timeout(resolver):
+    """A caller-supplied URL must never be fetched without a bound."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with({"https://example.com/x": (200, {}, b"ok")})
+    captured = {}
+    original = session.get
+
+    def spy(url, **kwargs):
+        captured.update(kwargs)
+        return original(url, **kwargs)
+
+    session.get = spy
+    safe_get("https://example.com/x", session=session)
+    assert captured["timeout"] is not None
+    assert captured["allow_redirects"] is False
+
+
+def test_safe_get_revalidates_redirect_targets(resolver):
+    """A public host that redirects to the metadata endpoint is stopped there."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, adapter = _session_with(
+        {"https://example.com/x": (302, {"Location": "http://169.254.169.254/latest/meta-data/"}, b"")}
+    )
+    with pytest.raises(UnsafeURLError):
+        safe_get("https://example.com/x", session=session)
+    # The redirect was never followed onto the wire.
+    assert adapter.requests == ["https://example.com/x"]
+
+
+def test_safe_get_follows_a_safe_redirect(resolver):
+    """A redirect to another public host is followed, not blocked."""
+    resolver({"example.com": ["93.184.216.34"], "cdn.example.com": ["93.184.216.35"]})
+    session, adapter = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "https://cdn.example.com/y"}, b""),
+            "https://cdn.example.com/y": (200, {}, b"payload"),
+        }
+    )
+    assert safe_get("https://example.com/x", session=session).text == "payload"
+    assert adapter.requests == ["https://example.com/x", "https://cdn.example.com/y"]
+
+
+def test_safe_get_caps_redirects(resolver):
+    """A redirect loop terminates instead of spinning."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, adapter = _session_with({"https://example.com/x": (302, {"Location": "https://example.com/x"}, b"")})
+    with pytest.raises(UnsafeURLError):
+        safe_get("https://example.com/x", session=session, max_redirects=2)
+    assert len(adapter.requests) == 3
+
+
+def test_safe_get_enforces_max_bytes(resolver):
+    """A hostile endpoint cannot balloon the memory of the fetching process."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with({"https://example.com/big": (200, {}, b"x" * 4096)})
+    with pytest.raises(UnsafeURLError):
+        safe_get("https://example.com/big", session=session, max_bytes=1024)
+
+
+# --------------------------------------------------------------------------
+# validate_upload_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc",
+        "https://s3.us-east-1.amazonaws.com/bucket/key",
+        "https://uploads.aixplain.com/x",
+        "https://aixplain.com/x",
+    ],
+)
+def test_expected_upload_hosts_are_allowed(url):
+    """The hosts the backend actually hands out keep working."""
+    assert validate_upload_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example.com/x",
+        "https://evil.com/?x=amazonaws.com",
+        "https://notamazonaws.com/x",
+        "http://bucket.s3.amazonaws.com/x",
+        "ftp://bucket.s3.amazonaws.com/x",
+    ],
+)
+def test_foreign_upload_hosts_are_rejected(url):
+    """Anything else raises before a single byte is PUT."""
+    with pytest.raises(UnsafeURLError):
+        validate_upload_url(url)
+
+
+def test_upload_allowlist_env_var_extends_the_defaults(monkeypatch):
+    """A custom object store is supported without a fork."""
+    monkeypatch.setenv(UPLOAD_ALLOWLIST_ENV_VAR, "storage.example.com, *.cdn.example.org")
+    assert validate_upload_url("https://storage.example.com/x")
+    assert validate_upload_url("https://a.cdn.example.org/x")
+    with pytest.raises(UnsafeURLError):
+        validate_upload_url("https://other.example.com/x")

--- a/tests/unit/v2/test_agent_polling.py
+++ b/tests/unit/v2/test_agent_polling.py
@@ -334,7 +334,10 @@ class TestAgentSyncPollWithExecutionId:
 
         agent.sync_poll(full_url)
 
-        agent.context.client.get.assert_called_once_with(full_url)
+        # ``sync_poll`` also bounds the request by its remaining budget, so
+        # assert on the URL rather than the whole call signature.
+        assert agent.context.client.get.call_count == 1
+        assert agent.context.client.get.call_args.args == (full_url,)
 
     def test_sync_poll_with_execution_id(self):
         """sync_poll() with a bare execution ID should construct the correct URL."""
@@ -350,7 +353,8 @@ class TestAgentSyncPollWithExecutionId:
         agent.sync_poll("exec-id-1")
 
         expected_url = f"{BACKEND_URL}/sdk/agents/exec-id-1/result"
-        agent.context.client.get.assert_called_once_with(expected_url)
+        assert agent.context.client.get.call_count == 1
+        assert agent.context.client.get.call_args.args == (expected_url,)
 
     def test_sync_poll_does_not_use_sdk_runs_endpoint(self):
         """sync_poll() must NOT use /sdk/runs/{id}."""

--- a/tests/unit/v2/test_agent_team_invariant.py
+++ b/tests/unit/v2/test_agent_team_invariant.py
@@ -1,0 +1,96 @@
+"""Guard: the team-agent tasks/tools invariant is deliberately *not* enforced.
+
+``Agent._sync_file_references`` carried a commented-out check for eight months::
+
+    # TODO: Re-enable this validation after backend data consistency is fixed
+    # if self.agents and (self.tasks or self.tools):
+    #     raise ValueError(
+    #         "Team agents cannot have tasks or tools. ..."
+    #     )
+
+It was disabled inside an unrelated 88-file commit, no replacement exists
+anywhere, and v1 never had it either (BUG-946). Re-enabling it as written is not
+safe: ``_sync_file_references`` sits on the run and payload-build paths as well
+as save, and it would fire for team agents *hydrated from the backend* -- which
+is precisely the inconsistency the TODO was deferring.
+
+So the comment is gone and the non-enforcement is now an explicit, tested
+decision rather than an accident. Anyone re-introducing the invariant has to
+consciously change these tests, and the backend follow-up is tracked on the PR.
+"""
+
+import pytest
+
+from aixplain import Aixplain
+
+
+@pytest.fixture
+def aix() -> Aixplain:
+    """Return an isolated client."""
+    return Aixplain(api_key="test-key", backend_url="https://example.test")
+
+
+def _team_agent_with_everything(aix):
+    """A team agent carrying sub-agents *and* tools *and* tasks."""
+    return aix.Agent(
+        name="team-agent",
+        instructions="Coordinate the sub-agents.",
+        agents=["sub-agent-id"],
+        tools=[{"id": "tool-id", "type": "model"}],
+        tasks=[{"name": "summarize", "description": "Summarize", "expectedOutput": "A summary"}],
+    )
+
+
+def test_team_agent_with_tools_and_tasks_constructs(aix):
+    """Construction must not raise for the combination."""
+    agent = _team_agent_with_everything(aix)
+
+    assert agent.agents == ["sub-agent-id"]
+    assert agent.tools
+    assert agent.tasks
+
+
+def test_team_agent_with_tools_and_tasks_builds_a_payload(aix):
+    """``build_save_payload`` runs ``_sync_file_references``; it must not raise.
+
+    This is the call the invariant would have broken, and it must keep emitting
+    both collections.
+    """
+    payload = _team_agent_with_everything(aix).build_save_payload()
+
+    assert payload["agents"]
+    assert payload["tools"]
+
+
+def test_backend_team_agent_with_tools_hydrates(aix):
+    """Loading an existing, inconsistent team agent must keep working.
+
+    ``Agent.from_dict`` is the ``get()`` path. Raising here would make already
+    stored team agents unloadable -- the reason the guard was disabled.
+    """
+    agent = aix.Agent.from_dict(
+        {
+            "id": "team-agent-id",
+            "name": "team-agent",
+            "description": "A team agent",
+            "role": "Coordinate the sub-agents.",
+            "agents": ["sub-agent-id"],
+            "tools": [{"id": "tool-id", "type": "model"}],
+            "tasks": [{"name": "summarize", "description": "Summarize", "expectedOutput": "A summary"}],
+        }
+    )
+
+    assert agent.agents == ["sub-agent-id"]
+    assert agent.tools
+    assert agent.build_save_payload()["tools"]
+
+
+def test_stale_invariant_comment_is_gone():
+    """The dead TODO must not come back as a comment instead of a decision."""
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parents[3] / "aixplain" / "v2" / "agent.py"
+    text = source.read_text()
+
+    assert "Re-enable this validation" not in text
+    assert "Team agents cannot have tasks or tools" not in text

--- a/tests/unit/v2/test_aixplain_v2_lazy.py
+++ b/tests/unit/v2/test_aixplain_v2_lazy.py
@@ -1,0 +1,191 @@
+"""Guard: the deprecated ``aixplain.aixplain_v2`` must never be a silent ``None``.
+
+It used to be constructed eagerly at import and the failure swallowed::
+
+    aixplain_v2 = None
+    try:
+        aixplain_v2 = Aixplain()
+    except Exception:
+        pass
+
+With no credential that discarded a precise, actionable message -- ``AssertionError:
+API key is required. Pass api_key=... to Aixplain() or set TEAM_API_KEY or
+AIXPLAIN_API_KEY.`` -- and left a public symbol bound to ``None``, so the first
+consumer hit ``AttributeError: 'NoneType' object has no attribute 'Agent'`` far
+from the cause (BUG-946).
+
+A module-level ``__getattr__`` now builds it on first access, so ``import aixplain``
+still works without a key (``aixplain --help`` and unit-test collection depend on
+that) while the real error reaches whoever actually asks for the client.
+
+``Aixplain(api_key=...)`` mutates ``os.environ``, and ``aixplain/__init__.py``
+loads a working-directory ``.env``, so every keyless case runs in a subprocess
+with the variables stripped and ``python-dotenv`` neutered.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Imported by the interpreter at startup (via `site`), before anything else can
+# read the environment, so the `from dotenv import load_dotenv` in
+# aixplain/__init__.py binds the neutered version.
+SITECUSTOMIZE = """
+import dotenv
+
+dotenv.load_dotenv = lambda *args, **kwargs: False
+dotenv.main.load_dotenv = dotenv.load_dotenv
+"""
+
+
+def _credential_free_env(sitecustomize_dir: Path) -> dict:
+    env = os.environ.copy()
+    env.pop("TEAM_API_KEY", None)
+    env.pop("AIXPLAIN_API_KEY", None)
+    existing_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (str(sitecustomize_dir), existing_path) if p)
+    return env
+
+
+def _run(code: str, tmp_path: Path, with_key: bool = False) -> subprocess.CompletedProcess:
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+    env = _credential_free_env(tmp_path)
+    if with_key:
+        env["TEAM_API_KEY"] = "unit-test-key"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_succeeds_without_api_key(tmp_path):
+    """`import aixplain` must not require a credential."""
+    result = _run("import aixplain; print('imported')", tmp_path)
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "imported" in result.stdout
+
+
+def test_access_without_key_raises_the_real_error(tmp_path):
+    """Accessing the attribute with no key must raise -- not hand back ``None``."""
+    result = _run(
+        """
+import aixplain
+
+try:
+    client = aixplain.aixplain_v2
+except AssertionError as e:
+    print("RAISED:", e)
+else:
+    print("RETURNED:", repr(client))
+""",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "RAISED: API key is required" in result.stdout, result.stdout
+    assert "RETURNED" not in result.stdout
+
+
+def test_from_import_without_key_raises_too(tmp_path):
+    """`from aixplain import aixplain_v2` must go through the same hook."""
+    result = _run(
+        """
+try:
+    from aixplain import aixplain_v2
+except AssertionError as e:
+    print("RAISED:", e)
+else:
+    print("RETURNED:", repr(aixplain_v2))
+""",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "RAISED: API key is required" in result.stdout, result.stdout
+
+
+def test_star_import_without_key_still_works(tmp_path):
+    """`from aixplain import *` must not construct the deprecated client.
+
+    ``aixplain_v2`` is deliberately absent from ``__all__``: leaving it there
+    would make a star import raise for a keyless user who intends to construct
+    ``Aixplain(api_key=...)`` themselves.
+    """
+    result = _run(
+        "from aixplain import *; print(Aixplain.__name__, File.__name__)",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "Aixplain File" in result.stdout
+
+
+def test_returns_cached_client_when_key_is_set(tmp_path):
+    """With a key, the attribute yields one `Aixplain`, stable across accesses."""
+    result = _run(
+        """
+import aixplain
+from aixplain import Aixplain
+
+first = aixplain.aixplain_v2
+second = aixplain.aixplain_v2
+print(isinstance(first, Aixplain), first is second)
+""",
+        tmp_path,
+        with_key=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert result.stdout.strip().endswith("True True"), result.stdout
+
+
+def test_first_access_warns_deprecation(tmp_path):
+    """First access must emit a `DeprecationWarning` naming the replacement."""
+    result = _run(
+        """
+import warnings
+import aixplain
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    aixplain.aixplain_v2
+
+deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+print(len(deprecations))
+print(str(deprecations[0].message))
+""",
+        tmp_path,
+        with_key=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == "1", result.stdout
+    assert "'aixplain.aixplain_v2' is deprecated" in lines[1]
+    assert "Aixplain()" in lines[1]
+
+
+def test_unknown_attribute_still_raises_attribute_error():
+    """The hook must not swallow genuine typos."""
+    import aixplain
+
+    with pytest.raises(AttributeError, match="no attribute 'not_a_real_symbol'"):
+        aixplain.not_a_real_symbol
+
+
+def test_dir_advertises_aixplain_v2():
+    """`dir(aixplain)` must keep listing the lazily provided symbol."""
+    import aixplain
+
+    listed = dir(aixplain)
+    assert "aixplain_v2" in listed
+    assert "Aixplain" in listed

--- a/tests/unit/v2/test_backoff_jitter.py
+++ b/tests/unit/v2/test_backoff_jitter.py
@@ -1,0 +1,170 @@
+"""Unit tests for the jittered backoff helpers (BUG-942 item 1).
+
+Every poll interval in the SDK grew deterministically from a shared start, so a
+batch of clients launched together stayed phase-locked for the whole run. These
+tests pin the properties the fix relies on: the jitter is bounded, it is
+actually random, it preserves the mean, and it can never push a budgeted loop
+past its own deadline.
+"""
+
+import statistics
+from unittest.mock import patch
+
+import pytest
+
+from aixplain.v2._backoff import (
+    BACKOFF_CAP,
+    BACKOFF_FACTOR,
+    JITTER_SPREAD,
+    jitter,
+    next_wait,
+    sleep_with_jitter,
+)
+
+
+class TestJitter:
+    """Bounds and distribution of :func:`jitter`."""
+
+    @pytest.mark.parametrize("wait_time", [0.2, 0.5, 1.0, 60.0])
+    def test_stays_within_the_spread(self, wait_time):
+        """1,000 real-RNG samples must all land in ``[0.8w, 1.2w]``."""
+        samples = [jitter(wait_time) for _ in range(1000)]
+
+        assert min(samples) >= wait_time * (1 - JITTER_SPREAD)
+        assert max(samples) <= wait_time * (1 + JITTER_SPREAD)
+
+    def test_is_actually_random(self):
+        """A constant "jitter" would decorrelate nothing, so pin the spread."""
+        samples = [jitter(1.0) for _ in range(200)]
+
+        assert len(set(samples)) >= 100
+
+    def test_preserves_the_mean_interval(self):
+        """Symmetric multiplicative jitter must not slow a run down on average.
+
+        This is why the helper multiplies by ``U(0.8, 1.2)`` rather than using
+        AWS-style ``U(0, w)``, which would halve the mean interval and issue
+        *more* requests per run.
+        """
+        mean = statistics.fmean(jitter(10.0) for _ in range(5000))
+
+        assert 10.0 * 0.97 < mean < 10.0 * 1.03
+
+    @pytest.mark.parametrize("wait_time", [0.0, -1.0])
+    def test_non_positive_wait_returns_zero(self, wait_time):
+        """A zero/negative interval must not become a negative sleep."""
+        assert jitter(wait_time) == 0.0
+
+    def test_zero_spread_disables_jitter(self):
+        """``spread=0`` reproduces the old deterministic behaviour exactly."""
+        assert jitter(3.0, spread=0.0) == 3.0
+
+    @pytest.mark.parametrize("spread", [-5.0, 5.0])
+    def test_spread_is_clamped_to_a_sane_range(self, spread):
+        """An out-of-range spread must not produce a negative or absurd sleep."""
+        samples = [jitter(1.0, spread=spread) for _ in range(200)]
+
+        assert min(samples) >= 0.0
+        assert max(samples) <= 2.0
+
+    @pytest.mark.parametrize(
+        "uniform_result,expected",
+        [(0.8, 0.8), (1.0, 1.0), (1.2, 1.2)],
+    )
+    def test_uses_the_documented_uniform_range(self, uniform_result, expected):
+        """The extremes come straight from ``random.uniform(0.8, 1.2)``."""
+        with patch("aixplain.v2._backoff.random.uniform", return_value=uniform_result) as uniform:
+            assert jitter(1.0) == pytest.approx(expected)
+
+        uniform.assert_called_once_with(0.8, 1.2)
+
+
+class TestNextWait:
+    """The SDK-wide ``x1.1`` / 60s-capped backoff ladder."""
+
+    def test_grows_by_the_backoff_factor(self):
+        assert next_wait(1.0) == pytest.approx(BACKOFF_FACTOR)
+
+    def test_is_capped(self):
+        assert next_wait(59.0) == pytest.approx(BACKOFF_CAP)
+        assert next_wait(BACKOFF_CAP) == BACKOFF_CAP
+        assert next_wait(1000.0) == BACKOFF_CAP
+
+    def test_ladder_converges_on_the_cap_and_never_exceeds_it(self):
+        wait = 0.5
+        for _ in range(500):
+            wait = next_wait(wait)
+            assert wait <= BACKOFF_CAP
+        assert wait == BACKOFF_CAP
+
+
+class TestSleepWithJitter:
+    """The deadline clamp: jitter may shorten a sleep, never extend a timeout."""
+
+    def test_sleeps_the_jittered_interval(self):
+        with patch("aixplain.v2._backoff.time.sleep") as sleep:
+            slept = sleep_with_jitter(2.0)
+
+        sleep.assert_called_once()
+        assert sleep.call_args.args[0] == pytest.approx(slept)
+        assert 1.6 <= slept <= 2.4
+
+    def test_never_sleeps_past_the_remaining_budget(self):
+        """The whole point of ``max_sleep``: jitter cannot overrun a deadline."""
+        with patch("aixplain.v2._backoff.time.sleep") as sleep:
+            for _ in range(200):
+                slept = sleep_with_jitter(10.0, max_sleep=0.25)
+                assert slept <= 0.25
+
+        assert all(call.args[0] <= 0.25 for call in sleep.call_args_list)
+
+    def test_exhausted_budget_does_not_sleep_at_all(self):
+        with patch("aixplain.v2._backoff.time.sleep") as sleep:
+            assert sleep_with_jitter(5.0, max_sleep=0.0) == 0.0
+            assert sleep_with_jitter(5.0, max_sleep=-3.0) == 0.0
+
+        sleep.assert_not_called()
+
+    def test_zero_interval_does_not_sleep(self):
+        with patch("aixplain.v2._backoff.time.sleep") as sleep:
+            assert sleep_with_jitter(0.0) == 0.0
+
+        sleep.assert_not_called()
+
+    def test_no_max_sleep_means_no_clamp(self):
+        with patch("aixplain.v2._backoff.time.sleep"):
+            assert sleep_with_jitter(4.0, max_sleep=None) >= 3.2
+
+
+class TestFleetDecorrelation:
+    """The acceptance criterion, as an offline proxy.
+
+    Two clients started at the same instant must produce a *spread* sequence of
+    poll timestamps rather than aligned spikes. Simulated by summing the sleeps
+    each client would perform: identical sequences prove phase-lock.
+    """
+
+    @staticmethod
+    def _poll_offsets(polls=25, spread=JITTER_SPREAD):
+        """Cumulative sleep offsets one client would poll at."""
+        offsets, elapsed, wait = [], 0.0, 0.5
+        for _ in range(polls):
+            elapsed += jitter(wait, spread=spread)
+            offsets.append(elapsed)
+            wait = next_wait(wait)
+        return offsets
+
+    def test_two_simultaneous_clients_drift_apart(self):
+        a, b = self._poll_offsets(), self._poll_offsets()
+
+        assert a != b
+        # By the 25th poll the two have accumulated a visible phase difference,
+        # rather than both landing in the same instant.
+        assert abs(a[-1] - b[-1]) > 0.05
+
+    def test_without_jitter_the_clients_stay_phase_locked(self):
+        """Control: reproduces the pre-fix behaviour, so the test above means something."""
+        a = self._poll_offsets(spread=0.0)
+        b = self._poll_offsets(spread=0.0)
+
+        assert a == b

--- a/tests/unit/v2/test_client.py
+++ b/tests/unit/v2/test_client.py
@@ -17,6 +17,11 @@ from aixplain.v2.client import (
     DEFAULT_TIMEOUT_READ,
     DEFAULT_RETRY_BACKOFF_FACTOR,
     DEFAULT_RETRY_STATUS_FORCELIST,
+    DEFAULT_RETRY_BACKOFF_JITTER,
+    DEFAULT_RETRY_BACKOFF_MAX,
+    DEFAULT_RETRY_AFTER_MAX,
+    DEFAULT_POOL_CONNECTIONS,
+    DEFAULT_POOL_MAXSIZE,
     RETRY_ALLOWED_METHODS,
 )
 from aixplain.v2.exceptions import APIError
@@ -790,3 +795,202 @@ class TestDefaultTimeout:
         client = self._client()
 
         assert client.timeout == (DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ)
+
+
+class TestRateLimitAndJitteredRetry:
+    """Retry hardening for BUG-942 item 7 / BUG-1097.
+
+    A platform 5xx used to make every installed copy of the SDK retry inside the
+    same ~3s window -- nothing jittered, nothing honoured the server's own
+    backoff signal, and 429 was not retried at all. The recovery wave then
+    re-degraded the platform it was recovering.
+    """
+
+    def test_429_is_in_the_default_forcelist(self):
+        """A throttled poll must be retried, not hammered through."""
+        assert 429 in DEFAULT_RETRY_STATUS_FORCELIST
+
+    def test_429_retry_is_still_method_scoped(self):
+        """Adding 429 must not make a throttled submission re-billable."""
+        retry = create_retry_session().get_adapter("https://example.com").max_retries
+
+        assert retry.is_retry("GET", 429) is True
+        assert retry.is_retry("POST", 429) is False
+
+    def test_post_is_absent_from_the_module_constant(self):
+        """BUG-1097 acceptance criterion, asserted on the constant itself."""
+        assert "POST" not in RETRY_ALLOWED_METHODS
+        assert RETRY_ALLOWED_METHODS == frozenset({"GET"})
+
+    def test_backoff_is_jittered(self):
+        """Without jitter every client's retry lands in the same instant."""
+        retry = create_retry_session().get_adapter("https://example.com").max_retries
+
+        assert retry.backoff_jitter == DEFAULT_RETRY_BACKOFF_JITTER
+        assert retry.backoff_jitter > 0
+
+    def test_jitter_actually_spreads_the_computed_backoff(self):
+        """Pin the urllib3 semantics, not just our configuration of them."""
+        retry = create_retry_session().get_adapter("https://example.com").max_retries
+        exhausted = retry
+        for _ in range(3):
+            exhausted = exhausted.increment(method="GET", error=Exception("boom"))
+
+        samples = {exhausted.get_backoff_time() for _ in range(200)}
+
+        assert len(samples) > 1, "backoff is still deterministic"
+        assert max(samples) - min(samples) <= DEFAULT_RETRY_BACKOFF_JITTER + 1e-9
+
+    def test_retry_after_header_is_respected_but_bounded(self):
+        """urllib3's own ``retry_after_max`` default is six hours."""
+        retry = create_retry_session().get_adapter("https://example.com").max_retries
+
+        assert retry.respect_retry_after_header is True
+        assert retry.retry_after_max == DEFAULT_RETRY_AFTER_MAX
+        assert retry.retry_after_max <= 60.0
+
+    def test_hostile_retry_after_cannot_pin_a_thread(self):
+        """A 6-hour ``Retry-After`` must be clamped to the configured bound."""
+        retry = create_retry_session().get_adapter("https://example.com").max_retries
+
+        assert retry.parse_retry_after("21600") == DEFAULT_RETRY_AFTER_MAX
+
+    def test_exponential_backoff_is_bounded(self):
+        retry = create_retry_session().get_adapter("https://example.com").max_retries
+
+        assert retry.backoff_max == DEFAULT_RETRY_BACKOFF_MAX
+
+    def test_caller_kwargs_still_win_over_the_new_defaults(self):
+        """The new defaults must not collide with an explicit caller value."""
+        session = create_retry_session(backoff_jitter=0.9, retry_after_max=5.0)
+        retry = session.get_adapter("https://example.com").max_retries
+
+        assert retry.backoff_jitter == 0.9
+        assert retry.retry_after_max == 5.0
+
+
+class TestBuildRetryFallback:
+    """``_build_retry`` must degrade on an older urllib3, not raise.
+
+    ``backoff_jitter`` landed in urllib3 2.0 and ``retry_after_max`` in 2.1,
+    while the only declared bound is ``requests``' loose ``urllib3<3`` -- so an
+    environment resolving to 1.26 has to lose the jitter, not fail at import.
+    """
+
+    def test_unsupported_kwargs_are_dropped(self):
+        from aixplain.v2.client import _build_retry
+
+        retry = _build_retry(total=3, backoff_factor=0.1, kwarg_from_a_future_urllib3=1)
+
+        assert retry.total == 3
+        assert retry.backoff_factor == 0.1
+
+    def test_supported_kwargs_survive(self):
+        from aixplain.v2.client import _build_retry
+
+        retry = _build_retry(total=2, backoff_jitter=0.4, not_a_real_kwarg="x")
+
+        assert retry.total == 2
+        assert retry.backoff_jitter == 0.4
+
+    def test_simulated_urllib3_1_26_still_builds_a_session(self, monkeypatch):
+        """With the modern kwargs unknown, session creation must still succeed."""
+        import aixplain.v2.client as client_module
+
+        monkeypatch.setattr(
+            client_module,
+            "_RETRY_INIT_PARAMS",
+            frozenset({"self", "total", "backoff_factor", "status_forcelist", "allowed_methods"}),
+        )
+
+        session = create_retry_session()
+        retry = session.get_adapter("https://example.com").max_retries
+
+        assert retry.total == DEFAULT_RETRY_TOTAL
+        assert retry.allowed_methods == RETRY_ALLOWED_METHODS
+        # urllib3 2.x still exposes its own defaults; the point is we didn't raise.
+        assert isinstance(session, requests.Session)
+
+
+class TestConnectionPoolSizing:
+    """BUG-942 item 4: urllib3's 10/10 defaults discard connections above 10.
+
+    Above ``pool_maxsize`` in-flight requests the adapter opens a connection,
+    uses it once and throws it away rather than pooling it -- a fresh TLS
+    handshake per request plus a "Connection pool is full" warning each time,
+    peaking exactly when the poll burst does.
+    """
+
+    @pytest.mark.parametrize("url", ["https://example.com", "http://example.com"])
+    def test_pool_is_sized_explicitly(self, url):
+        adapter = create_retry_session().get_adapter(url)
+
+        assert adapter._pool_connections == DEFAULT_POOL_CONNECTIONS
+        assert adapter._pool_maxsize == DEFAULT_POOL_MAXSIZE
+        assert adapter._pool_block is False
+
+    def test_pool_is_larger_than_the_urllib3_default(self):
+        """The regression guard: 10/10 is what the ticket is about."""
+        assert DEFAULT_POOL_CONNECTIONS > 10
+        assert DEFAULT_POOL_MAXSIZE > 10
+
+    def test_underlying_urllib3_pool_honours_the_maxsize(self):
+        """Assert the value reaches urllib3, not just the adapter's attribute."""
+        adapter = create_retry_session().get_adapter("https://example.com")
+        pool = adapter.poolmanager.connection_from_url("https://example.com")
+
+        assert pool.pool.maxsize == DEFAULT_POOL_MAXSIZE
+        assert pool.block is False
+
+    @staticmethod
+    def _cycle_connections(pool, count):
+        """Check out and return *count* connections concurrently.
+
+        This is what 50 SDK threads do to a pool: each takes a connection for
+        the duration of a request and hands it back. Nothing is dialled -- the
+        defect is in the bookkeeping, not on the wire.
+        """
+        import threading
+
+        barrier = threading.Barrier(count)
+        conns = [None] * count
+
+        def hold(index):
+            conns[index] = pool._get_conn()
+            barrier.wait()  # all `count` are out at once
+            pool._put_conn(conns[index])
+
+        threads = [threading.Thread(target=hold, args=(i,)) for i in range(count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    def test_fifty_concurrent_requests_do_not_warn_about_a_full_pool(self, caplog):
+        """The acceptance criterion: no "Connection pool is full" at 50 threads.
+
+        urllib3 logs that at WARNING -- and discards the connection, forcing a
+        fresh TLS handshake next time -- whenever a returned connection has
+        nowhere to go.
+        """
+        session = create_retry_session()
+        pool = session.get_adapter("https://example.com").poolmanager.connection_from_url("https://example.com")
+
+        with caplog.at_level("WARNING", logger="urllib3.connectionpool"):
+            self._cycle_connections(pool, 50)
+
+        assert not [r for r in caplog.records if "pool is full" in r.getMessage().lower()], caplog.records
+
+    def test_control_the_old_default_does_warn_at_fifty_threads(self, caplog):
+        """Control case, so the assertion above is not vacuous.
+
+        The pre-fix adapter (urllib3's 10/10 default) discards ~40 of the 50.
+        """
+        from urllib3 import HTTPSConnectionPool
+
+        pool = HTTPSConnectionPool("example.com", maxsize=10, block=False)
+
+        with caplog.at_level("WARNING", logger="urllib3.connectionpool"):
+            self._cycle_connections(pool, 50)
+
+        assert [r for r in caplog.records if "pool is full" in r.getMessage().lower()]

--- a/tests/unit/v2/test_client.py
+++ b/tests/unit/v2/test_client.py
@@ -877,10 +877,17 @@ class TestBuildRetryFallback:
     environment resolving to 1.26 has to lose the jitter, not fail at import.
     """
 
-    def test_unsupported_kwargs_are_dropped(self):
+    def test_optional_kwargs_are_dropped_when_unsupported(self, monkeypatch):
+        import aixplain.v2.client as client_module
         from aixplain.v2.client import _build_retry
 
-        retry = _build_retry(total=3, backoff_factor=0.1, kwarg_from_a_future_urllib3=1)
+        monkeypatch.setattr(
+            client_module,
+            "_RETRY_INIT_PARAMS",
+            frozenset({"self", "total", "backoff_factor"}),
+        )
+
+        retry = _build_retry(total=3, backoff_factor=0.1, backoff_jitter=0.3, retry_after_max=60.0)
 
         assert retry.total == 3
         assert retry.backoff_factor == 0.1
@@ -888,10 +895,25 @@ class TestBuildRetryFallback:
     def test_supported_kwargs_survive(self):
         from aixplain.v2.client import _build_retry
 
-        retry = _build_retry(total=2, backoff_jitter=0.4, not_a_real_kwarg="x")
+        retry = _build_retry(total=2, backoff_jitter=0.4)
 
         assert retry.total == 2
         assert retry.backoff_jitter == 0.4
+
+    def test_an_unknown_kwarg_is_not_silently_swallowed(self):
+        """Only the SDK's own hardening kwargs are droppable.
+
+        Treating every unknown name as "an older urllib3" would turn a caller's
+        typo into a silently-ignored setting.
+        """
+        from aixplain.v2.client import _build_retry
+
+        with pytest.raises(TypeError):
+            _build_retry(total=2, bakoff_factor=0.5)
+
+    def test_a_typo_on_the_public_factory_still_raises(self):
+        with pytest.raises(TypeError):
+            create_retry_session(bakoff_jitter=0.9)
 
     def test_simulated_urllib3_1_26_still_builds_a_session(self, monkeypatch):
         """With the modern kwargs unknown, session creation must still succeed."""

--- a/tests/unit/v2/test_client_log_redaction.py
+++ b/tests/unit/v2/test_client_log_redaction.py
@@ -1,0 +1,148 @@
+"""Tests that the v2 client never logs credentials or bodies (BUG-939).
+
+The client used to ``logger.debug`` the whole ``kwargs`` dict -- which by that
+point carries the merged ``x-api-key`` header and the request body -- plus the
+full ``response.text``. With ``.env.example`` shipping ``LOG_LEVEL=DEBUG``, a
+single connected Slack tool wrote the user's third-party bot token and the team
+key into the application log.
+"""
+
+import logging
+
+import pytest
+from unittest.mock import Mock, patch
+
+from aixplain.v2.client import (
+    LOG_BODIES_ENV_VAR,
+    LOG_BODY_MAX_BYTES,
+    AixplainClient,
+)
+
+TEAM_KEY = "TEAMKEY_AAA"
+SLACK_TOKEN = "xoxb-USER-THIRD-PARTY-SECRET"
+RESPONSE_BODY = '{"accessKey": "ACCESSKEY_FOR_EVERY_KEY_ON_THE_ACCOUNT"}'
+REQUEST_BODY = {"name": "slack", "data": {"token": SLACK_TOKEN}}
+
+SECRETS = (TEAM_KEY, SLACK_TOKEN, "ACCESSKEY_FOR_EVERY_KEY_ON_THE_ACCOUNT", "x-api-key")
+
+
+@pytest.fixture(autouse=True)
+def bodies_off(monkeypatch):
+    """Ensure the body-logging opt-in is off unless a test sets it."""
+    monkeypatch.delenv(LOG_BODIES_ENV_VAR, raising=False)
+
+
+@pytest.fixture
+def client():
+    """A client pointed at a trusted origin, with a recognisable API key."""
+    return AixplainClient(base_url="https://platform-api.aixplain.com", team_api_key=TEAM_KEY)
+
+
+def _mock_response(body=RESPONSE_BODY, status=200):
+    """Return a mock response carrying *body* and *status*."""
+    response = Mock()
+    response.ok = 200 <= status < 400
+    response.status_code = status
+    response.text = body
+    response.content = body.encode()
+    response.headers = {"Content-Length": str(len(body))}
+    return response
+
+
+def _messages(caplog):
+    """Return every formatted log message captured so far."""
+    return [record.getMessage() for record in caplog.records]
+
+
+def test_no_record_contains_a_secret_or_a_body(client, caplog):
+    """The acceptance criterion: nothing sensitive reaches a log record."""
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw(
+                "POST",
+                "sdk/tools",
+                json=REQUEST_BODY,
+                headers={"Authorization": "Bearer abcdefghijklmnopqrst"},
+            )
+
+    joined = "\n".join(_messages(caplog))
+    for secret in SECRETS:
+        assert secret not in joined
+    assert RESPONSE_BODY not in joined
+    assert "slack" not in joined
+
+
+def test_outline_is_still_logged(client, caplog):
+    """Method, path, status and byte count remain available for debugging."""
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", json=REQUEST_BODY)
+
+    joined = "\n".join(_messages(caplog))
+    assert "POST" in joined
+    assert "sdk/tools" in joined
+    assert "200" in joined
+    assert f"{len(RESPONSE_BODY)} bytes" in joined
+
+
+def test_query_string_is_not_logged(client, caplog):
+    """Query strings carry presigned signatures and one-time tokens."""
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("GET", "https://platform-api.aixplain.com/sdk/x?X-Amz-Signature=SECRETSIG")
+
+    joined = "\n".join(_messages(caplog))
+    assert "SECRETSIG" not in joined
+    assert "/sdk/x" in joined
+
+
+def test_opt_in_logs_bodies_but_redacts_credentials(client, caplog, monkeypatch):
+    """With the opt-in on, bodies appear -- with credential values masked."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", json=REQUEST_BODY)
+
+    joined = "\n".join(_messages(caplog))
+    assert "slack" in joined  # the body really is logged now
+    assert SLACK_TOKEN not in joined
+    assert "***REDACTED***" in joined
+
+
+def test_opt_in_truncates_long_bodies(client, caplog, monkeypatch):
+    """A large response cannot flood the log even under the opt-in."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    big = "a" * (LOG_BODY_MAX_BYTES * 3)
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response(body=big)):
+            client.request_raw("GET", "sdk/x")
+
+    joined = "\n".join(_messages(caplog))
+    assert "(truncated)" in joined
+    assert len(joined) < len(big)
+
+
+def test_streaming_request_does_not_consume_the_body(client, caplog):
+    """The streaming path must not touch ``.content``/``.text`` to log a size."""
+    response = Mock()
+    response.ok = True
+    response.status_code = 200
+    response.headers = {}
+    type(response).content = property(lambda self: pytest.fail("streaming body was consumed"))
+    type(response).text = property(lambda self: pytest.fail("streaming body was consumed"))
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=response):
+            client.request_stream("GET", "sdk/stream")
+
+    assert any("sdk/stream" in message for message in _messages(caplog))
+
+
+def test_env_example_does_not_ship_debug_logging():
+    """``.env.example`` was the documented way to turn the leak on."""
+    from pathlib import Path
+
+    env_example = Path(__file__).resolve().parents[3] / ".env.example"
+    lines = [line.strip() for line in env_example.read_text().splitlines() if not line.strip().startswith("#")]
+    assert "LOG_LEVEL=DEBUG" not in lines
+    assert "LOG_LEVEL=INFO" in lines

--- a/tests/unit/v2/test_client_log_redaction.py
+++ b/tests/unit/v2/test_client_log_redaction.py
@@ -146,3 +146,75 @@ def test_env_example_does_not_ship_debug_logging():
     lines = [line.strip() for line in env_example.read_text().splitlines() if not line.strip().startswith("#")]
     assert "LOG_LEVEL=DEBUG" not in lines
     assert "LOG_LEVEL=INFO" in lines
+
+
+def test_opt_in_redacts_credential_keys_in_a_serialised_body(client, caplog, monkeypatch):
+    """A body that arrives already serialised is still redacted *by key*.
+
+    ``response.text`` and ``data=<json string>`` are plain strings, so key-based
+    redaction only applies once they are parsed back. ``APIKey.list()`` returns
+    the ``accessKey`` of every key on the account as JSON text, and it matches
+    none of the token patterns.
+    """
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    serialised = '{"headers": {"x-api-key": "%s"}, "note": "hi"}' % TEAM_KEY
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", data=serialised)
+
+    joined = "\n".join(_messages(caplog))
+    assert "hi" in joined  # the body really is logged
+    for secret in SECRETS:
+        if secret == "x-api-key":
+            continue  # the key *name* is fine; the value is not
+        assert secret not in joined
+
+
+def test_opt_in_redacts_a_non_json_body(client, caplog, monkeypatch):
+    """A body that is not JSON still gets pattern redaction."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response(body="plain " + SLACK_TOKEN)):
+            client.request_raw("GET", "sdk/x")
+
+    joined = "\n".join(_messages(caplog))
+    assert SLACK_TOKEN not in joined
+    assert "***REDACTED***" in joined
+
+
+def test_opt_in_does_not_crash_on_a_binary_body(client, caplog, monkeypatch):
+    """A ``data=`` payload of raw bytes must not raise from the log path."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/upload", data=b"\xff\xfe\x00binary")
+
+    assert any("sdk/upload" in message for message in _messages(caplog))
+
+
+def test_opt_in_never_lets_the_log_path_break_the_request(client, caplog, monkeypatch):
+    """Rendering a pathological body degrades to a placeholder, not a traceback."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+
+    class Explodes:
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", data=Explodes())
+
+    joined = "\n".join(_messages(caplog))
+    assert "could not be redacted" in joined
+
+
+def test_opt_in_survives_a_deeply_nested_response_body(client, caplog, monkeypatch):
+    """``json.loads`` raises RecursionError on deep nesting; the caller must not see it."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    deep = "[" * 5000 + "]" * 5000
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response(body=deep)):
+            response = client.request_raw("GET", "sdk/x")
+
+    assert response.status_code == 200

--- a/tests/unit/v2/test_file.py
+++ b/tests/unit/v2/test_file.py
@@ -67,7 +67,7 @@ def test_save_local_file_promotes_upload_to_asset(tmp_path, aix):
     aix.client.get = Mock(return_value={"allowed": True})
     aix.client.post = Mock(
         side_effect=[
-            {"uploadUrl": "https://upload.test", "downloadUrl": "s3://bucket/temp/data.csv"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/upload", "downloadUrl": "s3://bucket/temp/data.csv"},
             _asset("file-1", "data.csv"),
         ]
     )
@@ -104,7 +104,7 @@ def test_save_local_file_sends_description_tags_and_privacy(tmp_path, aix):
     aix.client.get = Mock(return_value={"allowed": True})
     aix.client.post = Mock(
         side_effect=[
-            {"uploadUrl": "https://upload.test", "downloadUrl": "s3://bucket/temp/report.pdf"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/upload", "downloadUrl": "s3://bucket/temp/report.pdf"},
             _asset("file-1", "report.pdf"),
         ]
     )
@@ -157,9 +157,9 @@ def test_save_directory_preserves_parent_relationships_and_empty_folders(tmp_pat
             _asset("empty-id", "empty", "folder"),
             _asset("policies-id", "policies", "folder"),
             _asset("regional-id", "regional", "folder"),
-            {"uploadUrl": "https://upload.test/one", "downloadUrl": "s3://one"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/one", "downloadUrl": "s3://one"},
             _asset("security", "security.pdf"),
-            {"uploadUrl": "https://upload.test/two", "downloadUrl": "s3://two"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/two", "downloadUrl": "s3://two"},
             _asset("eu", "eu.txt"),
         ]
     )

--- a/tests/unit/v2/test_integration_poll_jitter.py
+++ b/tests/unit/v2/test_integration_poll_jitter.py
@@ -1,0 +1,133 @@
+"""Unit tests for ``ActionMixin._poll_for_data`` (BUG-942 item 1).
+
+This loop was the worst of the four v2 sites: a *fixed* 1s tick with no backoff
+at all, so a batch of clients not only stayed phase-locked, they polled at a
+constant 1 req/s each for the whole 30s budget.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aixplain.v2.integration import ActionMixin
+
+POLL_URL = "https://platform-api.aixplain.com/sdk/actions/exec-1"
+PENDING = {"completed": False, "status": "IN_PROGRESS"}
+DONE = {"completed": True, "status": "SUCCESS", "data": {"rows": 1}}
+
+
+class _Poller(ActionMixin):
+    """ActionMixin bound to a mock client returning *responses* in order."""
+
+    def __init__(self, responses):
+        self.actions_available = True
+        self.context = Mock()
+        self.context.client.request = Mock(side_effect=list(responses))
+
+
+class TestShortCircuits:
+    """Unchanged behaviour for anything that isn't an async poll URL."""
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"completed": True, "data": {"x": 1}},
+            {"completed": False, "data": {"x": 1}},
+            {"completed": False, "data": "not-a-url"},
+            {"completed": False, "data": None},
+        ],
+    )
+    def test_returns_data_without_polling(self, response):
+        poller = _Poller([])
+
+        assert poller._poll_for_data(response) == response["data"]
+        poller.context.client.request.assert_not_called()
+
+
+class TestJitteredBackoff:
+    """The sleep must be jittered, backed off, and deadline-clamped."""
+
+    def test_uses_the_jittered_sleep_helper(self):
+        poller = _Poller([DONE])
+
+        with patch("aixplain.v2.integration.sleep_with_jitter", return_value=0.0) as sleeper:
+            with patch("aixplain.v2.integration.time.sleep") as bare_sleep:
+                data = poller._poll_for_data({"completed": False, "data": POLL_URL})
+
+        assert data == {"rows": 1}
+        assert sleeper.call_count == 1
+        bare_sleep.assert_not_called()
+
+    def test_interval_now_backs_off(self):
+        """It used to be a flat 1s tick with no growth whatsoever."""
+        poller = _Poller([PENDING, PENDING, DONE])
+        waits = []
+
+        with patch(
+            "aixplain.v2.integration.sleep_with_jitter",
+            side_effect=lambda w, **k: waits.append(w) or 0.0,
+        ):
+            poller._poll_for_data({"completed": False, "data": POLL_URL}, timeout=600)
+
+        assert waits == sorted(waits)
+        assert waits[0] == pytest.approx(1.0)
+        assert waits[1] == pytest.approx(1.1)
+        assert waits[2] == pytest.approx(1.21)
+
+    def test_sleep_is_clamped_to_the_remaining_budget(self):
+        poller = _Poller([PENDING] * 20 + [DONE])
+        clamps = []
+
+        with patch(
+            "aixplain.v2.integration.sleep_with_jitter",
+            side_effect=lambda w, **k: clamps.append(k.get("max_sleep")) or 0.0,
+        ):
+            poller._poll_for_data({"completed": False, "data": POLL_URL}, timeout=5, wait_time=30)
+
+        assert clamps
+        assert all(c is not None and c <= 5 for c in clamps)
+
+    def test_real_delays_are_spread_across_clients(self):
+        observed = []
+
+        for _ in range(2):
+            poller = _Poller([PENDING, PENDING, DONE])
+            delays = []
+            with patch("aixplain.v2._backoff.time.sleep", side_effect=delays.append):
+                poller._poll_for_data({"completed": False, "data": POLL_URL}, timeout=600)
+            observed.append(delays)
+
+        assert observed[0] != observed[1]
+
+
+class TestBudget:
+    """The loop must still honour its ``timeout``."""
+
+    def test_exhausted_budget_returns_none_without_polling(self):
+        poller = _Poller([DONE])
+
+        assert poller._poll_for_data({"completed": False, "data": POLL_URL}, timeout=0) is None
+        poller.context.client.request.assert_not_called()
+
+    def test_returns_none_when_the_budget_expires(self):
+        poller = _Poller([PENDING] * 50)
+
+        with patch("aixplain.v2.integration.sleep_with_jitter", return_value=0.0):
+            clock = {"t": 0.0}
+            with patch("aixplain.v2.integration.time.time", lambda: clock["t"]):
+
+                def advance(*_args, **_kwargs):
+                    clock["t"] += 5.0
+                    return PENDING
+
+                poller.context.client.request = Mock(side_effect=advance)
+                assert poller._poll_for_data({"completed": False, "data": POLL_URL}, timeout=30) is None
+
+        assert poller.context.client.request.call_count == 6
+
+    @pytest.mark.parametrize("terminal", [{"completed": True, "data": "d"}, {"status": "SUCCESS", "data": "d"}])
+    def test_both_terminal_shapes_still_return_data(self, terminal):
+        poller = _Poller([terminal])
+
+        with patch("aixplain.v2.integration.sleep_with_jitter", return_value=0.0):
+            assert poller._poll_for_data({"completed": False, "data": POLL_URL}) == "d"

--- a/tests/unit/v2/test_no_unjittered_poll_sleeps.py
+++ b/tests/unit/v2/test_no_unjittered_poll_sleeps.py
@@ -1,0 +1,87 @@
+"""Guard test: no unjittered network sleep left in the v2 poll paths (BUG-942).
+
+A bare ``time.sleep(wait_time)`` in a poll loop is what keeps a fleet of clients
+phase-locked: ``wait_time`` grows deterministically from a shared start, so a
+batch launched together never drifts apart and the platform sees synchronized
+waves. Every network-facing sleep in the files below must go through
+``aixplain.v2._backoff.sleep_with_jitter``.
+
+Modelled on ``test_no_unbounded_requests.py``: AST-based, so a comment or a
+string literal can't trip it, and scoped to a fixed file list so it has no
+false-positive surface.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The v2 modules that sleep between network polls.
+GUARDED_FILES = [
+    "aixplain/v2/resource.py",
+    "aixplain/v2/integration.py",
+    "aixplain/v2/agent_progress.py",
+]
+
+# ``agent_progress`` animates a local spinner at 20 FPS. Those sleeps issue no
+# requests, so there is no fleet to decorrelate -- jittering them would only
+# make the animation stutter.
+ALLOWED_SLEEP_ARGS = frozenset({"DISPLAY_REFRESH_RATE"})
+
+
+def _bare_sleep_calls(path):
+    """``time.sleep(...)`` nodes in *path* that are not on the allowlist."""
+    tree = ast.parse((REPO_ROOT / path).read_text())
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "sleep"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "time"):
+            continue
+        arg = node.args[0] if node.args else None
+        # ``time.sleep(self.DISPLAY_REFRESH_RATE)`` / ``time.sleep(X.DISPLAY_REFRESH_RATE)``
+        if isinstance(arg, ast.Attribute) and arg.attr in ALLOWED_SLEEP_ARGS:
+            continue
+        if isinstance(arg, ast.Name) and arg.id in ALLOWED_SLEEP_ARGS:
+            continue
+        offenders.append(node.lineno)
+    return offenders
+
+
+@pytest.mark.parametrize("path", GUARDED_FILES)
+def test_no_unjittered_sleep_in_v2_poll_paths(path):
+    offenders = _bare_sleep_calls(path)
+
+    assert not offenders, f"{path} sleeps without jitter at line(s) {offenders}; use sleep_with_jitter"
+
+
+@pytest.mark.parametrize("path", GUARDED_FILES)
+def test_guarded_files_import_the_jitter_helper(path):
+    """A file that polls must actually have the helper available.
+
+    Without this, deleting every sleep would satisfy the test above vacuously.
+    """
+    source = (REPO_ROOT / path).read_text()
+
+    assert "sleep_with_jitter" in source, f"{path} has no jittered sleep"
+
+
+def test_the_guard_detects_a_regression():
+    """Meta-test: the AST walk really does flag a bare sleep."""
+    tree = ast.parse("import time\nwait = 5\ntime.sleep(wait)\n")
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "sleep"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "time"
+    ]
+
+    assert offenders == [3]

--- a/tests/unit/v2/test_no_v1_imports.py
+++ b/tests/unit/v2/test_no_v1_imports.py
@@ -19,6 +19,13 @@ V2_PACKAGE_DIR = Path(__file__).resolve().parents[3] / "aixplain" / "v2"
 #   core.py — optional try/except guarded sync of api key to v1 config
 EXCLUDED_FILES = {"enums_include.py", "core.py"}
 
+# Modules under ``aixplain.utils`` that v2 *may* import. The rule exists to keep
+# the v1 env-var validation chain out of v2, and ``aixplain.utils.url_safety``
+# imports nothing from ``aixplain`` at all -- it is the shared URL trust policy
+# used by v1, v2 and ``aixplain/utils`` alike (BUG-939), so it cannot pull that
+# chain in. ``test_url_safety_stays_v1_free`` below keeps that true.
+ALLOWED_SHARED_MODULES = {"aixplain.utils.url_safety"}
+
 # Patterns that constitute a v1 import.
 # Matches:  from aixplain.modules  / from aixplain.factories
 #           from aixplain.enums    / from aixplain.utils
@@ -54,6 +61,8 @@ def _find_v1_imports_via_ast(filepath):
     violations = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module in ALLOWED_SHARED_MODULES:
+                continue
             parts = node.module.split(".")
             # e.g. from aixplain.modules.model.utils import ...
             if (
@@ -71,6 +80,8 @@ def _find_v1_imports_via_ast(filepath):
                 violations.append(f"  line {node.lineno}: from {node.module} import {names}")
         elif isinstance(node, ast.Import):
             for alias in node.names:
+                if alias.name in ALLOWED_SHARED_MODULES:
+                    continue
                 parts = alias.name.split(".")
                 if (
                     len(parts) >= 2
@@ -95,3 +106,23 @@ def test_no_v1_imports(rel_name, filepath):
     """``aixplain/v2/{rel_name}`` must not import from v1 modules."""
     violations = _find_v1_imports_via_ast(filepath)
     assert not violations, f"v1 imports found in aixplain/v2/{rel_name}:\n" + "\n".join(violations)
+
+
+def test_url_safety_stays_v1_free():
+    """The one shared module v2 may import must not reach into v1 itself.
+
+    ``aixplain.utils.url_safety`` is exempted from the rule above only because it
+    imports nothing from ``aixplain``; if that ever changes, the exemption would
+    silently reopen the v1 import chain for every v2 module that uses it.
+    """
+    path = V2_PACKAGE_DIR.parent / "utils" / "url_safety.py"
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+
+    assert not [name for name in imported if name.split(".")[0] == "aixplain"]

--- a/tests/unit/v2/test_ssrf_call_sites.py
+++ b/tests/unit/v2/test_ssrf_call_sites.py
@@ -24,6 +24,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 # Every module that fetches a URL chosen by a caller or by a response body.
 GUARDED_SINK_FILES = [
     "aixplain/v2/code_utils.py",
+    "aixplain/v2/file.py",
     "aixplain/v2/rlm.py",
     "aixplain/v1/modules/model/utils.py",
     "aixplain/v1/modules/model/rlm.py",
@@ -113,6 +114,19 @@ def test_v2_file_source_url_is_guarded(tmp_path):
     file.context = SimpleNamespace(client=SimpleNamespace(timeout=(1, 1)))
     with pytest.raises(UnsafeURLError):
         file.save()
+
+
+def test_v2_file_source_goes_through_safe_get():
+    """The fetch is wired to ``safe_get``, so every redirect is re-validated.
+
+    A one-shot ``validate_fetch_url(self.source)`` followed by ``requests.get``
+    was bypassable: a public host answering 302 with
+    ``http://169.254.169.254/...`` had the fetched body uploaded to the platform.
+    """
+    from aixplain.utils.url_safety import safe_get
+    from aixplain.v2 import file as file_module
+
+    assert file_module.safe_get is safe_get
 
 
 def _fetch_sinks(path):

--- a/tests/unit/v2/test_ssrf_call_sites.py
+++ b/tests/unit/v2/test_ssrf_call_sites.py
@@ -1,0 +1,124 @@
+"""Tests that every caller/response URL sink goes through the SSRF guard (BUG-939).
+
+``validators.url()`` is a syntax check, and against the pinned validators 0.35.0
+it returns True for ``http://169.254.169.254/latest/meta-data/``,
+``http://127.0.0.1:8080/x`` and ``http://10.0.0.1/``. Each sink below used to
+fetch such a URL directly; these tests assert that the request is now refused
+before any socket is opened.
+"""
+
+import ast
+import socket
+from pathlib import Path
+
+import pytest
+import requests
+
+from aixplain.utils.url_safety import UnsafeURLError
+
+METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Every module that fetches a URL chosen by a caller or by a response body.
+GUARDED_SINK_FILES = [
+    "aixplain/v2/code_utils.py",
+    "aixplain/v2/rlm.py",
+    "aixplain/v1/modules/model/utils.py",
+    "aixplain/v1/modules/model/rlm.py",
+    "aixplain/v1/modules/agent/tool/sql_tool.py",
+    "aixplain/v1/factories/model_factory/utils.py",
+]
+
+
+@pytest.fixture(autouse=True)
+def no_sockets(monkeypatch):
+    """Fail loudly if any of these code paths actually tries to connect."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("an outbound request was attempted")
+
+    monkeypatch.setattr(requests.Session, "send", explode)
+    monkeypatch.setattr(socket, "create_connection", explode)
+
+
+def test_parse_code_refuses_a_metadata_url():
+    """The v2 utility-model sink no longer fetches the cloud metadata endpoint."""
+    from aixplain.v2.code_utils import parse_code
+
+    with pytest.raises(UnsafeURLError):
+        parse_code(METADATA_URL)
+
+
+def test_parse_code_decorated_refuses_a_private_url():
+    """The decorated variant is the second sink in the same module."""
+    from aixplain.v2.code_utils import parse_code_decorated
+
+    with pytest.raises(UnsafeURLError):
+        parse_code_decorated("http://127.0.0.1:8080/tool.py")
+
+
+def test_rlm_url_context_is_guarded():
+    """``_resolve_url_context`` fetches a caller-supplied URL, so it is gated."""
+    from aixplain.v2.rlm import RLM
+
+    with pytest.raises(UnsafeURLError):
+        RLM._resolve_url_context(METADATA_URL)
+
+
+def test_v1_parse_code_refuses_a_private_url():
+    """v1 gets the same guard, as a one-line call-site change."""
+    from aixplain.v1.modules.model.utils import parse_code
+
+    with pytest.raises(UnsafeURLError):
+        parse_code("http://10.0.0.1/code.py")
+
+
+def test_v1_model_factory_version_link_is_guarded():
+    """A ``version.id`` taken from a response is a blind-SSRF port scanner otherwise.
+
+    The surrounding ``except Exception: code = ""`` is left in place (v1 is
+    unmaintained), so the guard has to refuse the request rather than rely on an
+    informative exception reaching the caller.
+    """
+    from aixplain.utils.url_safety import safe_get
+    from aixplain.v1.factories.model_factory import utils as factory_utils
+
+    assert factory_utils.safe_get is safe_get
+    with pytest.raises(UnsafeURLError):
+        factory_utils.safe_get("http://127.0.0.1:22/")
+
+
+def test_v1_benchmark_report_url_is_guarded():
+    """``reportUrl`` is also a response field, so it is validated before download."""
+    from aixplain.utils.url_safety import validate_fetch_url
+    from aixplain.v1.modules import benchmark_job
+
+    assert benchmark_job.validate_fetch_url is validate_fetch_url
+    with pytest.raises(UnsafeURLError):
+        benchmark_job.validate_fetch_url("http://169.254.169.254/latest/meta-data/")
+
+
+def _fetch_sinks(path):
+    """Return the ``requests.<verb>(...)`` dispatch nodes in *path*.
+
+    String literals are ignored, which matters because ``rlm.py`` embeds worker
+    source code that legitimately calls ``requests.get`` *inside the sandbox*.
+    """
+    tree = ast.parse((REPO_ROOT / path).read_text())
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        target = node.func
+        if target.attr not in ("get",) or not isinstance(target.value, ast.Name):
+            continue
+        if target.value.id == "requests":
+            found.append(node.lineno)
+    return found
+
+
+@pytest.mark.parametrize("path", GUARDED_SINK_FILES)
+def test_no_direct_requests_get_remains(path):
+    """Guard test: these modules must reach remote URLs only via ``safe_get``."""
+    assert _fetch_sinks(path) == [], f"{path} still calls requests.get directly"

--- a/tests/unit/v2/test_ssrf_call_sites.py
+++ b/tests/unit/v2/test_ssrf_call_sites.py
@@ -9,6 +9,7 @@ before any socket is opened.
 
 import ast
 import socket
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
@@ -97,6 +98,21 @@ def test_v1_benchmark_report_url_is_guarded():
     assert benchmark_job.validate_fetch_url is validate_fetch_url
     with pytest.raises(UnsafeURLError):
         benchmark_job.validate_fetch_url("http://169.254.169.254/latest/meta-data/")
+
+
+def test_v2_file_source_url_is_guarded(tmp_path):
+    """``File(source=<url>).save()`` fetches a caller URL and uploads the body.
+
+    Same sink shape as the utility-model code fetch, in a different module: it
+    is what would turn ``File("http://169.254.169.254/...")`` into an
+    instance-credentials upload.
+    """
+    from aixplain.v2.file import File
+
+    file = File(source=METADATA_URL)
+    file.context = SimpleNamespace(client=SimpleNamespace(timeout=(1, 1)))
+    with pytest.raises(UnsafeURLError):
+        file.save()
 
 
 def _fetch_sinks(path):

--- a/tests/unit/v2/test_stream_progress_bounds.py
+++ b/tests/unit/v2/test_stream_progress_bounds.py
@@ -115,20 +115,37 @@ class TestDeadline:
         tracker = _tracker(poll_interval=0.01)
 
         with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
-            result = tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=0.05)
+            with pytest.raises(TimeoutError):
+                tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=0.05)
 
-        assert result.status == "IN_PROGRESS"
         assert tracker._poll_count >= 1
 
-    def test_timeout_logs_a_warning_rather_than_raising(self, caplog):
-        """A documented public method that has never raised still doesn't."""
+    def test_timeout_raises_like_sync_poll(self, caplog):
+        """The two polling surfaces must agree: an expired budget is an error.
+
+        Returning the last IN_PROGRESS response made ``stream_progress`` report a
+        timeout as a result, while ``sync_poll`` raised ``TimeoutError`` for the
+        same situation.
+        """
         tracker = _tracker(poll_interval=0.01)
 
         with caplog.at_level("WARNING", logger="aixplain.v2.agent_progress"):
             with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+                with pytest.raises(TimeoutError) as excinfo:
+                    tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=0.01)
+
+        assert "IN_PROGRESS" in str(excinfo.value)
+        assert any("timed out" in record.message for record in caplog.records)
+
+    def test_the_display_thread_is_stopped_on_timeout(self):
+        """The ``finally`` block still runs when the deadline raises."""
+        tracker = _tracker(poll_interval=0.01)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            with pytest.raises(TimeoutError):
                 tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=0.01)
 
-        assert any("timed out" in record.message for record in caplog.records)
+        assert tracker._stop_display.is_set()
 
     def test_deadline_is_measured_from_the_start_with_a_fake_clock(self):
         """Exactly two polls fit a 10s budget when each poll advances the clock 6s."""
@@ -143,9 +160,10 @@ class TestDeadline:
 
         with patch.object(type(tracker), "_now", lambda self: clock["t"]):
             with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
-                tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=10.0)
+                with pytest.raises(TimeoutError):
+                    tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=10.0)
 
-        # Poll 1 at t=6 (4s left), poll 2 at t=12 -> budget exhausted, return.
+        # Poll 1 at t=6 (4s left), poll 2 at t=12 -> budget exhausted, raise.
         assert tracker._poll_count == 2
 
     def test_timeout_none_preserves_unbounded_behaviour(self):

--- a/tests/unit/v2/test_stream_progress_bounds.py
+++ b/tests/unit/v2/test_stream_progress_bounds.py
@@ -1,0 +1,233 @@
+"""Unit tests for ``stream_progress`` termination guarantees (BUG-942 item 2).
+
+``stream_progress`` was a ``while True`` at ``poll_interval=0.05`` -- 20
+requests/second per job -- with no ``timeout`` parameter at all. Worse,
+``self._poll_count += 1`` sat *inside* ``if steps:``, so a backend returning a
+valid non-terminal response with no ``steps`` array never advanced the counter
+and ``max_polls`` was unreachable: the loop ran forever.
+
+Every test below drives a poll function that returns ``IN_PROGRESS`` and **no
+steps**, which is precisely the shape that used to hang.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from aixplain.v2.agent_progress import AgentProgressTracker, ProgressFormat
+
+
+class _Response:
+    """Minimal poll response: a status and an optional steps payload."""
+
+    def __init__(self, status="IN_PROGRESS", steps=None):
+        self.status = status
+        self.data = {"intermediate_steps": steps or []}
+
+
+def _tracker(responses=None, **kwargs):
+    """Tracker whose poll returns *responses* in order, then repeats the last."""
+    responses = list(responses or [_Response()])
+    calls = []
+
+    def poll(url):
+        calls.append(url)
+        index = min(len(calls) - 1, len(responses) - 1)
+        return responses[index]
+
+    tracker = AgentProgressTracker(poll_func=poll, **kwargs)
+    tracker._poll_calls = calls
+    return tracker
+
+
+class TestDefaults:
+    """The 20 req/s default is the load defect; pin the new one."""
+
+    def test_default_poll_interval_is_at_least_half_a_second(self):
+        tracker = _tracker()
+
+        assert tracker.poll_interval >= 0.5
+        assert AgentProgressTracker.DEFAULT_POLL_INTERVAL >= 0.5
+
+    def test_default_poll_interval_is_not_the_display_refresh_rate(self):
+        """0.05s is the local spinner's cadence, never a network cadence."""
+        assert AgentProgressTracker.DEFAULT_POLL_INTERVAL != AgentProgressTracker.DISPLAY_REFRESH_RATE
+
+    def test_stream_progress_has_a_default_timeout(self):
+        """Unlike before, the method is bounded even if the caller says nothing."""
+        import inspect
+
+        default = inspect.signature(AgentProgressTracker.stream_progress).parameters["timeout"].default
+
+        assert default is not None
+        assert default > 0
+
+
+class TestUnconditionalPollCount:
+    """``max_polls`` must terminate the loop even with no ``steps``."""
+
+    def test_max_polls_fires_without_any_steps(self):
+        """The regression test: this looped forever before the fix."""
+        tracker = _tracker(max_polls=3, poll_interval=0.0)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            result = tracker.stream_progress("http://poll", format=ProgressFormat.NONE)
+
+        assert tracker._poll_count == 3
+        assert len(tracker._poll_calls) == 3
+        assert result.status == "IN_PROGRESS"
+
+    @pytest.mark.parametrize("max_polls", [1, 2, 5])
+    def test_poll_count_matches_max_polls_exactly(self, max_polls):
+        tracker = _tracker(max_polls=max_polls, poll_interval=0.0)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            tracker.stream_progress("http://poll", format=ProgressFormat.NONE)
+
+        assert len(tracker._poll_calls) == max_polls
+
+    def test_counter_matches_the_sibling_update_method(self):
+        """``update()`` always incremented; the inconsistency *was* the bug."""
+        tracker = _tracker()
+        tracker.start(format=ProgressFormat.LOGS)
+
+        tracker.update(_Response())
+        tracker.update(_Response())
+
+        assert tracker._poll_count == 2
+
+    def test_steps_bearing_responses_still_count_once_each(self):
+        """Moving the increment must not double-count a response with steps."""
+        steps = [{"agent": "a", "tool": "t", "input": "i", "output": "o"}]
+        tracker = _tracker([_Response(steps=steps)], max_polls=4, poll_interval=0.0)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            tracker.stream_progress("http://poll", format=ProgressFormat.NONE)
+
+        assert tracker._poll_count == 4
+        assert len(tracker._poll_calls) == 4
+
+
+class TestDeadline:
+    """The ``timeout`` parameter, enforced as a wall-clock deadline."""
+
+    def test_timeout_terminates_the_loop(self):
+        tracker = _tracker(poll_interval=0.01)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            result = tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=0.05)
+
+        assert result.status == "IN_PROGRESS"
+        assert tracker._poll_count >= 1
+
+    def test_timeout_logs_a_warning_rather_than_raising(self, caplog):
+        """A documented public method that has never raised still doesn't."""
+        tracker = _tracker(poll_interval=0.01)
+
+        with caplog.at_level("WARNING", logger="aixplain.v2.agent_progress"):
+            with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+                tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=0.01)
+
+        assert any("timed out" in record.message for record in caplog.records)
+
+    def test_deadline_is_measured_from_the_start_with_a_fake_clock(self):
+        """Exactly two polls fit a 10s budget when each poll advances the clock 6s."""
+        clock = {"t": 0.0}
+        responses = [_Response()]
+
+        def poll(url):
+            clock["t"] += 6.0
+            return responses[0]
+
+        tracker = AgentProgressTracker(poll_func=poll, poll_interval=1.0)
+
+        with patch.object(type(tracker), "_now", lambda self: clock["t"]):
+            with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+                tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=10.0)
+
+        # Poll 1 at t=6 (4s left), poll 2 at t=12 -> budget exhausted, return.
+        assert tracker._poll_count == 2
+
+    def test_timeout_none_preserves_unbounded_behaviour(self):
+        """Opt-out escape hatch; ``max_polls`` is then the only bound."""
+        tracker = _tracker(max_polls=4, poll_interval=0.0)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=None)
+
+        assert tracker._poll_count == 4
+
+    def test_terminal_status_still_wins_over_the_deadline(self):
+        tracker = _tracker([_Response(status="SUCCESS")], poll_interval=0.0)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            result = tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=60)
+
+        assert result.status == "SUCCESS"
+        assert tracker._poll_count == 1
+
+    @pytest.mark.parametrize("status", ["FAILED", "ABORTED", "CANCELLED", "ERROR"])
+    def test_terminal_failures_still_return_immediately(self, status):
+        tracker = _tracker([_Response(status=status)], poll_interval=0.0)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0):
+            result = tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=60)
+
+        assert result.status == status
+        assert tracker._poll_count == 1
+
+
+class TestSleepBehaviour:
+    """The sleep must be jittered, backed off, and deadline-clamped."""
+
+    def test_sleep_is_jittered_not_a_bare_time_sleep(self):
+        tracker = _tracker(max_polls=3, poll_interval=0.5)
+
+        with patch("aixplain.v2.agent_progress.sleep_with_jitter", return_value=0.0) as sleeper:
+            with patch("aixplain.v2.agent_progress.time.sleep") as bare_sleep:
+                tracker.stream_progress("http://poll", format=ProgressFormat.NONE)
+
+        # One sleep per poll except the last, which returns instead.
+        assert sleeper.call_count == 2
+        bare_sleep.assert_not_called()
+
+    def test_interval_backs_off_and_is_capped(self):
+        tracker = _tracker(max_polls=6, poll_interval=0.5)
+        waits = []
+
+        with patch(
+            "aixplain.v2.agent_progress.sleep_with_jitter",
+            side_effect=lambda w, **k: waits.append(w) or 0.0,
+        ):
+            tracker.stream_progress("http://poll", format=ProgressFormat.NONE)
+
+        assert waits == sorted(waits)
+        assert waits[0] == pytest.approx(0.5)
+        assert waits[1] == pytest.approx(0.55)
+        assert all(w <= 60.0 for w in waits)
+
+    def test_sleep_is_clamped_to_the_remaining_budget(self):
+        tracker = _tracker(max_polls=3, poll_interval=30.0)
+        clamps = []
+
+        with patch(
+            "aixplain.v2.agent_progress.sleep_with_jitter",
+            side_effect=lambda w, **k: clamps.append(k.get("max_sleep")) or 0.0,
+        ):
+            tracker.stream_progress("http://poll", format=ProgressFormat.NONE, timeout=5.0)
+
+        assert clamps
+        assert all(c is not None and c <= 5.0 for c in clamps)
+
+    def test_a_sub_refresh_rate_interval_is_floored(self):
+        """A caller asking for 0.001s must not reinstate a 1,000 req/s loop."""
+        tracker = _tracker(max_polls=2, poll_interval=0.001)
+        waits = []
+
+        with patch(
+            "aixplain.v2.agent_progress.sleep_with_jitter",
+            side_effect=lambda w, **k: waits.append(w) or 0.0,
+        ):
+            tracker.stream_progress("http://poll", format=ProgressFormat.NONE)
+
+        assert waits[0] >= AgentProgressTracker.DISPLAY_REFRESH_RATE

--- a/tests/unit/v2/test_sync_poll_budget.py
+++ b/tests/unit/v2/test_sync_poll_budget.py
@@ -93,6 +93,63 @@ class TestPollRequestTimeout:
         assert agent.context.client.get.call_args.kwargs["timeout"][1] == 1.0
 
 
+class TestPollHonoursTheClientTimeout:
+    """The cap must come from the client, not from the module default.
+
+    A deployment that narrowed ``AixplainClient(timeout=...)`` did so to bound
+    its own requests; reading ``default_timeout()`` instead would silently
+    widen a poll back out to the 300s module default.
+    """
+
+    @staticmethod
+    def _agent_with_client_timeout(timeout):
+        agent = _create_agent([SUCCESS])
+        agent.context.client.timeout = timeout
+        return agent
+
+    def test_tuple_timeout_is_honoured(self):
+        agent = self._agent_with_client_timeout((3.0, 20.0))
+
+        agent.poll("exec-1", timeout=999.0)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (3.0, 20.0)
+
+    def test_scalar_timeout_is_honoured_for_both_phases(self):
+        agent = self._agent_with_client_timeout(15.0)
+
+        agent.poll("exec-1", timeout=999.0)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (15.0, 15.0)
+
+    def test_a_budget_below_the_client_bound_still_wins(self):
+        agent = self._agent_with_client_timeout((3.0, 200.0))
+
+        agent.poll("exec-1", timeout=7.0)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (3.0, 7.0)
+
+    @pytest.mark.parametrize("configured", [None, "not-a-timeout", (1.0, 2.0, 3.0)])
+    def test_unrecognisable_client_timeout_falls_back_to_the_defaults(self, configured):
+        """A mock or a malformed value must still produce a bounded request."""
+        agent = self._agent_with_client_timeout(configured)
+
+        agent.poll("exec-1", timeout=999.0)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (
+            DEFAULT_TIMEOUT_CONNECT,
+            DEFAULT_TIMEOUT_READ,
+        )
+
+    def test_a_real_client_reports_its_own_configuration(self):
+        """End-to-end through the actual client, not a mock."""
+        from aixplain.v2.client import AixplainClient
+        from aixplain.v2.resource import _client_timeout_bounds
+
+        client = AixplainClient(base_url=BACKEND_URL, team_api_key="k", timeout=(2.0, 8.0))
+
+        assert _client_timeout_bounds(client) == (2.0, 8.0)
+
+
 class TestSyncPollBudget:
     """A single poll must not be able to over-run the caller's ``timeout``."""
 
@@ -182,6 +239,62 @@ class TestSyncPollBudget:
         for wait_time, max_sleep in recorded:
             assert max_sleep is not None
             assert max_sleep <= 50
+
+
+class TestDeadlineWinsOverTheErrorItCauses:
+    """The bound must not change which exception a timed-out run reports.
+
+    Each poll is now bounded by the remaining budget, so the last poll before
+    the deadline can fail *because* the deadline arrived. That must still
+    surface as the documented ``TimeoutError``, not as an ``APIError`` about a
+    read timeout.
+    """
+
+    def test_read_timeout_at_the_deadline_raises_timeout_error(self):
+        import requests
+
+        from aixplain.v2.exceptions import APIError
+
+        agent = _create_agent()
+        # Budget gone by the time the (bounded) request gives up.
+        clock = {"t": 0.0}
+
+        def hang(path, **kwargs):
+            clock["t"] += 40.0
+            raise requests.exceptions.ReadTimeout("read timed out")
+
+        agent.context.client.get = Mock(side_effect=hang)
+
+        with patch("aixplain.v2.resource.time.time", lambda: clock["t"]):
+            with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+                with pytest.raises(AixplainTimeoutError):
+                    agent.sync_poll("exec-1", timeout=30, wait_time=0.5)
+
+        assert agent.context.client.get.call_count == 1
+        # Sanity: the underlying failure really is an APIError from ``poll``.
+        with pytest.raises(APIError):
+            agent.poll("exec-1", timeout=5.0)
+
+    def test_an_api_error_inside_the_budget_still_propagates(self):
+        """Only budget exhaustion softens the error; a live failure must not."""
+        from aixplain.v2.exceptions import APIError
+
+        agent = _create_agent([APIError("upstream exploded", 500, {})])
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            with pytest.raises(APIError):
+                agent.sync_poll("exec-1", timeout=300, wait_time=0.5)
+
+    def test_untrusted_url_is_never_softened_into_a_timeout(self):
+        """A refused credential leak must stay a security error, budget or not."""
+        from aixplain.v2.exceptions import UntrustedURLError
+
+        agent = _create_agent()
+        agent.context.client.ensure_trusted_url = Mock(side_effect=UntrustedURLError("nope"))
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            with pytest.raises(UntrustedURLError):
+                agent.sync_poll("exec-1", timeout=30, wait_time=0.5)
 
 
 class TestSyncPollJitter:

--- a/tests/unit/v2/test_sync_poll_budget.py
+++ b/tests/unit/v2/test_sync_poll_budget.py
@@ -6,7 +6,10 @@ Two defects are pinned here:
   its request with no ``timeout``, so the client's own 300s read timeout
   applied.  With the 300s ``sync_poll`` default one hung poll consumed the whole
   budget -- and up to ``DEFAULT_RETRY_TOTAL`` times that, since GET is still
-  retryable at the transport layer (BUG-1097, second-order item).
+  retryable at the transport layer (BUG-1097, second-order item). The read
+  timeout is therefore divided by ``retry_total + 1``: bounding one *request*
+  is not the same as bounding the wall clock when urllib3 re-sends it
+  underneath ``requests``.
 * The sleep between polls was deterministic, keeping a fleet phase-locked
   (BUG-942 item 1).
 """
@@ -19,7 +22,7 @@ import pytest
 from dataclasses_json import dataclass_json
 
 from aixplain.v2.agent import Agent
-from aixplain.v2.client import DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ
+from aixplain.v2.client import DEFAULT_RETRY_TOTAL, DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ
 from aixplain.v2.exceptions import TimeoutError as AixplainTimeoutError
 
 BACKEND_URL = "https://platform-api.aixplain.com"
@@ -39,6 +42,9 @@ def _create_agent(responses=None):
     agent = BoundAgent(id="agent-123", name="test-agent")
     agent.context = Mock()
     agent.context.backend_url = BACKEND_URL
+    # A Mock attribute is not an int, so spell the transport retry budget out
+    # rather than leaning on ``_client_retry_attempts``'s fallback.
+    agent.context.client.retry_total = DEFAULT_RETRY_TOTAL
     if responses is not None:
         agent.context.client.get = Mock(side_effect=list(responses))
     return agent
@@ -66,11 +72,15 @@ class TestPollRequestTimeout:
         assert "timeout" not in agent.context.client.get.call_args.kwargs
 
     def test_poll_with_timeout_passes_a_connect_read_tuple(self):
+        """The budget is a *wall-clock* bound, so it is split across attempts."""
         agent = _create_agent([SUCCESS])
 
         agent.poll("exec-1", timeout=42.0)
 
-        assert agent.context.client.get.call_args.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, 42.0)
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (
+            DEFAULT_TIMEOUT_CONNECT,
+            42.0 / (DEFAULT_RETRY_TOTAL + 1),
+        )
 
     def test_read_timeout_is_capped_at_the_client_default(self):
         """A caller's budget must not widen the bound the deployment configured."""
@@ -126,7 +136,10 @@ class TestPollHonoursTheClientTimeout:
 
         agent.poll("exec-1", timeout=7.0)
 
-        assert agent.context.client.get.call_args.kwargs["timeout"] == (3.0, 7.0)
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (
+            3.0,
+            7.0 / (DEFAULT_RETRY_TOTAL + 1),
+        )
 
     @pytest.mark.parametrize("configured", [None, "not-a-timeout", (1.0, 2.0, 3.0)])
     def test_unrecognisable_client_timeout_falls_back_to_the_defaults(self, configured):
@@ -137,7 +150,7 @@ class TestPollHonoursTheClientTimeout:
 
         assert agent.context.client.get.call_args.kwargs["timeout"] == (
             DEFAULT_TIMEOUT_CONNECT,
-            DEFAULT_TIMEOUT_READ,
+            999.0 / (DEFAULT_RETRY_TOTAL + 1),
         )
 
     def test_a_real_client_reports_its_own_configuration(self):
@@ -148,6 +161,69 @@ class TestPollHonoursTheClientTimeout:
         client = AixplainClient(base_url=BACKEND_URL, team_api_key="k", timeout=(2.0, 8.0))
 
         assert _client_timeout_bounds(client) == (2.0, 8.0)
+
+
+class TestTransportRetriesDoNotMultiplyTheBudget:
+    """The wall-clock budget must survive urllib3's retries (BUG-1097).
+
+    ``GET`` is in ``RETRY_ALLOWED_METHODS``, so a ``ReadTimeoutError`` is
+    re-sent up to ``retry_total`` more times *below* ``requests``. A read
+    timeout equal to the whole remaining budget therefore let a hung endpoint
+    block ``timeout * (retry_total + 1)`` seconds before ``sync_poll`` looked at
+    its deadline again -- ~30 minutes for the 300s default.
+    """
+
+    @staticmethod
+    def _agent_with_retry_total(total):
+        agent = _create_agent([SUCCESS])
+        agent.context.client.retry_total = total
+        agent.context.client.timeout = (10.0, 10000.0)  # never the binding constraint
+        return agent
+
+    @pytest.mark.parametrize("retry_total", [0, 1, 3, 5, 10])
+    def test_read_timeout_times_attempts_never_exceeds_the_budget(self, retry_total):
+        agent = self._agent_with_retry_total(retry_total)
+
+        agent.poll("exec-1", timeout=600.0)
+
+        read = agent.context.client.get.call_args.kwargs["timeout"][1]
+        assert read * (retry_total + 1) <= 600.0
+
+    def test_a_zero_retry_client_gets_the_whole_budget(self):
+        """Nothing is given away when the transport cannot re-send at all."""
+        agent = self._agent_with_retry_total(0)
+
+        agent.poll("exec-1", timeout=600.0)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"][1] == 600.0
+
+    def test_the_default_client_budget_is_not_multiplied_by_six(self):
+        """The reported symptom: ``sync_poll(timeout=300)`` blocking ~30 minutes."""
+        agent = self._agent_with_retry_total(DEFAULT_RETRY_TOTAL)
+
+        agent.poll("exec-1", timeout=300.0)
+
+        read = agent.context.client.get.call_args.kwargs["timeout"][1]
+        assert read == 50.0
+        assert read * (DEFAULT_RETRY_TOTAL + 1) == 300.0
+
+    @pytest.mark.parametrize("configured", [None, "five", -1, True])
+    def test_an_unusable_retry_total_falls_back_conservatively(self, configured):
+        """A mock or a nonsense value must shorten the bound, never widen it."""
+        from aixplain.v2.resource import _client_retry_attempts
+
+        agent = self._agent_with_retry_total(configured)
+
+        assert _client_retry_attempts(agent.context.client) == DEFAULT_RETRY_TOTAL + 1
+
+    def test_a_real_client_reports_its_own_retry_total(self):
+        """End-to-end through the actual client, not a mock."""
+        from aixplain.v2.client import AixplainClient
+        from aixplain.v2.resource import _client_retry_attempts
+
+        client = AixplainClient(base_url=BACKEND_URL, team_api_key="k", retry_total=2)
+
+        assert _client_retry_attempts(client) == 3
 
 
 class TestSyncPollBudget:
@@ -174,8 +250,9 @@ class TestSyncPollBudget:
             with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
                 agent.sync_poll("exec-1", timeout=100, wait_time=0.5)
 
+        attempts = DEFAULT_RETRY_TOTAL + 1
         reads = _read_timeouts(agent.context.client.get)
-        assert reads == [100.0, 90.0, 80.0]
+        assert reads == [100.0 / attempts, 90.0 / attempts, 80.0 / attempts]
 
     def test_never_exceeds_the_client_read_timeout(self):
         """Even a huge ``sync_poll`` budget stays inside the transport bound."""
@@ -284,6 +361,37 @@ class TestDeadlineWinsOverTheErrorItCauses:
         with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
             with pytest.raises(APIError):
                 agent.sync_poll("exec-1", timeout=300, wait_time=0.5)
+
+    def test_the_final_failure_is_chained_onto_the_timeout(self):
+        """A 401 on the last poll must stay visible, not become "timed out"."""
+        from aixplain.v2.exceptions import APIError
+
+        agent = _create_agent()
+        clock = {"t": 0.0}
+
+        def expire(poll_url, timeout=None):
+            clock["t"] += 40.0
+            raise APIError("Unauthorized", 401, {})
+
+        with patch("aixplain.v2.resource.time.time", lambda: clock["t"]):
+            with patch.object(type(agent), "poll", side_effect=expire):
+                with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+                    with pytest.raises(AixplainTimeoutError) as excinfo:
+                        agent.sync_poll("exec-1", timeout=30, wait_time=0.5)
+
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, APIError)
+        assert cause.status_code == 401
+        assert "Unauthorized" in str(cause)
+
+    def test_a_plain_timeout_has_no_spurious_cause(self):
+        """Nothing failed, so nothing is chained."""
+        agent = _create_agent([SUCCESS])
+
+        with pytest.raises(AixplainTimeoutError) as excinfo:
+            agent.sync_poll("exec-1", timeout=0)
+
+        assert excinfo.value.__cause__ is None
 
     def test_untrusted_url_is_never_softened_into_a_timeout(self):
         """A refused credential leak must stay a security error, budget or not."""

--- a/tests/unit/v2/test_sync_poll_budget.py
+++ b/tests/unit/v2/test_sync_poll_budget.py
@@ -1,0 +1,335 @@
+"""Unit tests for ``sync_poll``'s time budget and jittered sleeps.
+
+Two defects are pinned here:
+
+* ``sync_poll`` checked its deadline only *between* polls, and ``poll()`` sent
+  its request with no ``timeout``, so the client's own 300s read timeout
+  applied.  With the 300s ``sync_poll`` default one hung poll consumed the whole
+  budget -- and up to ``DEFAULT_RETRY_TOTAL`` times that, since GET is still
+  retryable at the transport layer (BUG-1097, second-order item).
+* The sleep between polls was deterministic, keeping a fleet phase-locked
+  (BUG-942 item 1).
+"""
+
+import time
+from dataclasses import dataclass
+from unittest.mock import Mock, patch
+
+import pytest
+from dataclasses_json import dataclass_json
+
+from aixplain.v2.agent import Agent
+from aixplain.v2.client import DEFAULT_TIMEOUT_CONNECT, DEFAULT_TIMEOUT_READ
+from aixplain.v2.exceptions import TimeoutError as AixplainTimeoutError
+
+BACKEND_URL = "https://platform-api.aixplain.com"
+
+IN_PROGRESS = {"status": "IN_PROGRESS", "completed": False, "data": {}}
+SUCCESS = {"status": "SUCCESS", "completed": True, "data": {}}
+
+
+def _create_agent(responses=None):
+    """Agent with a mocked client whose ``get`` returns *responses* in order."""
+
+    @dataclass_json
+    @dataclass
+    class BoundAgent(Agent):
+        pass
+
+    agent = BoundAgent(id="agent-123", name="test-agent")
+    agent.context = Mock()
+    agent.context.backend_url = BACKEND_URL
+    if responses is not None:
+        agent.context.client.get = Mock(side_effect=list(responses))
+    return agent
+
+
+def _read_timeouts(client_get):
+    """The read component of every ``timeout=`` the client was called with."""
+    timeouts = []
+    for call in client_get.call_args_list:
+        timeout = call.kwargs.get("timeout")
+        assert timeout is not None, "poll must bound its own request"
+        timeouts.append(timeout[1])
+    return timeouts
+
+
+class TestPollRequestTimeout:
+    """``poll`` must be able to bound a single request."""
+
+    def test_poll_without_timeout_leaves_the_client_default(self):
+        """Additive change: a bare ``poll(url)`` behaves exactly as before."""
+        agent = _create_agent([SUCCESS])
+
+        agent.poll("exec-1")
+
+        assert "timeout" not in agent.context.client.get.call_args.kwargs
+
+    def test_poll_with_timeout_passes_a_connect_read_tuple(self):
+        agent = _create_agent([SUCCESS])
+
+        agent.poll("exec-1", timeout=42.0)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"] == (DEFAULT_TIMEOUT_CONNECT, 42.0)
+
+    def test_read_timeout_is_capped_at_the_client_default(self):
+        """A caller's budget must not widen the bound the deployment configured."""
+        agent = _create_agent([SUCCESS])
+
+        agent.poll("exec-1", timeout=DEFAULT_TIMEOUT_READ * 10)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"][1] == DEFAULT_TIMEOUT_READ
+
+    @pytest.mark.parametrize("budget", [0.001, 0.5, 1.0])
+    def test_read_timeout_is_floored_at_one_second(self, budget):
+        """A nearly-exhausted budget must still send a real request.
+
+        Otherwise the last poll before the deadline is guaranteed to time out.
+        """
+        agent = _create_agent([SUCCESS])
+
+        agent.poll("exec-1", timeout=budget)
+
+        assert agent.context.client.get.call_args.kwargs["timeout"][1] == 1.0
+
+
+class TestSyncPollBudget:
+    """A single poll must not be able to over-run the caller's ``timeout``."""
+
+    def test_every_poll_is_bounded_by_the_remaining_budget(self):
+        agent = _create_agent([IN_PROGRESS, IN_PROGRESS, SUCCESS])
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            agent.sync_poll("exec-1", timeout=120, wait_time=0.5)
+
+        reads = _read_timeouts(agent.context.client.get)
+        assert len(reads) == 3
+        # Monotonically non-increasing, and never more than the budget.
+        assert reads == sorted(reads, reverse=True)
+        assert max(reads) <= 120
+
+    def test_budget_shrinks_as_time_is_consumed(self):
+        """With a fake clock the read timeout tracks the remaining budget exactly."""
+        agent = _create_agent([IN_PROGRESS, IN_PROGRESS, SUCCESS])
+        clock = iter([0.0, 0.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 30.0, 30.0, 30.0])
+
+        with patch("aixplain.v2.resource.time.time", lambda: next(clock)):
+            with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+                agent.sync_poll("exec-1", timeout=100, wait_time=0.5)
+
+        reads = _read_timeouts(agent.context.client.get)
+        assert reads == [100.0, 90.0, 80.0]
+
+    def test_never_exceeds_the_client_read_timeout(self):
+        """Even a huge ``sync_poll`` budget stays inside the transport bound."""
+        agent = _create_agent([IN_PROGRESS, SUCCESS])
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            agent.sync_poll("exec-1", timeout=100000, wait_time=0.5)
+
+        assert all(read <= DEFAULT_TIMEOUT_READ for read in _read_timeouts(agent.context.client.get))
+
+    def test_wall_clock_respects_the_timeout_when_every_poll_fails(self):
+        """Non-API poll errors are swallowed and retried -- but still bounded.
+
+        ``poll`` is patched directly because the real one rewraps everything as
+        ``APIError``, which ``sync_poll`` re-raises by design.
+        """
+        agent = _create_agent()
+        polls = []
+
+        def flaky(poll_url, timeout=None):
+            polls.append(timeout)
+            raise ValueError("transient")
+
+        started = time.monotonic()
+        with patch.object(type(agent), "poll", side_effect=flaky):
+            with pytest.raises(AixplainTimeoutError):
+                agent.sync_poll("exec-1", timeout=0.4, wait_time=0.05)
+        elapsed = time.monotonic() - started
+
+        assert len(polls) >= 2, polls
+        assert all(t is not None and t <= 0.4 for t in polls), polls
+        # The loop must not overshoot its own budget by a whole sleep interval.
+        assert elapsed < 1.0, elapsed
+
+    def test_zero_budget_polls_nothing_and_times_out(self):
+        """A caller with no budget left must not issue a request at all."""
+        agent = _create_agent([SUCCESS])
+
+        with pytest.raises(AixplainTimeoutError):
+            agent.sync_poll("exec-1", timeout=0)
+
+        agent.context.client.get.assert_not_called()
+
+    def test_does_not_sleep_past_the_deadline(self):
+        """The sleep is clamped, so an exhausted budget never adds a sleep.
+
+        Before the fix the loop slept the full ``wait_time`` after its last
+        poll, overshooting ``timeout`` by up to 60s.
+        """
+        agent = _create_agent([IN_PROGRESS, IN_PROGRESS, SUCCESS])
+        recorded = []
+
+        def record(wait_time, *args, **kwargs):
+            recorded.append((wait_time, kwargs.get("max_sleep")))
+            return 0.0
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", side_effect=record):
+            agent.sync_poll("exec-1", timeout=50, wait_time=1.0)
+
+        assert recorded, "expected sleeps between polls"
+        for wait_time, max_sleep in recorded:
+            assert max_sleep is not None
+            assert max_sleep <= 50
+
+
+class TestSyncPollJitter:
+    """The poll sleep must be jittered, not a bare ``time.sleep``."""
+
+    def test_uses_the_jittered_sleep_helper(self):
+        agent = _create_agent([IN_PROGRESS, IN_PROGRESS, SUCCESS])
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0) as sleeper:
+            with patch("aixplain.v2.resource.time.sleep") as bare_sleep:
+                agent.sync_poll("exec-1", timeout=60, wait_time=0.5)
+
+        assert sleeper.call_count == 2
+        bare_sleep.assert_not_called()
+
+    def test_backoff_ladder_is_preserved(self):
+        """Jitter replaces the constant, it does not remove the growth."""
+        agent = _create_agent([IN_PROGRESS] * 4 + [SUCCESS])
+        waits = []
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", side_effect=lambda w, **k: waits.append(w) or 0.0):
+            agent.sync_poll("exec-1", timeout=600, wait_time=0.5)
+
+        assert waits == sorted(waits)
+        assert waits[0] == pytest.approx(0.5)
+        assert waits[-1] > waits[0]
+
+    def test_real_sleeps_are_spread(self):
+        """End-to-end: the actual delays differ from run to run."""
+        observed = []
+
+        for _ in range(2):
+            agent = _create_agent([IN_PROGRESS] * 3 + [SUCCESS])
+            delays = []
+            with patch("aixplain.v2._backoff.time.sleep", side_effect=delays.append):
+                agent.sync_poll("exec-1", timeout=600, wait_time=0.5)
+            observed.append(delays)
+
+        assert observed[0] != observed[1]
+
+
+class TestSubmitRetryJitter:
+    """``_submit_with_retries`` sleeps between submissions -- also jittered."""
+
+    def test_submission_retry_sleep_is_jittered(self):
+        from aixplain.v2.exceptions import APIError
+        from aixplain.v2.resource import RunnableResourceMixin
+
+        agent = _create_agent()
+        attempts = []
+
+        def fail(**kwargs):
+            attempts.append(kwargs)
+            raise APIError("upstream unavailable", 503, {})
+
+        with patch.object(RunnableResourceMixin, "_post_and_handle_run", side_effect=fail):
+            with patch.object(RunnableResourceMixin, "_is_retryable_run_error", return_value=True):
+                with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0) as sleeper:
+                    with patch("aixplain.v2.resource.time.sleep") as bare_sleep:
+                        with pytest.raises(APIError):
+                            agent._submit_with_retries(run_retries=2, run_retry_wait=1.0)
+
+        assert len(attempts) == 3
+        assert sleeper.call_count == 2
+        bare_sleep.assert_not_called()
+
+
+class TestLegacyPollOverrideCompatibility:
+    """``poll`` gained ``timeout`` additively, so old overrides must keep working.
+
+    A third-party subclass may still define ``poll(self, poll_url)``. Passing
+    the remaining budget to it would raise ``TypeError``; such an override
+    should simply lose the bound instead.
+    """
+
+    @staticmethod
+    def _agent_with_poll(poll_impl):
+        @dataclass_json
+        @dataclass
+        class BoundAgent(Agent):
+            pass
+
+        BoundAgent.poll = poll_impl
+        agent = BoundAgent(id="agent-123", name="test-agent")
+        agent.context = Mock()
+        agent.context.backend_url = BACKEND_URL
+        return agent
+
+    def test_old_signature_override_does_not_raise(self):
+        calls = []
+
+        def legacy_poll(self, poll_url):
+            calls.append(poll_url)
+            return Mock(completed=True, status="SUCCESS")
+
+        agent = self._agent_with_poll(legacy_poll)
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            agent.sync_poll("exec-1", timeout=30)
+
+        # Agent.sync_poll resolves the execution ID before delegating.
+        assert calls == [f"{BACKEND_URL}/sdk/agents/exec-1/result"]
+
+    def test_new_signature_override_still_receives_the_budget(self):
+        seen = []
+
+        def modern_poll(self, poll_url, timeout=None):
+            seen.append(timeout)
+            return Mock(completed=True, status="SUCCESS")
+
+        agent = self._agent_with_poll(modern_poll)
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            agent.sync_poll("exec-1", timeout=30)
+
+        assert seen and seen[0] is not None
+        assert seen[0] <= 30
+
+    def test_kwargs_only_override_receives_the_budget(self):
+        """``poll(self, poll_url, **kwargs)`` can absorb it, so it should."""
+        seen = []
+
+        def kwargs_poll(self, poll_url, **kwargs):
+            seen.append(kwargs.get("timeout"))
+            return Mock(completed=True, status="SUCCESS")
+
+        agent = self._agent_with_poll(kwargs_poll)
+
+        with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+            agent.sync_poll("exec-1", timeout=30)
+
+        assert seen and seen[0] is not None
+
+    def test_the_shipped_poll_is_detected_as_supporting_timeout(self):
+        agent = _create_agent([SUCCESS])
+
+        assert agent._poll_accepts_timeout() is True
+
+    def test_support_is_cached_per_callable(self):
+        """The introspection must not run once per poll."""
+        import aixplain.v2.resource as resource_module
+
+        agent = _create_agent([IN_PROGRESS, IN_PROGRESS, SUCCESS])
+        agent._poll_accepts_timeout()  # warm the cache
+
+        with patch.object(resource_module, "inspect", wraps=resource_module.inspect) as inspect_module:
+            with patch("aixplain.v2.resource.sleep_with_jitter", return_value=0.0):
+                agent.sync_poll("exec-1", timeout=30)
+
+        inspect_module.signature.assert_not_called()
+        assert agent.context.client.get.call_count == 3

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -733,3 +733,79 @@ class TestMergeWithDynamicAttrs:
         for key, _ in tool._RUN_HEADER_KEYS:
             assert key not in payload_kwargs
         assert payload_kwargs["data"] == {"q": "hi"}
+
+
+class TestValidateParamsReportsFailures:
+    """_validate_params must never report "valid" when validation crashed.
+
+    The action-input branch used to be wrapped in a bare `except Exception: pass`,
+    so an unresolvable action name or a malformed payload produced an *empty*
+    error list -- indistinguishable from "validated clean" -- and `Model.run`
+    happily shipped the call to the backend (BUG-946).
+    """
+
+    def test_unknown_action_returns_non_empty_errors(self):
+        """A name absent from the cached actions must surface as an error."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        errors = tool._validate_params(action="NO_SUCH_ACTION", data={"query": "hi"})
+
+        assert errors, "an unresolvable action must not validate clean"
+        assert "NO_SUCH_ACTION" in errors[0]
+
+    def test_lazy_input_loader_failure_is_reported(self):
+        """The real unknown-action path: `Actions` fabricates an `ActionView`.
+
+        `Actions.__getitem__` does not raise for an unknown name when an action
+        factory is configured; the failure surfaces one line later, when
+        `action_obj.inputs` runs the lazy loader.
+        """
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        def _boom(action_name, description=None):
+            def _load_inputs():
+                raise ValueError(f"Action '{action_name}' not found or has no input parameters defined.")
+
+            return Action(name=action_name, _inputs_loader=_load_inputs)
+
+        actions = Actions(actions={}, _action_factory=_boom)
+        tool.__dict__["actions"] = actions
+
+        errors = tool._validate_params(action="GHOST", data={})
+
+        assert len(errors) == 1
+        assert "Could not validate inputs for 'GHOST'" in errors[0]
+        assert "not found or has no input parameters defined" in errors[0]
+
+    def test_crashing_validate_is_reported_not_swallowed(self):
+        """A malformed payload that makes `Inputs.validate` raise must be reported."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        with patch.object(Inputs, "validate", side_effect=TypeError("unhashable payload")):
+            errors = tool._validate_params(action="search", data={"query": "hi"})
+
+        assert errors == ["Could not validate inputs for 'search': unhashable payload"]
+
+    def test_valid_action_still_validates_clean(self):
+        """The happy path must be unchanged: satisfied inputs return no errors."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        assert tool._validate_params(action="search", data={"query": "hello"}) == []
+
+    def test_missing_required_input_reports_once(self):
+        """`Inputs.validate` messages pass through unchanged -- no double reporting."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        errors = tool._validate_params(action="search", data={})
+
+        assert errors == ["Required input 'query' is missing"]

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -5,7 +5,10 @@ from unittest.mock import Mock, patch, MagicMock
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 
+import requests
+
 from aixplain.v2.actions import Action, Actions, Inputs
+from aixplain.v2.exceptions import APIError
 from aixplain.v2.integration import ActionInputSpec, ActionSpec
 from aixplain.v2.tool import Tool, ToolResult
 from aixplain.v2.integration import Integration
@@ -809,3 +812,68 @@ class TestValidateParamsReportsFailures:
         errors = tool._validate_params(action="search", data={})
 
         assert errors == ["Required input 'query' is missing"]
+
+
+class TestValidateParamsToleratesTransportFailures:
+    """A backend blip in the lazy input loader must not block the run.
+
+    ``Action.inputs`` fetches ``LIST_INPUTS`` over the network, so treating every
+    exception as a validation error turned a transient 5xx into a client-side
+    failure for a ``tool.run()`` that previously worked. The BUG-946 contract --
+    an unknown action still reports errors -- is unchanged.
+    """
+
+    @staticmethod
+    def _tool_whose_loader_raises(exc):
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        def _factory(action_name, description=None):
+            def _load_inputs():
+                raise exc
+
+            return Action(name=action_name, _inputs_loader=_load_inputs)
+
+        tool.__dict__["actions"] = Actions(actions={}, _action_factory=_factory)
+        return tool
+
+    def test_a_backend_5xx_does_not_block_the_run(self, caplog):
+        tool = self._tool_whose_loader_raises(APIError("Bad Gateway", status_code=502))
+
+        with caplog.at_level("WARNING", logger="aixplain.v2.tool"):
+            errors = tool._validate_params(action="search", data={"query": "hi"})
+
+        assert errors == []
+        assert any("Skipping input validation" in record.message for record in caplog.records)
+
+    def test_a_dropped_connection_does_not_block_the_run(self):
+        tool = self._tool_whose_loader_raises(requests.ConnectionError("connection reset"))
+
+        assert tool._validate_params(action="search", data={"query": "hi"}) == []
+
+    def test_a_transport_level_apierror_does_not_block_the_run(self):
+        """``status_code=0`` is the SDK sentinel for "no HTTP response at all"."""
+        tool = self._tool_whose_loader_raises(APIError("Polling failed: ReadTimeout", status_code=0))
+
+        assert tool._validate_params(action="search", data={"query": "hi"}) == []
+
+    def test_a_backend_4xx_still_blocks_the_run(self):
+        """A 4xx is the backend rejecting *this* action or payload, not a blip."""
+        tool = self._tool_whose_loader_raises(APIError("Unknown action", status_code=400))
+
+        errors = tool._validate_params(action="search", data={"query": "hi"})
+
+        assert len(errors) == 1
+        assert "Could not validate inputs for 'search'" in errors[0]
+
+    def test_an_unknown_action_still_returns_errors(self):
+        """The BUG-946 acceptance criterion, restated against the new branch."""
+        tool = self._tool_whose_loader_raises(
+            ValueError("Action 'GHOST' not found or has no input parameters defined.")
+        )
+
+        errors = tool._validate_params(action="GHOST", data={})
+
+        assert len(errors) == 1
+        assert "Could not validate inputs for 'GHOST'" in errors[0]

--- a/tests/unit/v2/test_upload_timeouts.py
+++ b/tests/unit/v2/test_upload_timeouts.py
@@ -123,3 +123,56 @@ class TestBlackholeFailsFast:
         elapsed = time.monotonic() - started
 
         assert elapsed < 60, f"took {elapsed:.1f}s; the retry budget is not bounded"
+
+
+class TestUploadSessionReuse:
+    """BUG-942 item 3: the upload path built a fresh Session per request.
+
+    ``create_session()`` called ``create_retry_session()`` on every request, so
+    each leg of every upload paid a TLS handshake and pooled nothing -- the same
+    defect as v1's ``_request_with_retry``, reproduced in v2.
+    """
+
+    def test_create_session_returns_the_same_object(self):
+        assert RequestManager.create_session() is RequestManager.create_session()
+
+    def test_a_hundred_requests_build_one_session(self):
+        RequestManager.create_session()  # warm the cache
+
+        with patch("requests.Session.request", return_value=_ok_response()):
+            with patch("aixplain.v2.client.create_retry_session") as factory:
+                for index in range(100):
+                    RequestManager.request_with_retry("get", f"https://api.example.com/{index}")
+
+        factory.assert_not_called()
+
+    def test_the_shared_session_is_pool_sized(self):
+        """It must be a ``create_retry_session``, not a bare Session."""
+        from aixplain.v2.client import DEFAULT_POOL_MAXSIZE, RETRY_ALLOWED_METHODS
+
+        adapter = RequestManager.create_session().get_adapter("https://api.example.com")
+
+        assert adapter._pool_maxsize == DEFAULT_POOL_MAXSIZE
+        assert adapter.max_retries.allowed_methods == RETRY_ALLOWED_METHODS
+
+    def test_concurrent_first_use_creates_exactly_one_session(self):
+        """The double-checked lock must not race into two sessions."""
+        import threading
+
+        from aixplain.v2 import upload_utils
+
+        upload_utils.RequestManager._session = None
+        barrier = threading.Barrier(16)
+        results = [None] * 16
+
+        def create(index):
+            barrier.wait()
+            results[index] = RequestManager.create_session()
+
+        threads = [threading.Thread(target=create, args=(i,)) for i in range(16)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len({id(session) for session in results}) == 1

--- a/tests/unit/v2/test_upload_timeouts.py
+++ b/tests/unit/v2/test_upload_timeouts.py
@@ -23,7 +23,7 @@ from aixplain.v2.upload_utils import FileUploader, RequestManager
 def _ok_response():
     response = Mock()
     response.status_code = 200
-    response.json.return_value = {"key": "uploads/x.csv", "uploadUrl": "https://s3.example.com/x"}
+    response.json.return_value = {"key": "uploads/x.csv", "uploadUrl": "https://bucket.s3.amazonaws.com/x"}
     return response
 
 


### PR DESCRIPTION
## Summary

This branch carries four SEV2 tickets from the SDK audit, merged in dependency order because each builds on the request/retry layer the previous one touched. Every ticket was reviewed and CI-checked as its own pull request before being merged down into this one; those PRs are linked below and their full write-ups remain readable there.

## Tickets in this branch

| Ticket | Reviewed in | What it fixes |
|---|---|---|
| [BUG-942 + BUG-1097](https://aixplain.atlassian.net/browse/BUG-942) | #1076 (this PR) | Jitter on every poll and backoff sleep, 429 added to the retry forcelist with Retry-After honoured, `stream_progress` given a deadline and an unconditional poll counter, connection pool sized explicitly, and the read timeout bounded by the remaining poll budget. BUG-1097's core item, POST removed from the urllib3 retry set, had already shipped in #1045; its residual items are here. |
| [BUG-941](https://aixplain.atlassian.net/browse/BUG-941) | #1080 | `call_run_endpoint` and `Pipeline.poll` returned a FAILED response object instead of raising `UnboundLocalError` on any network error or non-JSON body. |
| [BUG-939](https://aixplain.atlassian.net/browse/BUG-939) | #1083 | Ancestor `.env` files no longer hijack `BACKEND_URL` or the API key, debug logs no longer emit request bodies, response bodies or third-party tokens, every URL fetched from a caller or a response goes through a scheme and resolved-IP check, and the presigned upload host is validated before the PUT. |
| [BUG-946](https://aixplain.atlassian.net/browse/BUG-946) | #1085 | Five declared controls that did nothing now take effect: action-input validation reports its own crash, `progress_verbosity` reaches `sync_poll`, the API key is validated lazily so `--help` and unit collection work without credentials, the v2 client is constructed lazily instead of silently becoming `None`, and the team-agent invariant is resolved. |

## Jira tickets closed by this branch

- [BUG-942](https://aixplain.atlassian.net/browse/BUG-942) — Poll backoff has no jitter, stream_progress polls unbounded, no connection reuse, pool_maxsize=10
- [BUG-1097](https://aixplain.atlassian.net/browse/BUG-1097) — The BUG-938 timeout fix activated a latent POST-retry path (residual items; core fix shipped in #1045)
- [BUG-941](https://aixplain.atlassian.net/browse/BUG-941) — call_run_endpoint raises UnboundLocalError on any network error instead of the documented FAILED status
- [BUG-939](https://aixplain.atlassian.net/browse/BUG-939) — dotenv walk-up hijacks BACKEND_URL, debug logs dump bodies and tokens, three SSRF sinks, unvalidated upload URL
- [BUG-946](https://aixplain.atlassian.net/browse/BUG-946) — Five controls that do nothing: validation returns valid when it crashes, dropped parameter, CLI --help crashes, client silently None, invariant commented out

## Notes for review

**Scope note carried from BUG-947 review:** the functional-test CI leg still targets the production tenant. Retargeting it is a policy decision and was deliberately left out.

## Testing

`python -m pytest tests/unit` passes on this branch, and pre-commit is green on every constituent pull request. No functional or network tests were run locally.

## Original ticket write-up

The detailed per-finding analysis for the head ticket follows; the other tickets' write-ups are in their linked pull requests.

---
## Summary

Every poll and backoff sleep in the SDK was deterministic. Any set of clients started together stayed phase-locked for the life of their runs and hit the platform in synchronized waves — and because this is a client SDK, the effect is multiplied by every installed copy, with the load landing on aiXplain's own platform.

This PR jitters every poll/backoff sleep, adds `429` to the retry forcelist, bounds `stream_progress` with a real deadline, and sizes the connection pools explicitly.

## Changes

### v2 (primary)

**New `aixplain/v2/_backoff.py`** — one place for the retry/poll timing policy:
- symmetric multiplicative jitter (±20%)
- the SDK-standard `×1.1` / 60s-capped ladder
- a sleep clamped to the caller's remaining budget, so jitter can shorten a sleep but never overrun a deadline

**Jittered sleeps** — `sync_poll`, `_submit_with_retries`, `ActionMixin._poll_for_data` (which had a flat 1s tick and no backoff at all), and `stream_progress`.

**`client.py`**
- add `429` to `DEFAULT_RETRY_STATUS_FORCELIST`; set `backoff_jitter`, `backoff_max`, `respect_retry_after_header`, and a bounded `retry_after_max` (urllib3's own default is 6 hours). Retrying 429 cannot duplicate a billable submission because `allowed_methods` stays GET-only.
- optional kwargs are filtered against the *installed* `Retry` signature, so urllib3 1.26 loses the jitter rather than raising. Only the SDK's own optional hardening kwargs are dropped — a caller's typo still reaches `Retry` and raises rather than being silently discarded.
- size the `HTTPAdapter` pool explicitly (32/64, `block=False`); urllib3's 10/10 default discards connections above 10 in flight.

**`sync_poll` budget** (BUG-1097 second-order item) — each poll request is now bounded by its remaining budget, so one hung poll can no longer consume the whole timeout. `poll()` gains an additive `timeout` kwarg; a subclass still overriding the old signature loses the bound instead of breaking. The per-request read timeout is bounded against the *client's* configured timeout, so narrowing `AixplainClient(timeout=...)` is honoured rather than silently widened back to 300s. Budget exhaustion also wins over the transport error it causes — the last poll before the deadline failing now surfaces as the documented `TimeoutError`, not `APIError`. `UntrustedURLError` is never softened.

**`stream_progress`** — add a `timeout` with a wall-clock deadline, raise the default poll interval from 0.05s to 0.5s with backoff, and increment `_poll_count` unconditionally so `max_polls` can terminate a run that never emits steps.

**`upload_utils`** — reuse one pooled `RequestManager` session instead of building one per request.

### v1 (minimal, line-level only — v1 is unmaintained)

- Jitter the four v1 poll sleeps.
- `request_utils`: one module-level `Session` instead of one per call, with an explicitly sized pool (the 10/10 default would have cancelled out the reuse the shared session exists to provide).
- `pipeline`: default timeout 20000s → 1800s.
- Per-poll logs no longer interpolate the response body, and use lazy `%s` args so nothing is stringified when the level is off.

## Out of scope

BUG-942 item 6 (client-side rate limiting / token bucket).

## Testing

New unit tests covering jitter distribution and budget clamping, the 429/`backoff_jitter` retry configuration and its urllib3-1.26 fallback, `sync_poll` budget accounting and error precedence, `stream_progress` deadline/`max_polls` bounds, upload timeouts, and a guard test asserting no unjittered poll sleeps remain. `ruff check` and `ruff format --check` are clean on all changed files.



[BUG-941]: https://aixplain.atlassian.net/browse/BUG-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUG-939]: https://aixplain.atlassian.net/browse/BUG-939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ