### PR TITLE
fix(v2): guard save() on deleted resources and stop clobbering server fields (BUG-1093)

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -240,6 +240,10 @@ _ROLES: List[_RoleSpec] = [
     _RoleSpec("response_generator", "responder", "responder"),
 ]
 
+# Attributes that hold a role ref, for the explicit-assignment tracking in
+# ``Agent.__setattr__``.
+_ROLE_ATTRS = frozenset(spec.attr for spec in _ROLES)
+
 
 class AgentRunParams(BaseRunParams):
     """Parameters for running an agent.
@@ -877,7 +881,7 @@ class Agent(
             self.skills = [self._skill_reference_id(skill) or skill for skill in self._original_skills]
 
     def __setattr__(self, name: str, value: Any) -> None:
-        """Keep ``self.budget`` a (never-None) ``Budget`` instance.
+        """Keep ``self.budget`` a (never-None) ``Budget`` instance, and note role assignments.
 
         Assigning ``agent.budget`` a dict / ``Budget`` / ``None`` is coerced into
         a ``Budget`` so attribute access (``agent.budget.max_cost = ...``) always
@@ -885,11 +889,27 @@ class Agent(
         ``Model.__setattr__`` coerces bulk ``inputs`` assignment). This runs for
         the generated ``__init__`` assignment too, so the field is a ``Budget``
         by the time ``__post_init__`` executes.
+
+        A role ref assigned *after* hydration is the caller's intent and must
+        always be sent on save, even when it happens to equal the class default
+        (BUG-1093). Assignments made by the generated ``__init__`` are not
+        recorded — ``_explicit_roles`` does not exist yet at that point — but
+        such an object also has no recorded server fields, so suppression is off
+        for it anyway. Hydration resets the set (see ``_record_server_fields``).
         """
         if name == "budget":
             coerced = self._coerce_budget(value)
             value = coerced if coerced is not None else Budget()
+        if name in _ROLE_ATTRS:
+            explicit = getattr(self, "_explicit_roles", None)
+            if explicit is not None:
+                explicit.add(name)
         super().__setattr__(name, value)
+
+    def _record_server_fields(self, data: Any) -> None:
+        """Reset explicit-role tracking: post-hydration role values came from the server."""
+        super()._record_server_fields(data)
+        self._explicit_roles = set()
 
     @classmethod
     def _fold_legacy_max_iterations(cls, kvs: Any) -> Any:
@@ -1278,8 +1298,15 @@ class Agent(
             Agent: The saved agent instance
 
         Raises:
+            ValidationError: If the agent has been deleted.
             ValueError: If child components are not saved and save_subcomponents is False
         """
+        # Guard before any child component is saved and before before_save()
+        # flips status DELETED -> ONBOARDED: a deleted agent must not touch the
+        # backend at all (BUG-1093).
+        if self.id or self.is_deleted:
+            self._ensure_valid_state()
+
         save_subcomponents = kwargs.pop("save_subcomponents", False)
 
         # Save all child components recursively if requested
@@ -1916,13 +1943,28 @@ class Agent(
 
         Each entry is ``{id, parameters?: [{name, value}]}`` (matches backend
         ``AgentModelInput``). Driven by the module-level ``_ROLES`` table.
+
+        A role whose value is still the SDK class default is omitted when the
+        response that hydrated this agent did not carry that key and the caller
+        never assigned it: sending it would write an SDK default (e.g.
+        ``DEFAULT_LLM``) over whatever the platform actually has (BUG-1093).
+        Creates are unaffected — a locally built Agent has no recorded server
+        fields, so nothing is suppressed.
         """
+        explicit = getattr(self, "_explicit_roles", None) or frozenset()
         for spec in _ROLES:
             ref = getattr(self, spec.attr, None)
-            if ref is not None:
-                payload[spec.save_key] = self._role_ref_to_save_manifest(ref)
-            else:
+            if ref is None:
                 payload.pop(spec.save_key, None)
+                continue
+            if (
+                spec.attr not in explicit
+                and self._is_at_field_default(spec.attr)
+                and self._server_omitted(spec.save_key)
+            ):
+                payload.pop(spec.save_key, None)
+                continue
+            payload[spec.save_key] = self._role_ref_to_save_manifest(ref)
         for k in self._LEGACY_ROLE_KEYS:
             payload.pop(k, None)
 

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1585,6 +1585,11 @@ class Agent(
 
         duplicated = Agent.from_dict(response_data)
         duplicated.context = self.context
+        # Record which keys the duplicate response carried, like get()/search()
+        # do: without this the duplicate has no provenance and a later save()
+        # would PUT the SDK default model over whatever the platform gave the
+        # copy (BUG-1093).
+        duplicated._record_server_fields(response_data)
         duplicated._update_saved_state()
 
         return duplicated

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -2402,7 +2402,11 @@ class Agent(
         fields = ("max_cost", "max_duration_seconds", "max_iterations")
         if session_budget is None:
             has_cap = any(getattr(agent_budget, name, None) is not None for name in fields)
-            return agent_budget if has_cap else None
+            # Copy, never alias: ``agent.budget`` is documented as mutated in
+            # place (``agent.budget.max_cost = ...``), so handing the same object
+            # to the session would let a later agent-side edit silently rewrite
+            # the session's persisted cap.
+            return replace(agent_budget) if has_cap else None
         filled = {
             name: getattr(agent_budget, name, None)
             for name in fields

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from datetime import datetime
 from enum import Enum
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Any, Dict, Tuple, Union, Text
 from typing_extensions import Unpack, NotRequired, TypedDict, Literal
 from dataclasses_json import dataclass_json, config
@@ -2158,7 +2158,17 @@ class Agent(
         return payload
 
     def build_run_payload(self, **kwargs: Unpack[AgentRunParams]) -> dict:
-        """Build the payload for the run action."""
+        """Build the payload for the run action.
+
+        SDK-control kwargs (``_RUN_CONTROL_KEYS``: retries/timeouts, the
+        ``progress_*`` display trio, ``api_key`` / ``resource_path``, and the
+        header-only run metadata) are dropped up front. The run path already
+        filters them via ``_payload_kwargs_for_run``; repeating it here means the
+        catch-all snake_case→camelCase forwarder below cannot put them on the
+        wire even when this builder is called directly (BUG-1091).
+        """
+        kwargs = {k: v for k, v in kwargs.items() if k not in self._RUN_CONTROL_KEYS}
+
         # Extract execution_params if provided, otherwise use defaults
         execution_params = kwargs.pop("execution_params", {})
 
@@ -2365,8 +2375,42 @@ class Agent(
                         values[name] = value
         return values
 
-    @staticmethod
-    def _apply_run_overrides_to_session(session: "Session", kwargs: Dict[str, Any]) -> None:
+    # Per-run kwargs that map onto ``ExecutionConfig`` fields. ``budget`` is
+    # intentionally absent: it is not a run kwarg (``build_run_payload`` pops any
+    # stray one) and reaches the session via the agent's own budget instead.
+    _SESSION_EXECUTION_OVERRIDES: ClassVar[tuple] = (
+        "execution_params",
+        "criteria",
+        "evolve",
+        "identifier",
+        "run_response_generation",
+    )
+
+    def _budget_for_session(self, session_budget: Optional["Budget"]) -> Optional["Budget"]:
+        """Fill unset session budget caps from ``self.budget``; session values win.
+
+        A session's stored cap is an explicit, persisted ceiling: the agent's own
+        budget may only fill slots the session leaves unset, never widen or
+        replace one.
+
+        Returns *session_budget* itself (identity, so the caller can tell nothing
+        changed) when the agent has no budget or contributes no new cap.
+        """
+        agent_budget = getattr(self, "budget", None)
+        if agent_budget is None:
+            return session_budget
+        fields = ("max_cost", "max_duration_seconds", "max_iterations")
+        if session_budget is None:
+            has_cap = any(getattr(agent_budget, name, None) is not None for name in fields)
+            return agent_budget if has_cap else None
+        filled = {
+            name: getattr(agent_budget, name, None)
+            for name in fields
+            if getattr(session_budget, name, None) is None and getattr(agent_budget, name, None) is not None
+        }
+        return replace(session_budget, **filled) if filled else session_budget
+
+    def _apply_run_overrides_to_session(self, session: "Session", kwargs: Dict[str, Any]) -> None:
         """Apply per-run execution overrides onto a session.
 
         When a caller runs within a ``session`` but also passes
@@ -2379,37 +2423,40 @@ class Agent(
         result differs from what's stored, persist it so the overrides
         take effect.
 
+        The agent's own ``budget`` applies on this path too (it already does on
+        the direct run path), but only fills caps the session leaves unset.
+
         We warn because this mutates the session's ``executionConfig`` for
         every subsequent message in the session, not just this run.
         """
         from .session import ExecutionConfig
 
-        overrides = {
-            "execution_params": kwargs.get("execution_params"),
-            "criteria": kwargs.get("criteria"),
-            "evolve": kwargs.get("evolve"),
-            "identifier": kwargs.get("identifier"),
-            "run_response_generation": kwargs.get("run_response_generation"),
-        }
-        provided = {key: value for key, value in overrides.items() if value is not None}
-        if not provided:
+        provided = {key: kwargs[key] for key in self._SESSION_EXECUTION_OVERRIDES if kwargs.get(key) is not None}
+
+        current = ExecutionConfig.coerce(session.execution_config)
+
+        # Rebuild *from the stored config*, never from an enumerated field list:
+        # a hardcoded ``base`` dict omitted ``budget``, so every session run with
+        # any override silently deleted the session's persisted spend cap — and
+        # the same trap would reopen for any field added to ExecutionConfig
+        # (BUG-1091).
+        merged = replace(current, **provided) if current is not None else ExecutionConfig(**provided)
+
+        seeded = self._budget_for_session(merged.budget)
+        budget_seeded = seeded is not merged.budget
+        if budget_seeded:
+            merged = replace(merged, budget=seeded)
+
+        # Nothing to apply: keep today's semantics that a plain session run (no
+        # overrides, no cap the agent can contribute) performs no write.
+        if not provided and not budget_seeded:
             return
-
-        current = session.execution_config
-        base = {
-            "execution_params": getattr(current, "execution_params", None),
-            "criteria": getattr(current, "criteria", None),
-            "evolve": getattr(current, "evolve", None),
-            "identifier": getattr(current, "identifier", None),
-            "run_response_generation": getattr(current, "run_response_generation", None),
-        }
-        merged = ExecutionConfig(**{**base, **provided})
-
         if current is not None and merged.to_api_dict() == current.to_api_dict():
             return
 
+        changed = sorted(provided) + (["budget (from agent.budget)"] if budget_seeded else [])
         warnings.warn(
-            f"Per-run execution overrides ({', '.join(sorted(provided))}) were "
+            f"Per-run execution overrides ({', '.join(changed)}) were "
             f"passed alongside session '{session.id}'. Updating the session's "
             f"stored executionConfig so the overrides take effect; this also "
             f"applies to every subsequent message in this session.",

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -288,7 +288,16 @@ class File(BaseResource):
         self._apply_data(root_data)
 
     def save(self, **_: Any) -> "File":
-        """Upload the source and persist it as a backend File asset."""
+        """Upload the source and persist it as a backend File asset.
+
+        Raises:
+            ValidationError: If the file has been deleted.
+        """
+        # File.save() never reaches BaseResource.save(), so it needs its own
+        # deleted-state guard (BUG-1093).
+        if self.id or self.is_deleted:
+            self._ensure_valid_state()
+
         if self.context is None:
             self.context = type(self).context
         if not self.source:

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -746,41 +746,37 @@ class Model(
         else:
             super().__setattr__(name, value)
 
-    # Orchestration params the SDK consumes itself, plus every per-run header
-    # kwarg. The header half is derived from RunnableResourceMixin._RUN_HEADER_KEYS
-    # rather than re-listed, so a new header can't be added to the wire while
-    # still leaking into the v1/URL payloads (a merge once silently dropped such a
-    # duplicated entry — see the _RUN_HEADER_KEYS note).
-    _SDK_ONLY_PARAMS = frozenset(
-        {
-            "timeout",
-            "wait_time",
-            "show_progress",
-            "stream",
-            "run_retries",
-            "run_retry_wait",
-        }
-    ) | {key for key, _ in RunnableResourceMixin._RUN_HEADER_KEYS}
-
     # ``identifier`` is a per-run caller identity emitted as the ``x-user-id``
     # header (RunnableResourceMixin._headers_for_run), never a model/action
-    # input. Exclude it from the v2 payload builder here (and from the v1/URL
-    # builders via _SDK_ONLY_PARAMS above) so it cannot leak into model inputs
-    # or supplier-facing logs. Agent keeps it in the body by NOT overriding this.
+    # input. Exclude it from the payload builders here so it cannot leak into
+    # model inputs or supplier-facing logs. Agent keeps it in the body by NOT
+    # overriding this.
     #
     # ``session_id`` (→ ``x-session-id``) and ``agent_name`` (→ ``x-agent``) are
     # the same kind of per-run metadata but header-only for every runnable, so the
-    # base _RUN_CONTROL_KEYS already excludes them; _SDK_ONLY_PARAMS above covers
-    # them again for the v1/URL builder paths.
-    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier"}
+    # base _RUN_CONTROL_KEYS already excludes them.
+    #
+    # ``stream`` selects the streaming *path* (see ``run``) and is expressed on
+    # the wire as ``options.stream`` by ``run_stream`` — never as a top-level
+    # body field.
+    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier", "stream"}
+
+    # The v1/URL builder path (``_run_async_v1``) and ``build_run_payload`` filter
+    # with the *same* set rather than a second hand-maintained literal: a merge
+    # once dropped a duplicated entry and silently put ``session_id`` back on the
+    # wire (BUG-1091). Kept as a distinct name because it is referenced by
+    # existing tests and by ``build_run_payload``'s docstring.
+    _SDK_ONLY_PARAMS = _RUN_CONTROL_KEYS
 
     def build_run_payload(self, **kwargs: Unpack[ModelRunParams]) -> dict:
         """Build the JSON payload for a model execution request.
 
         Strips SDK-only orchestration params (``timeout``, ``wait_time``,
-        ``show_progress``, ``stream``, ``run_retries``, ``run_retry_wait``) and
-        the header-only run metadata (``identifier``, ``session_id``,
-        ``agent_name``) so they are never forwarded to the backend API.
+        ``show_progress``, ``progress_*``, ``stream``, ``run_retries``,
+        ``run_retry_wait``), the request-dispatch params (``api_key``,
+        ``resource_path``) and the header-only run metadata (``identifier``,
+        ``session_id``, ``agent_name``) so they are never forwarded to the
+        backend API.
         """
         filtered = {k: v for k, v in kwargs.items() if k not in self._SDK_ONLY_PARAMS}
         return super().build_run_payload(**filtered)
@@ -828,13 +824,24 @@ class Model(
         # Use v2 endpoint - it uses "results" as the items key (default)
         return super().search(**kwargs)
 
-    def run(self, **kwargs: Unpack[ModelRunParams]) -> ModelResult:
+    def run(self, **kwargs: Unpack[ModelRunParams]) -> Union[ModelResult, "ModelResponseStreamer"]:
         """Run the model with dynamic parameter validation and default handling.
 
         This method routes the execution based on the model's connection type:
         - Sync models: Uses V2 endpoint directly (returns result immediately)
         - Async models: Uses V2 endpoint and polls until completion
+
+        Returns:
+            ModelResult, or a :class:`ModelResponseStreamer` when ``stream=True``
+            — the flag selects the streaming path rather than being silently
+            dropped (BUG-1091).
         """
+        # ``stream`` selects the path, so it is consumed here rather than
+        # forwarded: run_stream sets ``options.stream`` on the wire itself and
+        # runs its own merge/validation, so passing it on would be redundant.
+        if kwargs.pop("stream", None):
+            return self.run_stream(**kwargs)
+
         # Merge dynamic attributes with provided kwargs
         effective_params = self._merge_with_dynamic_attrs(**kwargs)
 
@@ -929,9 +936,16 @@ class Model(
         v1_base_url = self.context.model_url.replace("/api/v2/", "/api/v1/")
         url = f"{v1_base_url}/{self.id}"
 
+        # Same identity headers as the sync path: this fallback is still a run,
+        # so its caller must stay attributable downstream (BUG-1091).
+        request_kwargs: dict = {"data": json_payload}
+        headers = self._headers_for_run(kwargs)
+        if headers:
+            request_kwargs["headers"] = headers
+
         # Use the v2 client's raw request method (raises APIError on non-2xx)
         try:
-            r = self.context.client.request_raw("post", url, data=json_payload)
+            r = self.context.client.request_raw("post", url, **request_kwargs)
             resp = r.json()
         except Exception as e:
             logger.error(f"Error in V1 async request: {e}")
@@ -1017,7 +1031,12 @@ class Model(
 
         self._ensure_valid_state()
 
-        payload = self.build_run_payload(**effective_params)
+        # Same body filter and identity headers as the sync path: a stream is
+        # still a run, so ``api_key`` must not reach the model input and the
+        # caller must stay attributable downstream (BUG-1091).
+        payload_input = self._payload_kwargs_for_run(effective_params)
+
+        payload = self.build_run_payload(**payload_input)
 
         if "options" not in payload:
             payload["options"] = {}
@@ -1025,11 +1044,15 @@ class Model(
         if payload.get("tools") is not None:
             payload["options"]["raw"] = True
 
-        run_url = self.build_run_url(**effective_params)
+        run_url = self.build_run_url(**payload_input)
 
         logger.debug(f"Model Run Stream: Start service for {run_url}")
 
-        response = self.context.client.request_stream("POST", run_url, json=payload)
+        request_kwargs: dict = {"json": payload}
+        headers = self._headers_for_run(effective_params)
+        if headers:
+            request_kwargs["headers"] = headers
+        response = self.context.client.request_stream("POST", run_url, **request_kwargs)
 
         return ModelResponseStreamer(response)
 

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -5,7 +5,7 @@ import logging
 import time
 import reprlib
 from datetime import datetime
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field
 from dataclasses_json import dataclass_json, config
 from urllib.parse import quote
 from typing import (
@@ -375,6 +375,45 @@ class BaseResource:
         """
         return getattr(self, "_deleted", False)
 
+    # -- hydration provenance -------------------------------------------------
+    #
+    # Stored as plain instance attributes (like ``_deleted``), never dataclass
+    # fields, so they stay invisible to ``to_dict``/``from_dict``, the
+    # ``__dataclass_fields__`` copy loop in ``_create`` and
+    # ``_get_serializable_state``.
+
+    @property
+    def _server_fields(self) -> Optional[frozenset]:
+        """Wire keys present in the response that last hydrated this instance.
+
+        ``None`` means "never hydrated from a server response" (a locally
+        constructed object): nothing is known to be absent, so no save-payload
+        key may be suppressed. A ``frozenset`` means the instance mirrors a
+        server record, and any key *not* in it was genuinely not reported by
+        the backend.
+        """
+        return getattr(self, "_server_field_names", None)
+
+    @_server_fields.setter
+    def _server_fields(self, value: Optional[frozenset]) -> None:
+        self._server_field_names = value
+
+    def _record_server_fields(self, data: Any) -> None:
+        """Remember which top-level wire keys the hydrating response carried."""
+        self._server_fields = frozenset(data.keys()) if isinstance(data, dict) else None
+
+    def _server_omitted(self, wire_key: str) -> bool:
+        """Return True when this instance came from the server and *wire_key* was absent."""
+        server_fields = self._server_fields
+        return server_fields is not None and wire_key not in server_fields
+
+    def _is_at_field_default(self, attr: str) -> bool:
+        """Return True when *attr* still holds its declared dataclass default."""
+        field_def = self.__dataclass_fields__.get(attr)
+        if field_def is None or field_def.default is MISSING:
+            return False
+        return getattr(self, attr, None) == field_def.default
+
     def _update_saved_state(self) -> None:
         """Update the saved state to match the current state.
 
@@ -428,9 +467,28 @@ class BaseResource:
         result = self.context.client.request("post", f"{resource_path}", json=payload)
         # Flatten assetInfo structure before deserialization
         result = _flatten_asset_info(dict(result)) if isinstance(result, dict) else result
+
+        # Record the server id BEFORE hydrating. The POST already succeeded, so
+        # the resource exists remotely; if from_dict() below fails (an
+        # unmodelled enum value, a new nested shape) the caller must still be
+        # able to reach it. Without this the object is left with id=None and
+        # the obvious reaction — retrying save() — creates a second resource
+        # and orphans the first (BUG-1093).
+        created_id = result.get("id") if isinstance(result, dict) else None
+        if created_id is not None:
+            self.id = created_id
+
         # Update the object from the full response
         if isinstance(self, HasFromDict):
-            updated = self.from_dict(result)
+            try:
+                updated = self.from_dict(result)
+            except Exception as e:
+                raise ResourceError(
+                    f"{type(self).__name__} was created (id={self.id!r}) but its response could not be "
+                    f"deserialized: {e}. The resource exists on the platform — do NOT retry save(), which "
+                    f"would create a duplicate. Re-fetch it with {type(self).__name__}.get({self.id!r}), "
+                    f"or delete it."
+                ) from e
             # Copy each field from the freshly-parsed ``updated`` onto self.
             # A field that is excluded from serialization is normally
             # authoritative locally (we never sent it, the response can't
@@ -439,8 +497,15 @@ class BaseResource:
             for field_name, field_def in self.__dataclass_fields__.items():
                 if _is_excluded_from_serialization(field_def) and not _is_auto_deserialize_only(field_def):
                     continue
-                if hasattr(updated, field_name):
-                    setattr(self, field_name, getattr(updated, field_name))
+                if not hasattr(updated, field_name):
+                    continue
+                value = getattr(updated, field_name)
+                # Never let a response the parser could not map back to "id"
+                # un-record the id we just captured.
+                if field_name == "id" and value is None and created_id is not None:
+                    continue
+                setattr(self, field_name, value)
+            self._record_server_fields(result)
         else:
             # Fallback: just set the ID
             self.id = result["id"]
@@ -469,8 +534,17 @@ class BaseResource:
             BaseResource: The saved resource instance
 
         Raises:
+            ValidationError: If the resource has been deleted.
             Backend validation errors as appropriate
         """
+        # save() is the only mutating path that may legitimately run without an
+        # id (the create branch below), so the state check is conditional. A
+        # deleted resource has id=None *and* _deleted=True, and must never fall
+        # through to _create(): that POSTs a duplicate and rebinds self.id to
+        # the new server id (BUG-1093).
+        if self.id or self.is_deleted:
+            self._ensure_valid_state()
+
         resource_path = kwargs.pop("resource_path", self.RESOURCE_PATH)
 
         # Set attributes from kwargs before saving
@@ -514,6 +588,11 @@ class BaseResource:
         # Reset ID and saved state for new asset
         cloned.id = None
         cloned._saved_state = None
+        # A clone is a brand-new resource: it is not the deleted original (so
+        # save() must not refuse it), and none of its field values came from a
+        # server response for *it*, so save() must send them all (BUG-1093).
+        cloned._deleted = False
+        cloned._server_fields = None
 
         # Set attributes from kwargs
         for key, value in kwargs.items():
@@ -920,6 +999,13 @@ class SearchResourceMixin(BaseMixin, Generic[SearchParamsT, ResourceT]):
                     errors.append(f"item[{index}]: {e}")
                     continue
             setattr(obj, "context", context)
+            # Remember which keys the backend actually reported, so save() can
+            # tell "server said null" from "server never mentioned it". The
+            # fallback branch above accepts any resource-shaped class, so this
+            # stays optional.
+            record_server_fields = getattr(obj, "_record_server_fields", None)
+            if callable(record_server_fields):
+                record_server_fields(item)
             # Set the saved state to match the loaded state
             obj._update_saved_state()
             resources.append(obj)
@@ -1162,6 +1248,12 @@ class GetResourceMixin(BaseMixin, Generic[GetParamsT, ResourceT]):
         else:
             instance = cls(**obj)  # type: ignore[call-arg]
         setattr(instance, "context", context)
+        # Remember which keys the backend actually reported, so save() can tell
+        # "server said null" from "server never mentioned it". The ``cls(**obj)``
+        # fallback above accepts any resource-shaped class, so this stays optional.
+        record_server_fields = getattr(instance, "_record_server_fields", None)
+        if callable(record_server_fields):
+            record_server_fields(obj)
         # Set the saved state to match the loaded state
         instance._update_saved_state()
         return instance

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -483,11 +483,19 @@ class BaseResource:
             try:
                 updated = self.from_dict(result)
             except Exception as e:
+                name = type(self).__name__
+                if created_id is not None:
+                    hint = (
+                        f"The resource exists on the platform — do NOT retry save(), which would create a "
+                        f"duplicate. Re-fetch it with {name}.get({created_id!r}), or delete it."
+                    )
+                else:
+                    hint = (
+                        "The resource may exist on the platform even though the response carried no id — "
+                        "check before retrying save(), which would create a duplicate."
+                    )
                 raise ResourceError(
-                    f"{type(self).__name__} was created (id={self.id!r}) but its response could not be "
-                    f"deserialized: {e}. The resource exists on the platform — do NOT retry save(), which "
-                    f"would create a duplicate. Re-fetch it with {type(self).__name__}.get({self.id!r}), "
-                    f"or delete it."
+                    f"{name} was created (id={created_id!r}) but its response could not be deserialized: {e}. {hint}"
                 ) from e
             # Copy each field from the freshly-parsed ``updated`` onto self.
             # A field that is excluded from serialization is normally
@@ -534,7 +542,10 @@ class BaseResource:
             BaseResource: The saved resource instance
 
         Raises:
-            ValidationError: If the resource has been deleted.
+            ResourceError: If the resource has been deleted. The guard raises
+                ``ValidationError``, which the ``@with_hooks`` wrapper re-raises
+                as ``ResourceError`` — the same shape ``delete()`` already had.
+                Both derive from ``AixplainV2Error``.
             Backend validation errors as appropriate
         """
         # save() is the only mutating path that may legitimately run without an

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -668,12 +668,31 @@ class BaseResource:
         return encode_resource_id(self.id)
 
 
+# Keys the SDK consumes itself when *dispatching* a request (choosing the path,
+# authenticating). They are declared on ``BaseParams`` for every operation, so
+# they can arrive on any call — and must never be forwarded to a backend body or
+# to ``requests.Session.request``, which would raise ``TypeError``.
+#
+# ``api_key`` authenticates nothing: ``Client.request_raw`` always overlays
+# ``_auth_headers()`` from the Aixplain context, so a per-call ``api_key``'s only
+# observable effect was riding into the model input body (BUG-1091).
+_SDK_REQUEST_KEYS: frozenset[str] = frozenset({"api_key", "resource_path"})
+
+
 class BaseParams(TypedDict):
     """Base class for parameters that include API key and resource path.
 
     Attributes:
-        api_key: str: The API key for authentication.
-        resource_path: str: Custom resource path for actions (optional).
+        api_key: Accepted for backward compatibility and **ignored**.
+            Authentication always comes from the ``Aixplain`` context
+            (``Client._auth_headers``), which overrides any per-call value. It is
+            stripped from every request so it can never reach a model input body
+            or a supplier's prompt logs. Configure credentials via
+            ``Aixplain(api_key=...)`` or ``TEAM_API_KEY`` / ``AIXPLAIN_API_KEY``
+            instead.
+        resource_path: Custom resource path for actions (optional). Consumed by
+            the URL builders; never forwarded to the backend body or to
+            ``requests``.
     """
 
     api_key: NotRequired[str]
@@ -1246,6 +1265,11 @@ class GetResourceMixin(BaseMixin, Generic[GetParamsT, ResourceT]):
         if host is not None:
             kwargs["params"] = {"host": host}
 
+        # ``api_key`` is inert (the client supplies auth) and is not a ``requests``
+        # kwarg; ``resource_path`` was already popped above. Same root cause as
+        # ``delete`` (BUG-1091).
+        kwargs = {k: v for k, v in kwargs.items() if k not in _SDK_REQUEST_KEYS}
+
         obj = context.client.get(path, **kwargs)
 
         # Flatten assetInfo structure before deserialization
@@ -1389,8 +1413,14 @@ class DeleteResourceMixin(BaseMixin, Generic[DeleteParamsT, DeleteResultT]):
         # Build the delete URL
         delete_url = self.build_delete_url(**kwargs)
 
+        # ``resource_path`` was consumed by build_delete_url and ``api_key`` is
+        # inert (the client supplies auth); neither is a ``requests`` kwarg.
+        # Forwarding them made ``delete(resource_path=…)`` raise TypeError deep
+        # inside requests (BUG-1091).
+        request_kwargs = {k: v for k, v in kwargs.items() if k not in _SDK_REQUEST_KEYS}
+
         # Execute the delete operation (delete endpoints don't return JSON)
-        response = self.context.client.request_raw("delete", delete_url, **kwargs)
+        response = self.context.client.request_raw("delete", delete_url, **request_kwargs)
 
         # Handle the response using the extensible response handler
         return self.handle_delete_response(response, **kwargs)
@@ -1530,16 +1560,34 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     # top-level ``session_id`` kwarg is purely the per-run correlation channel
     # emitted as ``x-session-id``; ``agent_name`` is likewise only the calling
     # agent's name, emitted as ``x-agent``.
-    _RUN_CONTROL_KEYS: frozenset[str] = frozenset(
-        {
-            "run_retries",
-            "run_retry_wait",
-            "timeout",
-            "wait_time",
-            "show_progress",
-            "session_id",
-            "agent_name",
-        }
+    #
+    # ``api_key`` / ``resource_path`` (``_SDK_REQUEST_KEYS``) are excluded for a
+    # different reason: they are declared on ``BaseParams`` for *every* operation,
+    # so they can arrive on a run call, and neither is a backend body field.
+    # ``api_key`` in particular authenticated nothing — its only observable effect
+    # was riding into the model input body and the supplier's prompt logs
+    # (BUG-1091).
+    #
+    # The ``progress_*`` trio configures the client-side progress display (the
+    # ``show_progress`` toggle already lived here). ``before_run`` / ``after_run``
+    # still receive the *unfiltered* kwargs, so the tracker keeps seeing them —
+    # only the payload/URL builders are filtered.
+    _RUN_CONTROL_KEYS: frozenset[str] = (
+        frozenset(
+            {
+                "run_retries",
+                "run_retry_wait",
+                "timeout",
+                "wait_time",
+                "show_progress",
+                "progress_format",
+                "progress_verbosity",
+                "progress_truncate",
+                "session_id",
+                "agent_name",
+            }
+        )
+        | _SDK_REQUEST_KEYS
     )
 
     @staticmethod

--- a/aixplain/v2/session.py
+++ b/aixplain/v2/session.py
@@ -423,6 +423,36 @@ class ExecutionConfig:
         return out
 
     @classmethod
+    def _lift_wire_budget(cls, kvs: Any) -> Any:
+        """Lift a wire ``executionParams.budget`` back into the ``budget`` slot.
+
+        ``to_api_dict`` serializes ``budget`` *into* ``executionParams.budget``,
+        but nothing decoded it back out — so a session loaded from the backend
+        came back with ``budget=None`` and the real cap buried inside
+        ``execution_params``. Anything that then set ``budget`` (e.g. the run
+        path seeding it from ``agent.budget``) would silently overwrite that
+        persisted cap on the next ``to_api_dict``. Decoding is now symmetric with
+        encoding, so there is exactly one representation of the cap in memory.
+
+        An explicit top-level ``budget`` wins; the standalone nested key is
+        always dropped so it cannot be emitted twice. Returns a copy; the
+        caller's dict is untouched.
+        """
+        if not isinstance(kvs, dict):
+            return kvs
+        key = "executionParams" if "executionParams" in kvs else "execution_params"
+        ep = kvs.get(key)
+        if not isinstance(ep, dict) or ep.get("budget") is None:
+            return kvs
+        kvs = dict(kvs)  # shallow copy; never mutate the caller's dict
+        ep = dict(ep)
+        nested = ep.pop("budget")
+        if kvs.get("budget") is None:
+            kvs["budget"] = nested
+        kvs[key] = ep
+        return kvs
+
+    @classmethod
     def _fold_legacy_max_iterations(cls, kvs: Any) -> Any:
         """Fold a legacy ``executionParams.maxIterations`` into ``budget`` silently.
 
@@ -476,7 +506,7 @@ _dataclass_json_execution_config_from_dict = ExecutionConfig.from_dict.__func__
 
 
 def _execution_config_from_dict(cls, kvs: Any, *, infer_missing: bool = False) -> "ExecutionConfig":
-    kvs = cls._fold_legacy_max_iterations(kvs)
+    kvs = cls._fold_legacy_max_iterations(cls._lift_wire_budget(kvs))
     return _dataclass_json_execution_config_from_dict(cls, kvs, infer_missing=infer_missing)
 
 
@@ -548,7 +578,7 @@ class Session(
         if isinstance(kvs, dict):
             ec = kvs.get("executionConfig") or kvs.get("execution_config")
             if isinstance(ec, dict):
-                folded = ExecutionConfig._fold_legacy_max_iterations(ec)
+                folded = ExecutionConfig._fold_legacy_max_iterations(ExecutionConfig._lift_wire_budget(ec))
                 if folded is not ec:  # only copy when a fold actually happened
                     kvs = dict(kvs)
                     if "executionConfig" in kvs:

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -479,3 +479,159 @@ class TestRunPathWarningStacklevel:
         conflict = [w for w in caught if w.category is UserWarning and "precedence" in str(w.message)]
         assert conflict, "expected a run-path conflict UserWarning"
         assert conflict[0].filename == __file__, conflict[0].filename
+
+
+class TestSessionBudgetPreservation:
+    """A per-run override must never delete a session's persisted spend cap.
+
+    ``_apply_run_overrides_to_session`` used to rebuild ``ExecutionConfig`` from a
+    hardcoded five-field ``base`` dict that omitted ``budget``, then ``save()``
+    the loss — so the session (and every later message in it) ran uncapped
+    (BUG-1091). The merge now rebuilds from the stored config object, and the
+    agent's own budget may only *fill* caps the session leaves unset.
+    """
+
+    @staticmethod
+    def _session(execution_config=None):
+        from aixplain.v2.session import Session
+
+        session = MagicMock(spec=Session)
+        session.id = "sess_abc"
+        session.execution_config = execution_config
+        session.save = MagicMock()
+        return session
+
+    @staticmethod
+    def _apply(agent, session, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            agent._apply_run_overrides_to_session(session, kwargs)
+
+    def test_override_preserves_session_budget(self):
+        """Row 1: session cap, no agent cap → the cap survives the override."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        session = self._session(ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0, max_iterations=7)))
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.criteria == "be terse"
+        assert session.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert session.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 7,
+        }
+        assert session.save.call_count == 1
+
+    def test_preserves_every_other_execution_config_field(self):
+        """The same trap would reopen for any other field, so pin them all."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        stored = ExecutionConfig(
+            execution_params={"maxTokens": 64},
+            criteria="old",
+            evolve="{}",
+            identifier="corr-1",
+            run_response_generation=True,
+            budget=Budget(max_cost=5.0),
+        )
+        session = self._session(stored)
+
+        self._apply(agent, session, criteria="be terse")
+
+        merged = session.execution_config
+        assert merged.execution_params == {"maxTokens": 64}
+        assert merged.evolve == "{}"
+        assert merged.identifier == "corr-1"
+        assert merged.run_response_generation is True
+        assert merged.budget == Budget(max_cost=5.0)
+
+    def test_session_cap_wins_over_agent_cap(self):
+        """Row 2: a persisted session cap is never widened or replaced."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0)))
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget == Budget(max_cost=5.0)
+
+    def test_agent_cap_fills_unset_session_slot(self):
+        """Row 3: the agent's budget only fills caps the session leaves unset."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_iterations=7)
+        session = self._session(ExecutionConfig(budget=Budget(max_cost=5.0)))
+
+        self._apply(agent, session)
+
+        assert session.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert session.save.call_count == 1
+
+    def test_agent_budget_applies_when_session_has_none(self):
+        """Row 4: ``agent.budget`` was applied on the direct run path only."""
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(None)
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget == Budget(max_cost=1.0)
+        assert session.execution_config.criteria == "be terse"
+        assert session.save.call_count == 1
+
+    def test_empty_agent_budget_contributes_nothing(self):
+        """Row 5: the default empty ``Budget()`` must stay inert."""
+        agent = _create_agent()
+        session = self._session(None)
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget is None
+
+    def test_no_overrides_and_no_new_cap_does_not_save(self):
+        """Row 6: a plain session run must still perform no write."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        session = self._session(ExecutionConfig(criteria="be brief", budget=Budget(max_cost=5.0)))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            agent._apply_run_overrides_to_session(session, {})
+
+        session.save.assert_not_called()
+
+    def test_no_overrides_and_no_config_does_not_save(self):
+        agent = _create_agent()
+        session = self._session(None)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            agent._apply_run_overrides_to_session(session, {})
+
+        session.save.assert_not_called()
+        assert session.execution_config is None
+
+    def test_warning_names_the_seeded_budget(self):
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(None)
+
+        with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
+            agent._apply_run_overrides_to_session(session, {"criteria": "be terse"})
+
+    def test_accepts_a_dict_execution_config(self):
+        """Sessions hydrated from the backend may carry a raw dict."""
+        agent = _create_agent()
+        session = self._session({"criteria": "old", "budget": {"maxCost": 5.0}})
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.criteria == "be terse"
+        assert session.execution_config.budget == Budget(max_cost=5.0)

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -293,18 +293,14 @@ class TestDeprecatedRunTimeMaxIterations:
     def test_folds_into_execution_budget(self):
         agent = _create_agent()
         with pytest.warns(DeprecationWarning):
-            payload = agent.build_run_payload(
-                query="q", execution_params={"max_iterations": 7}
-            )
+            payload = agent.build_run_payload(query="q", execution_params={"max_iterations": 7})
         assert payload["executionParams"]["budget"] == {"maxIterations": 7}
         assert "maxIterations" not in payload["executionParams"]
 
     def test_camel_case_exec_param_also_folds(self):
         agent = _create_agent()
         with pytest.warns(DeprecationWarning):
-            payload = agent.build_run_payload(
-                query="q", execution_params={"maxIterations": 7}
-            )
+            payload = agent.build_run_payload(query="q", execution_params={"maxIterations": 7})
         assert payload["executionParams"]["budget"] == {"maxIterations": 7}
         assert "maxIterations" not in payload["executionParams"]
 
@@ -411,9 +407,7 @@ class TestFromDictLegacyMaxIterations:
                 "id": "a",
                 "name": "t",
                 "maxIterations": 3,
-                "tasks": [
-                    {"name": "task1", "description": "desc", "expectedOutput": "o"}
-                ],
+                "tasks": [{"name": "task1", "description": "desc", "expectedOutput": "o"}],
             }
         )
         assert agent.budget.max_iterations == 3
@@ -625,6 +619,30 @@ class TestSessionBudgetPreservation:
 
         with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
             agent._apply_run_overrides_to_session(session, {"criteria": "be terse"})
+
+    def test_backend_hydrated_session_cap_still_wins(self):
+        """The session's cap must win even when it arrives in the wire shape.
+
+        ``to_api_dict`` nests the cap inside ``executionParams.budget``. If the
+        decoder leaves it there, ``execution_config.budget`` reads as ``None``,
+        the agent's budget looks like it is filling an unset slot, and the next
+        ``to_api_dict`` overwrites the session's persisted cap wholesale
+        (BUG-1091).
+        """
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=0.01, max_iterations=3)
+        wire = ExecutionConfig(execution_params={"maxTokens": 64}, budget=Budget(max_cost=5.0)).to_api_dict()
+        session = self._session(ExecutionConfig.from_dict(wire))
+
+        self._apply(agent, session, criteria="be terse")
+
+        # Session's max_cost survives; the agent only fills the unset slot.
+        assert session.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 3,
+        }
 
     def test_accepts_a_dict_execution_config(self):
         """Sessions hydrated from the backend may carry a raw dict."""

--- a/tests/unit/v2/test_agent_progress.py
+++ b/tests/unit/v2/test_agent_progress.py
@@ -1,5 +1,8 @@
 """Unit tests for the v2 agent progress formatter."""
 
+from unittest.mock import MagicMock
+
+from aixplain.v2.agent import Agent
 from aixplain.v2.agent_progress import AgentProgressTracker
 
 
@@ -61,3 +64,71 @@ def test_completion_message_includes_arrow_style_totals(capsys):
 
     captured = capsys.readouterr().out
     assert "↓510 ↑536 (1046)" in captured
+
+
+class TestProgressKwargsStayOffTheWire:
+    """``progress_*`` configure the client-side display, never the run body.
+
+    They were in no filter, so ``build_run_payload``'s catch-all snake_case →
+    camelCase forwarder put them in the run POST — coupling the SDK's display
+    options to the backend's input contract (BUG-1091). The tracker must keep
+    receiving them: ``before_run`` sees the *unfiltered* kwargs.
+    """
+
+    PROGRESS_KWARGS = {"progress_format": "logs", "progress_verbosity": 2, "progress_truncate": False}
+
+    @staticmethod
+    def _runnable_agent():
+        agent = Agent.from_dict({"id": "a1", "name": "t"})
+        agent.context = MagicMock()
+        agent.status = None
+        fake_result = MagicMock()
+        fake_result.url = None
+        fake_result.completed = True
+        agent.handle_run_response = lambda response, **kw: fake_result
+        return agent
+
+    def test_progress_kwargs_absent_from_build_run_payload(self):
+        agent = self._runnable_agent()
+        payload = agent.build_run_payload(query="hi", **self.PROGRESS_KWARGS)
+
+        for key in self.PROGRESS_KWARGS:
+            assert key not in payload
+
+    def test_progress_kwargs_absent_from_the_posted_body(self):
+        agent = self._runnable_agent()
+        agent.run(query="hi", **self.PROGRESS_KWARGS)
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        for key in self.PROGRESS_KWARGS:
+            assert key not in body
+        assert body["query"] == {"input": "hi"}
+
+    def test_tracker_still_receives_the_progress_kwargs(self):
+        agent = self._runnable_agent()
+        observed = {}
+
+        def capture(kwargs):
+            observed.update({k: kwargs.get(k) for k in self.PROGRESS_KWARGS})
+
+        agent._start_progress_tracker = capture
+        agent.run(query="hi", **self.PROGRESS_KWARGS)
+
+        assert observed == self.PROGRESS_KWARGS
+
+
+class TestSdkRequestKwargsStayOffTheAgentWire:
+    """``api_key`` / ``resource_path`` are dispatch params, never model input."""
+
+    @staticmethod
+    def _runnable_agent():
+        return TestProgressKwargsStayOffTheWire._runnable_agent()
+
+    def test_api_key_never_reaches_the_agent_run_body(self):
+        agent = self._runnable_agent()
+        agent.run(query="hi", api_key="SECRET", resource_path="sdk/agents")
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert "SECRET" not in str(body)

--- a/tests/unit/v2/test_agent_save_server_fields.py
+++ b/tests/unit/v2/test_agent_save_server_fields.py
@@ -1,0 +1,131 @@
+"""Tests that save() does not write SDK defaults over server state (BUG-1093).
+
+``Agent.llm`` carries a class default (``DEFAULT_LLM``). When the response that
+hydrated an agent omitted ``model``, ``build_save_payload`` used to emit that
+default, so an unrelated edit (``agent.name = ...; agent.save()``) silently
+replaced the platform's configured model.
+
+Suppression is gated on hydration provenance: it only applies to a value that
+came from a server response which did not mention the key, and never to a value
+the caller assigned or to a locally constructed agent being created.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aixplain.v2.agent import Agent
+
+
+@pytest.fixture
+def context() -> MagicMock:
+    """Bind a mock context to the Agent class for the duration of a test."""
+    original = Agent.context
+    mock = MagicMock()
+    Agent.context = mock
+    try:
+        yield mock
+    finally:
+        Agent.context = original
+
+
+def _fetch(context: MagicMock, payload: dict) -> Agent:
+    """Hydrate an Agent through GetResourceMixin.get from *payload*."""
+    context.client.get.return_value = payload
+    return Agent.get(payload["id"])
+
+
+def test_save_omits_model_when_get_response_omitted_it(context):
+    """A GET without "model" must not cause the SDK default to be PUT back."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+
+    assert agent.llm == Agent.DEFAULT_LLM  # read side is unchanged
+    assert "model" not in agent.build_save_payload()
+
+
+def test_save_sends_model_when_get_response_included_it(context):
+    """A server-reported model is echoed back unchanged."""
+    agent = _fetch(context, {"id": "A1", "name": "agent", "model": {"id": "SERVER-LLM"}})
+
+    assert agent.build_save_payload()["model"] == {"id": "SERVER-LLM"}
+
+
+def test_save_sends_model_when_assigned_after_fetch(context):
+    """An explicit assignment is the caller's intent and is always sent."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    agent.llm = "CHOSEN-LLM"
+
+    assert agent.build_save_payload()["model"] == {"id": "CHOSEN-LLM"}
+
+
+def test_save_sends_model_when_explicitly_assigned_the_default(context):
+    """Assigning the default explicitly is still an assignment, not a fallback."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    agent.llm = Agent.DEFAULT_LLM
+
+    assert agent.build_save_payload()["model"] == {"id": Agent.DEFAULT_LLM}
+
+
+def test_save_sends_model_when_passed_through_save_kwargs(context):
+    """save(llm=...) sets the attribute, which counts as explicit."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    context.client.request.return_value = {"id": "A1", "name": "agent"}
+
+    agent.save(llm="KWARG-LLM")
+
+    payload = context.client.request.call_args.kwargs["json"]
+    assert payload["model"] == {"id": "KWARG-LLM"}
+
+
+def test_create_still_sends_default_model(context):
+    """Non-regression: a locally built agent still creates with the default LLM."""
+    agent = Agent(name="new agent")
+
+    assert agent.build_save_payload()["model"] == {"id": Agent.DEFAULT_LLM}
+
+
+def test_search_hydrated_agent_does_not_clobber_model(context):
+    """List/search hydration records provenance too, not just get()."""
+    (agent,) = Agent._build_resources([{"id": "A1", "name": "agent"}], context)
+
+    assert "model" not in agent.build_save_payload()
+
+
+def test_absent_none_defaulted_roles_are_still_popped(context):
+    """Roles defaulting to None keep their existing "omit the key" behaviour."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    payload = agent.build_save_payload()
+
+    assert agent.supervisor is None
+    for key in ("supervisor", "planner", "responder"):
+        assert key not in payload
+
+
+def test_clone_of_fetched_agent_sends_model(context):
+    """A clone is a create: it forgets provenance and sends the full payload."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    cloned = agent.clone(name="copy")
+
+    assert cloned.build_save_payload()["model"] == {"id": Agent.DEFAULT_LLM}
+
+
+def test_update_payload_still_carries_server_model(context):
+    """End-to-end: the PUT for a model-bearing agent is unchanged."""
+    agent = _fetch(context, {"id": "A1", "name": "agent", "model": {"id": "SERVER-LLM"}})
+    context.client.request.return_value = {"id": "A1", "name": "renamed"}
+
+    agent.save(name="renamed")
+
+    payload = context.client.request.call_args.kwargs["json"]
+    assert payload["model"] == {"id": "SERVER-LLM"}
+
+
+def test_update_payload_omits_model_for_model_less_agent(context):
+    """End-to-end: renaming an agent fetched without "model" leaves it alone."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    context.client.request.return_value = {"id": "A1", "name": "renamed"}
+
+    agent.save(name="renamed")
+
+    payload = context.client.request.call_args.kwargs["json"]
+    assert "model" not in payload

--- a/tests/unit/v2/test_agent_save_server_fields.py
+++ b/tests/unit/v2/test_agent_save_server_fields.py
@@ -129,3 +129,28 @@ def test_update_payload_omits_model_for_model_less_agent(context):
 
     payload = context.client.request.call_args.kwargs["json"]
     assert "model" not in payload
+
+
+def test_duplicate_response_records_provenance(context):
+    """duplicate() hydrates like get() does, so it must record provenance too."""
+    agent = _fetch(context, {"id": "A1", "name": "agent", "model": {"id": "SERVER-LLM"}})
+    context.client.request.return_value = {"id": "A2", "name": "agent (copy)"}
+
+    duplicated = agent.duplicate()
+
+    assert duplicated.id == "A2"
+    assert "model" not in duplicated.build_save_payload()
+
+
+def test_duplicate_keeps_model_reported_by_the_copy(context):
+    """A duplicate whose response carries "model" still echoes it back."""
+    agent = _fetch(context, {"id": "A1", "name": "agent"})
+    context.client.request.return_value = {
+        "id": "A2",
+        "name": "agent (copy)",
+        "model": {"id": "COPY-LLM"},
+    }
+
+    duplicated = agent.duplicate()
+
+    assert duplicated.build_save_payload()["model"] == {"id": "COPY-LLM"}

--- a/tests/unit/v2/test_agent_via_session.py
+++ b/tests/unit/v2/test_agent_via_session.py
@@ -259,6 +259,71 @@ class TestRunWithSessionOverrides:
             agent.run("hi again", session="sess_abc", criteria="be brief")
         existing.save.assert_not_called()
 
+    def test_override_does_not_delete_the_session_budget(self):
+        """A per-run override must not silently drop the session's spend cap.
+
+        The merge used to rebuild ExecutionConfig from a hardcoded field list
+        that omitted ``budget`` and then ``save()`` the loss, so the session ran
+        uncapped from that point on (BUG-1091).
+        """
+        from aixplain.v2.agent import Budget
+
+        ctx = _make_mock_context()
+
+        existing = Mock(spec=Session)
+        existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0, max_iterations=7))
+        existing.save = Mock()
+        existing.add_message = Mock(return_value=_user_message(request_id="req_budget"))
+
+        ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_budget")
+
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        with pytest.warns(UserWarning, match="session 'sess_abc'"):
+            agent.run("hi again", session="sess_abc", criteria="be brief")
+
+        existing.save.assert_called_once()
+        assert existing.execution_config.criteria == "be brief"
+        assert existing.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert existing.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 7,
+        }
+
+    def test_agent_budget_seeds_a_session_without_one(self):
+        """``agent.budget`` applied on the direct run path only; now on both."""
+        from aixplain.v2.agent import Budget
+
+        ctx = _make_mock_context()
+
+        existing = Mock(spec=Session)
+        existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = None
+        existing.save = Mock()
+        existing.add_message = Mock(return_value=_user_message(request_id="req_seed"))
+
+        ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_seed")
+
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent.budget = Budget(max_cost=1.0)
+        agent._update_saved_state()
+
+        with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
+            agent.run("hi again", session="sess_abc")
+
+        existing.save.assert_called_once()
+        assert existing.execution_config.budget == Budget(max_cost=1.0)
+
 
 # ---------------------------------------------------------------------------
 # 4. Attachments / files / audio-as-prompt

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -6,6 +6,8 @@ This module tests Model-specific functionality including:
 - V1 payload conversion for sync-only models
 """
 
+import json
+
 import pytest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -341,8 +343,15 @@ class TestModelRunRouting:
         mock_super_run_async.assert_called_once()
         assert result.status == "IN_PROGRESS"
 
-    def test_build_run_payload_strips_sdk_params(self):
-        """build_run_payload should exclude timeout, wait_time, show_progress, stream."""
+    def test_build_run_payload_keeps_sdk_control_keys_out_of_the_body(self):
+        """SDK-control kwargs must not ride in the model *input body*.
+
+        ``stream`` in particular is a path selector expressed on the wire as
+        ``options.stream`` by ``run_stream`` — see
+        ``TestModelStreamDispatch`` for the dispatch half. Stripping it here is
+        correct but is *not* on its own evidence that ``run(stream=True)``
+        streams (BUG-1091).
+        """
         model = self._create_model_with_mocks(connection_type=["asynchronous"])
         payload = model.build_run_payload(
             text="hello",
@@ -506,6 +515,184 @@ class TestRunHeaderKeysAreSingleSourceOfTruth:
 
     def test_header_kwargs_covered_by_sdk_only_params(self):
         assert {key for key, _ in Model._RUN_HEADER_KEYS} <= Model._SDK_ONLY_PARAMS
+
+    def test_sdk_only_params_is_derived_not_duplicated(self):
+        """``_SDK_ONLY_PARAMS`` must *be* ``_RUN_CONTROL_KEYS``, not a copy of it.
+
+        Two hand-maintained literals is how ``session_id`` was once filtered on
+        one path and shipped on the other. Identity here makes that drift
+        impossible rather than merely absent (BUG-1091).
+        """
+        assert Model._SDK_ONLY_PARAMS == Model._RUN_CONTROL_KEYS
+
+    @pytest.mark.parametrize("path", ["run", "run_stream", "_run_async_v1"])
+    def test_every_header_kwarg_rides_as_header_on_every_request_path(self, path):
+        """Each ``_RUN_HEADER_KEYS`` entry must become a header — and stay out of
+        the body — on *all three* request-issuing model paths.
+
+        ``run_stream`` and ``_run_async_v1`` build their own requests, which is
+        exactly where the shared filters silently stopped applying (BUG-1091).
+        """
+        for key, header in Model._RUN_HEADER_KEYS:
+            model = _model_with_mock_client(sync_only=(path != "run"))
+            client = model.context.client
+            kwargs = {"text": "hi", key: "v"}
+
+            if path == "run":
+                model.run(**kwargs)
+                call = client.request.call_args
+                body = call.kwargs["json"]
+            elif path == "run_stream":
+                model.run_stream(**kwargs)
+                call = client.request_stream.call_args
+                body = call.kwargs["json"]
+            else:
+                model._run_async_v1(**kwargs)
+                call = client.request_raw.call_args
+                body = json.loads(call.kwargs["data"])
+
+            assert call.kwargs["headers"][header] == "v", f"{path} dropped {header}"
+            assert key not in body, f"{path} leaked {key} into the body"
+
+
+def _model_with_mock_client(sync_only: bool = True) -> Model:
+    """A Model wired to a mock client that answers every request-issuing path."""
+    model = Model.__new__(Model)
+    model.id = "test-model-id"
+    model.name = "Test Model"
+    model.connection_type = ["synchronous"] if sync_only else ["asynchronous"]
+    model.params = None
+    model.supports_streaming = True
+    model.__post_init__()
+    model.context = Mock()
+    model.context.model_url = "https://models.aixplain.com/api/v2/execute"
+    model.context.client.request.return_value = {"status": "SUCCESS", "completed": True, "data": "ok"}
+    model.context.client.request_raw.return_value.json.return_value = {
+        "status": "IN_PROGRESS",
+        "data": "https://models.aixplain.com/api/v1/data/poll-id",
+    }
+    return model
+
+
+class TestModelStreamDispatch:
+    """``run(stream=True)`` must actually stream (BUG-1091).
+
+    The flag was declared, documented in four shipped places (including the
+    ``Model`` docstring and the bundled skill), stripped from the payload — and
+    never read by ``run``, so callers silently got a blocking ``ModelResult``.
+    """
+
+    def test_stream_true_dispatches_to_run_stream(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello", stream=True)
+
+        assert isinstance(result, ModelResponseStreamer)
+        assert model.context.client.request_stream.call_count == 1
+        assert model.context.client.request.call_count == 0
+
+    def test_stream_true_sets_options_stream_on_the_wire(self):
+        """The flag is expressed as ``options.stream``, never as a body field."""
+        model = _model_with_mock_client()
+        model.run(text="hello", stream=True)
+
+        body = model.context.client.request_stream.call_args.kwargs["json"]
+        assert body["options"]["stream"] is True
+        assert "stream" not in body
+
+    def test_stream_false_runs_normally(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello", stream=False)
+
+        assert isinstance(result, ModelResult)
+        assert model.context.client.request_stream.call_count == 0
+        assert model.context.client.request.call_count == 1
+        assert "stream" not in model.context.client.request.call_args.kwargs["json"]
+
+    def test_run_without_stream_kwarg_unchanged(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello")
+
+        assert isinstance(result, ModelResult)
+        assert model.context.client.request_stream.call_count == 0
+        assert model.context.client.request.call_args.kwargs["json"] == {"text": "hello"}
+
+    def test_stream_dispatch_forwards_remaining_kwargs(self):
+        """Model params and identity metadata survive the hand-off to run_stream."""
+        model = _model_with_mock_client()
+        model.run(text="hello", temperature=0.7, stream=True, identifier="alice")
+
+        call = model.context.client.request_stream.call_args
+        assert call.kwargs["json"]["temperature"] == 0.7
+        assert call.kwargs["headers"] == {"x-user-id": "alice"}
+
+
+class TestModelStreamPathFilters:
+    """``run_stream`` is still a run: same body filter, same identity headers."""
+
+    def test_run_stream_sends_identity_headers(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi", identifier="alice", session_id="sess-1", agent_name="Researcher")
+
+        headers = model.context.client.request_stream.call_args.kwargs["headers"]
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
+    def test_run_stream_omits_headers_when_no_metadata(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi")
+
+        assert "headers" not in model.context.client.request_stream.call_args.kwargs
+
+    def test_run_stream_strips_api_key_from_body(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi", api_key="SECRET", resource_path="v2/models")
+
+        body = model.context.client.request_stream.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert body["text"] == "hi"
+
+
+class TestRunAsyncV1Headers:
+    """The sync-only async fallback builds its own request — it must still send
+    the identity headers the sync path sends (BUG-1091)."""
+
+    def test_run_async_v1_sends_identity_headers(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi", identifier="alice", session_id="sess-1", agent_name="Researcher")
+
+        headers = model.context.client.request_raw.call_args.kwargs["headers"]
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
+    def test_run_async_v1_omits_headers_when_no_metadata(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi")
+
+        assert "headers" not in model.context.client.request_raw.call_args.kwargs
+
+    def test_run_async_v1_strips_sdk_keys_from_body(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi", api_key="SECRET", resource_path="v2/models", temperature=0.7)
+
+        body = json.loads(model.context.client.request_raw.call_args.kwargs["data"])
+        assert body == {"data": "hi", "temperature": 0.7}
+
+
+class TestOpenEndedModelParamsStillPassThrough:
+    """Model parameters are declared per-model by the backend and ship without an
+    SDK release, so ``run()`` deliberately does **not** reject unknown kwargs —
+    only the known SDK-control keys are stripped.
+
+    Pinned so a later tidy-up cannot quietly close the open channel and break
+    ``temperature`` / ``max_tokens`` / every future backend parameter. See the
+    BUG-1091 PR body for the deviation rationale.
+    """
+
+    def test_known_and_unknown_model_params_are_both_forwarded(self):
+        model = _model_with_mock_client()
+        model.run(text="hi", temperature=0.7, maxTokns=100)
+
+        body = model.context.client.request.call_args.kwargs["json"]
+        assert body == {"text": "hi", "temperature": 0.7, "maxTokns": 100}
 
 
 class TestRunHeaderValuesMustBeAscii:

--- a/tests/unit/v2/test_run_kwargs_stripped.py
+++ b/tests/unit/v2/test_run_kwargs_stripped.py
@@ -1,0 +1,204 @@
+"""SDK-control run kwargs must never reach the wire body (BUG-1091).
+
+``api_key`` and ``resource_path`` are declared on ``BaseParams``, so they can
+arrive on *any* v2 call. Neither is a backend body field:
+
+- ``api_key`` authenticates nothing — ``Client.request_raw`` always overlays
+  ``_auth_headers()`` from the Aixplain context — so its only observable effect
+  was riding into the model input body and, from there, the supplier's prompt
+  logs.
+- ``resource_path`` is consumed by the URL builders.
+
+Both are also not ``requests`` kwargs, which is why the same root cause made
+``delete(resource_path=…)`` and ``get(id, api_key=…)`` raise deep inside
+``requests``.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from dataclasses_json import dataclass_json
+
+from aixplain.v2.actions import Action, Actions, Inputs
+from aixplain.v2.agent import Agent
+from aixplain.v2.integration import ActionInputSpec
+from aixplain.v2.model import Model
+from aixplain.v2.resource import (
+    BaseDeleteParams,
+    BaseResource,
+    DeleteResourceMixin,
+    DeleteResult,
+    GetResourceMixin,
+    RunnableResourceMixin,
+)
+from aixplain.v2.tool import Tool
+
+SDK_REQUEST_KWARGS = {"api_key": "SECRET-TEAM-KEY", "resource_path": "v2/custom"}
+
+
+def _model(cls=Model):
+    model = cls.__new__(cls)
+    model.id = "test-model-id"
+    model.name = "Test Model"
+    model.connection_type = ["synchronous"]
+    model.params = None
+    model.__post_init__()
+    model.context = Mock()
+    model.context.model_url = "https://models.aixplain.com/api/v2/execute"
+    model.context.client.request.return_value = {"status": "SUCCESS", "completed": True, "data": "ok"}
+    return model
+
+
+def _tool():
+    """A Tool with one allowed action, wired to a mock client."""
+    tool = _model(Tool)
+    tool.description = "Tool description"
+    tool.allowed_actions = ["search"]
+    tool._dynamic_attrs = {}
+    spec = ActionInputSpec(
+        name="Query", code="query", datatype="string", default_value=[], required=False, description="Query"
+    )
+    action = Action(name="search", inputs=Inputs.from_action_input_specs([spec]))
+    tool.__dict__["actions"] = Actions(actions={"search": action})
+    return tool
+
+
+def _agent():
+    agent = Agent.from_dict({"id": "a1", "name": "t"})
+    agent.context = MagicMock()
+    agent.status = None
+    fake_result = MagicMock()
+    fake_result.url = None
+    fake_result.completed = True
+    agent.handle_run_response = lambda response, **kw: fake_result
+    return agent
+
+
+class TestControlKeysAreDeclaredOnce:
+    """One authoritative set, inherited by every runnable."""
+
+    def test_base_mixin_strips_the_dispatch_keys(self):
+        assert {"api_key", "resource_path"} <= RunnableResourceMixin._RUN_CONTROL_KEYS
+
+    def test_base_mixin_strips_the_progress_display_keys(self):
+        assert {
+            "show_progress",
+            "progress_format",
+            "progress_verbosity",
+            "progress_truncate",
+        } <= RunnableResourceMixin._RUN_CONTROL_KEYS
+
+    @pytest.mark.parametrize("cls", [Model, Tool, Agent])
+    def test_every_runnable_inherits_them(self, cls):
+        assert {"api_key", "resource_path"} <= cls._RUN_CONTROL_KEYS
+
+
+class TestApiKeyNeverReachesARunBody:
+    def test_model_build_run_payload(self):
+        assert _model().build_run_payload(text="hi", **SDK_REQUEST_KWARGS) == {"text": "hi"}
+
+    def test_tool_build_run_payload(self):
+        assert _model(Tool).build_run_payload(text="hi", **SDK_REQUEST_KWARGS) == {"text": "hi"}
+
+    def test_model_posted_body(self):
+        model = _model()
+        model.run(text="hi", **SDK_REQUEST_KWARGS)
+
+        body = model.context.client.request.call_args.kwargs["json"]
+        assert body == {"text": "hi"}
+
+    def test_tool_posted_body(self):
+        tool = _tool()
+        tool.run(data={"query": "hi"}, **SDK_REQUEST_KWARGS)
+
+        body = tool.context.client.request.call_args.kwargs["json"]
+        assert body == {"action": "search", "data": {"query": "hi"}}
+
+    def test_agent_posted_body(self):
+        agent = _agent()
+        agent.run(query="hi", **SDK_REQUEST_KWARGS)
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert SDK_REQUEST_KWARGS["api_key"] not in str(body)
+
+    def test_resource_path_still_selects_the_run_url(self):
+        """Stripping it from the *body* must not stop it steering the URL."""
+        model = _model()
+        model.run(text="hi", **SDK_REQUEST_KWARGS)
+
+        url = model.context.client.request.call_args[0][1]
+        assert url.endswith("/test-model-id")
+
+
+class TestDeleteAcceptsTheDispatchKeys:
+    """``delete()`` forwarded every kwarg to ``requests``, so passing either key
+    raised ``TypeError`` inside ``session.request()``."""
+
+    def _resource(self):
+        @dataclass_json
+        @dataclass
+        class DeletableResource(BaseResource, DeleteResourceMixin[BaseDeleteParams, DeleteResult]):
+            RESOURCE_PATH = "deletable"
+
+        resource = DeletableResource(id="123", name="to delete")
+        resource.context = Mock()
+        resource.context.client.request_raw = Mock(return_value=Mock())
+        return resource
+
+    def test_delete_with_resource_path_succeeds_and_uses_it(self):
+        resource = self._resource()
+
+        resource.delete(resource_path="sdk/agents")
+
+        call_args = resource.context.client.request_raw.call_args
+        assert call_args[0][0] == "delete"
+        assert "sdk/agents/123" in call_args[0][1]
+        assert "resource_path" not in call_args.kwargs
+
+    def test_delete_with_api_key_succeeds(self):
+        resource = self._resource()
+
+        resource.delete(api_key="SECRET-TEAM-KEY")
+
+        call_args = resource.context.client.request_raw.call_args
+        assert "deletable/123" in call_args[0][1]
+        assert "api_key" not in call_args.kwargs
+
+    def test_delete_still_forwards_genuine_request_kwargs(self):
+        resource = self._resource()
+
+        resource.delete(timeout=30)
+
+        assert resource.context.client.request_raw.call_args.kwargs["timeout"] == 30
+
+
+class TestGetAcceptsTheDispatchKeys:
+    def _cls(self):
+        @dataclass_json
+        @dataclass
+        class Gettable(BaseResource, GetResourceMixin[dict, "Gettable"]):
+            RESOURCE_PATH = "gettable"
+
+        Gettable.context = Mock()
+        Gettable.context.client.get = Mock(return_value={"id": "123", "name": "got"})
+        return Gettable
+
+    def test_get_with_api_key_succeeds(self):
+        cls = self._cls()
+
+        instance = cls.get("123", api_key="SECRET-TEAM-KEY")
+
+        assert instance.id == "123"
+        call_args = cls.context.client.get.call_args
+        assert call_args[0][0] == "gettable/123"
+        assert "api_key" not in call_args.kwargs
+
+    def test_get_still_forwards_genuine_request_kwargs(self):
+        cls = self._cls()
+
+        cls.get("123", timeout=30)
+
+        assert cls.context.client.get.call_args.kwargs["timeout"] == 30

--- a/tests/unit/v2/test_save_correctness.py
+++ b/tests/unit/v2/test_save_correctness.py
@@ -1,0 +1,235 @@
+"""Unit tests for save() correctness invariants (BUG-1093).
+
+Covers two failure modes that damaged the user's resources:
+
+* ``save()`` on a deleted resource took the create branch and POSTed a
+  duplicate, because ``save()`` was the only mutating path that never called
+  ``_ensure_valid_state()``.
+* ``_create()`` hydrated the POST response *before* recording the returned id,
+  so a deserialization failure orphaned a resource that already existed
+  remotely — and the obvious retry created a second one.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+from dataclasses_json import config, dataclass_json
+
+from aixplain.v2.agent import Agent
+from aixplain.v2.enums import AssetStatus
+from aixplain.v2.exceptions import AixplainV2Error, ResourceError
+from aixplain.v2.resource import (
+    BaseResource,
+    DeleteResourceMixin,
+    GetResourceMixin,
+)
+from aixplain.v2.tool import Tool
+
+
+def _reject(value):
+    """Decoder standing in for an SDK that is behind the backend."""
+    raise ValueError(f"unmodelled value {value!r}")
+
+
+@dataclass_json
+@dataclass
+class Thing(BaseResource, DeleteResourceMixin, GetResourceMixin):
+    """Minimal resource whose ``kind`` decoder rejects unmodelled values."""
+
+    kind: Optional[str] = field(default=None, metadata=config(decoder=_reject))
+
+
+Thing.RESOURCE_PATH = "v2/things"
+
+
+def _thing(**kwargs) -> Thing:
+    """Return a Thing bound to a mock context."""
+    thing = Thing(**kwargs)
+    thing.context = MagicMock()
+    return thing
+
+
+def _methods(context) -> list:
+    """Return the HTTP methods requested through *context*'s client."""
+    return [call.args[0] for call in context.client.request.call_args_list if call.args]
+
+
+# =============================================================================
+# Finding 1 — save() after delete() must not create a duplicate
+# =============================================================================
+
+
+def test_save_after_delete_raises_and_issues_no_request():
+    """A deleted resource must never fall through to the create branch."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+    thing.context.client.request.reset_mock()
+
+    with pytest.raises(AixplainV2Error, match="deleted"):
+        thing.save()
+
+    assert thing.context.client.request.call_args_list == []
+    assert thing.id is None
+
+
+def test_save_on_never_saved_resource_still_creates():
+    """The guard is conditional: a fresh resource must still be created."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {"id": "NEW-ID", "name": "thing"}
+
+    thing.save()
+
+    assert _methods(thing.context) == ["post"]
+    assert thing.id == "NEW-ID"
+
+
+def test_save_after_delete_is_not_one_shot():
+    """Repeated saves on a deleted resource keep raising."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+
+    for _ in range(2):
+        with pytest.raises(AixplainV2Error, match="deleted"):
+            thing.save()
+
+    assert _methods(thing.context) == []
+
+
+def test_clone_of_deleted_resource_can_be_saved():
+    """clone() produces a new resource, so the deleted flag must not carry over."""
+    thing = _thing(id="ID1", name="thing")
+    thing._update_saved_state()
+    thing.mark_as_deleted()
+
+    cloned = thing.clone(name="revived")
+    cloned.context = MagicMock()
+    cloned.context.client.request.return_value = {"id": "NEW-ID", "name": "revived"}
+
+    assert cloned.is_deleted is False
+    cloned.save()
+
+    assert _methods(cloned.context) == ["post"]
+    assert cloned.id == "NEW-ID"
+
+
+def test_agent_save_after_delete_does_not_touch_subcomponents_or_status():
+    """Agent.save() guards before saving children and before the status flip."""
+    child = Tool(name="child tool", code="def main():\n    return 1\n")
+    child.context = MagicMock()
+    agent = Agent(name="agent", tools=[child])
+    agent.context = MagicMock()
+    agent.id = "AGENT-1"
+    agent._update_saved_state()
+    agent.status = AssetStatus.ONBOARDED
+    agent.mark_as_deleted()
+    agent.status = AssetStatus.DELETED
+
+    with pytest.raises(AixplainV2Error, match="deleted"):
+        agent.save(save_subcomponents=True)
+
+    assert agent.status == AssetStatus.DELETED
+    assert child.id is None
+    assert agent.context.client.request.call_args_list == []
+    assert child.context.client.request.call_args_list == []
+
+
+def test_file_save_after_delete_raises():
+    """File.save() bypasses BaseResource.save(), so it carries its own guard.
+
+    File has no delete mixin today, so the deleted flag is set directly — the
+    guard exists so File never regains the duplicate-on-save behaviour if one
+    is added.
+    """
+    from aixplain.v2.file import File
+
+    file = File(id="FILE-1", name="report.pdf")
+    file.context = MagicMock()
+    file._update_saved_state()
+    file.id = None
+    file._deleted = True
+    file.context.client.request.reset_mock()
+
+    with pytest.raises(AixplainV2Error, match="deleted"):
+        file.save()
+
+    assert file.context.client.request.call_args_list == []
+
+
+# =============================================================================
+# Finding 2 — a create whose response cannot be hydrated must keep the id
+# =============================================================================
+
+
+def test_create_hydration_failure_records_server_id():
+    """The POST succeeded, so the id must land on self before hydration runs."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {
+        "id": "SERVER-ID-123",
+        "name": "thing",
+        "kind": "WEIRD_NEW_ENUM",
+    }
+
+    with pytest.raises(ResourceError) as excinfo:
+        thing.save()
+
+    assert thing.id == "SERVER-ID-123"
+    message = str(excinfo.value)
+    assert "SERVER-ID-123" in message
+    assert "do NOT retry" in message
+
+
+def test_create_hydration_failure_does_not_duplicate_on_second_save():
+    """After the failure the resource is reachable, so a retry updates it."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {
+        "id": "SERVER-ID-123",
+        "name": "thing",
+        "kind": "WEIRD_NEW_ENUM",
+    }
+    with pytest.raises(ResourceError):
+        thing.save()
+
+    thing.context.client.request.reset_mock()
+    thing.context.client.request.return_value = {"id": "SERVER-ID-123", "name": "thing"}
+    thing.save()
+
+    assert _methods(thing.context) == ["put"]
+    assert thing.context.client.request.call_args_list[0].args[1] == "v2/things/SERVER-ID-123"
+
+
+def test_api_key_create_reraises_hydration_failure():
+    """ApiKey._create's 422 fallback must not swallow the hydration error."""
+    from aixplain.v2.api_key import APIKey
+
+    api_key = APIKey(name="key")
+    api_key.context = MagicMock()
+    api_key.context.client.request.return_value = {"id": "KEY-1", "globalLimits": "not-a-mapping"}
+
+    with pytest.raises(ResourceError, match="do NOT retry"):
+        api_key.save()
+
+    assert api_key.id == "KEY-1"
+
+
+def test_create_preserves_recorded_id_when_response_omits_id_field():
+    """The copy loop must not overwrite the captured id with None."""
+
+    @dataclass_json
+    @dataclass
+    class IdLosingThing(BaseResource):
+        """Resource whose id decoder drops the value."""
+
+        id: Optional[str] = field(default=None, metadata=config(decoder=lambda _: None))
+
+    IdLosingThing.RESOURCE_PATH = "v2/things"
+    thing = IdLosingThing(name="thing")
+    thing.context = MagicMock()
+    thing.context.client.request.return_value = {"id": "SERVER-ID-123", "name": "thing"}
+
+    thing.save()
+
+    assert thing.id == "SERVER-ID-123"

--- a/tests/unit/v2/test_save_correctness.py
+++ b/tests/unit/v2/test_save_correctness.py
@@ -233,3 +233,17 @@ def test_create_preserves_recorded_id_when_response_omits_id_field():
     thing.save()
 
     assert thing.id == "SERVER-ID-123"
+
+
+def test_create_hydration_failure_without_id_gives_actionable_message():
+    """A response with no id cannot be re-fetched, so the hint must not claim it can."""
+    thing = _thing(name="thing")
+    thing.context.client.request.return_value = {"name": "thing", "kind": "WEIRD_NEW_ENUM"}
+
+    with pytest.raises(ResourceError) as excinfo:
+        thing.save()
+
+    message = str(excinfo.value)
+    assert thing.id is None
+    assert "Thing.get(None)" not in message
+    assert "check before retrying" in message

--- a/tests/unit/v2/test_session.py
+++ b/tests/unit/v2/test_session.py
@@ -1242,6 +1242,43 @@ class TestExecutionConfigBudget:
             )
         assert cfg.to_api_dict()["executionParams"]["budget"]["maxIterations"] == 9
 
+    def test_from_dict_lifts_nested_budget_out_of_execution_params(self):
+        """Decoding must mirror encoding: ``executionParams.budget`` -> ``budget``.
+
+        ``to_api_dict`` nests the cap inside ``executionParams``, but nothing
+        decoded it back out, so a backend-loaded session had ``budget=None`` with
+        the real cap buried in ``execution_params``. Anything that then set
+        ``budget`` (the run path seeds it from ``agent.budget``) silently
+        overwrote the persisted cap on the next send (BUG-1091).
+        """
+        sent = ExecutionConfig(execution_params={"maxTokens": 64}, budget=Budget(max_cost=5.0)).to_api_dict()
+
+        cfg = ExecutionConfig.from_dict(sent)
+
+        assert cfg.budget == Budget(max_cost=5.0)
+        assert cfg.execution_params == {"maxTokens": 64}
+        assert cfg.to_api_dict() == sent  # round-trip is stable
+
+    def test_from_dict_nested_budget_defers_to_an_explicit_top_level_one(self):
+        cfg = ExecutionConfig.from_dict(
+            {"executionParams": {"budget": {"maxCost": 5.0}}, "budget": {"maxCost": 1.0}}
+        )
+
+        assert cfg.budget == Budget(max_cost=1.0)
+        assert cfg.to_api_dict() == {"executionParams": {"budget": {"maxCost": 1.0}}}
+
+    def test_session_from_dict_lifts_nested_budget(self):
+        session = Session.from_dict(
+            {
+                "id": "s1",
+                "agentId": "a1",
+                "executionConfig": {"executionParams": {"maxTokens": 64, "budget": {"maxCost": 5.0}}},
+            }
+        )
+
+        assert session.execution_config.budget == Budget(max_cost=5.0)
+        assert session.execution_config.execution_params == {"maxTokens": 64}
+
     def test_session_from_dict_legacy_execution_config_no_warning(self):
         # Loading a Session whose nested executionConfig carries a legacy
         # maxIterations must not warn and must fold into budget.


### PR DESCRIPTION
## Summary

Three ways `save()` damaged the user's resources, all re-verified by runtime reproduction on this branch before any change (the ticket's line numbers had drifted):

1. **`save()` after `delete()` created a duplicate.** `mark_as_deleted()` sets `id=None`, and `save()` branched on `if self.id` — so a deleted object took the `_create()` path. `save()` was the only mutating path that never called `_ensure_valid_state()`; every other one (`delete`, `_action`, `encoded_id`, `build_delete_url`, `build_run_url`, …) does.
2. **A create whose response failed to deserialize lost the server id.** The POST succeeded (the resource exists remotely), then `from_dict(result)` raised before `self.id` was ever assigned. The natural reaction — retrying `save()` — created a second resource and orphaned the first.
3. **`save()` wrote SDK defaults over server state.** When the hydrating GET/list response omitted `model`, `Agent.llm` fell back to the class default and the PUT actively wrote `DEFAULT_LLM` over the platform's configured model.

### Reproduction (before the fix)

```
F1: after delete(), save() issued  post v2/things {"id": None, "name": "n", ...}  and rebound self.id
F2: ResourceError: Failed to save resource: unmodelled value 'WEIRD_NEW_ENUM'   |  resource.id is None
F3: Agent.get() with a model-less response -> build_save_payload()["model"] == {"id": "69b7e5f1b2fe44704ab0e7d0"}
```

### After

```
F1: raises AixplainV2Error("... has been deleted and cannot be used for operations."), zero HTTP calls
F2: ResourceError names the id ("do NOT retry save()"), resource.id == "SERVER-ID-123"; the retry issues put v2/things/SERVER-ID-123
F3: model-less hydration -> no "model" key in the payload;  locally built Agent -> {"id": DEFAULT_LLM} (unchanged)
```

## Per-finding status

| # | Finding | Status | Notes |
| - | ------- | ------ | ----- |
| 1 | `save()` on a deleted object creates a duplicate | **Fixed** | `BaseResource.save()` now calls `_ensure_valid_state()` when the resource has an id or is deleted. Unconditional would break every create (a fresh object has `id=None` and raises "has not been saved yet") — verified. `Agent.save()` and `File.save()` carry the same guard at their own entry points. |
| 1b | `Agent.save()` damages a deleted agent before the base call | **Fixed** (found while re-verifying) | `Agent.save()` runs `_save_subcomponents()` first, and `before_save()` flips `status` `DELETED → ONBOARDED`. A base-only guard left both. |
| 1c | `File.save()` bypasses `BaseResource.save()` entirely | **Fixed** (found while re-verifying) | Own guard added. `File` has no delete mixin today, so this is forward-looking; `Skill.save()` delegates to the base and is covered for free. |
| 2 | Create + hydration failure loses the server id | **Fixed** | `_create()` records `result["id"]` before `from_dict()`, then raises a `ResourceError` naming the id and telling the caller not to retry. The copy loop can no longer null the captured id. |
| 3 | `save()` writes SDK defaults over server fields | **Fixed for the reported case** (`Agent` role refs) | Narrow, provenance-gated fix — see below. |
| 3b | `save()` sends explicit `null`s / omits fields the SDK does not model | **Skipped — blocked on a backend answer** | See "Open backend question". |

## Finding 3 — what was fixed, and what deliberately was not

`BaseResource` now records which top-level wire keys the hydrating response actually carried (`_server_fields`), at all four hydration sites: `GetResourceMixin.get`, `_deserialize_items` (list/search — the highest-value site, since `search(...)[0].save()` is a common pattern), `_create`, and `Agent.duplicate()` (the one Agent hydration path that review caught still missing provenance — without it, `save()` on a duplicate could PUT the SDK default model over the platform's value). `Agent._apply_llm_fields_to_save_payload` omits a role ref only when **all three** hold: it is still the class default, the server never reported that key, and the caller never assigned it.

| Scenario | Emits `model`? |
| -------- | -------------- |
| `Agent(name=…)` then `save()` (create) | yes (unchanged) |
| `Agent(llm="X")` then `save()` (create) | yes (unchanged) |
| `get()` response **has** `model` | yes (unchanged) |
| `get()` / `search()` response **omits** `model` | **no — the fix** |
| omitted, then `agent.llm = "X"` (or `= DEFAULT_LLM`, or `save(llm="X")`) | yes — explicit assignment wins |
| `clone()` of a fetched agent | yes — a clone is a create, so it forgets provenance |
| `duplicate()` whose response omits `model` | **no** — provenance is recorded from the duplicate response |

`_server_fields` / `_explicit_roles` are plain instance attributes (the pattern `_deleted` already uses), never dataclass fields, so they are invisible to `to_dict`/`from_dict`, the `__dataclass_fields__` copy loop in `_create`, and `_get_serializable_state()`.

**Not attempted, per the ticket's "conservative" instruction:** no PATCH support, no dirty-field diffing, no `is_modified`-gated payload pruning. Note that `is_modified`/`_is_state_changed` could not have caught this bug anyway — they compare `to_dict()` output, which excludes role refs entirely (`exclude=lambda x: True`).

Also rejected: changing `Agent.llm`'s default to `None` (breaking read-side change to a public attribute), and suppressing on "equals default" alone without provenance (would break creates).

## Open backend question — is the v2 PUT merge- or replace-semantics?

`save()` PUTs the whole object. Reproduced on an `Agent` fetched from a sparse response, the payload carries **ten explicit nulls**: `instructions`, `expectedOutput`, `description`, `teamId`, `createdAt`, `updatedAt`, `inspectorId`, `maxInspectors`, `contextOverflowStrategy`, `path` — and omits any server-side field this SDK version does not model.

- If the backend **merges**, the residual blast radius is near zero and this narrow fix is the whole story.
- If it **replaces**, then every `save()` on a partially-hydrated object also drops unmodelled server fields, and a follow-up ticket is warranted (PATCH support, or `Undefined.INCLUDE` + round-tripping unknown keys). Sending `createdAt: null` / `updatedAt: null` looks wrong either way.

**This PR does not depend on the answer.** Recording it here as an explicit open item.

Two smaller follow-ups worth a decision: `_update()` discards the PUT response, so provenance goes stale across repeated saves (low impact — suppression only ever omits keys); and the `_server_fields` substrate is generic but is applied only to `Agent`'s role refs for now, though `Model`, `Tool`, `APIKey` and `Session` also have non-`None` class defaults on server-owned fields.

## Behaviour changes

| Change | Previously | Now |
| ------ | ---------- | --- |
| `save()` on a deleted resource | silently POSTed a duplicate | raises `AixplainV2Error` matching `"deleted"` |
| create + hydration failure | `ResourceError`, `id is None` | `ResourceError` naming the id, `id` recorded |
| `save()` after a `model`-less GET/list | PUT `model = DEFAULT_LLM` | `model` key omitted |
| `clone()` of a deleted resource | carried `_deleted=True` | `_deleted=False`, savable |

The only way to depend on the old behaviour is using `delete()`-then-`save()` as a "re-create" idiom; `clone().save()` is the supported replacement and is now covered by a test.

No public API signature changes — every addition is `_`-prefixed. No v1 changes (none of the findings required one).

## Test evidence

```
$ python -m pytest tests/unit -q
2109 passed, 3 skipped, 146 warnings in 32.24s

$ python -m pytest tests/unit/v2/test_save_correctness.py tests/unit/v2/test_agent_save_server_fields.py -q
24 passed in 0.45s
```

New: `tests/unit/v2/test_save_correctness.py` (11) — save-after-delete raises with zero HTTP calls; the guard is not one-shot; a never-saved resource still creates (regression guard for the conditional predicate); `clone()` of a deleted resource saves; a deleted `Agent` touches neither subcomponents nor its `DELETED` status; `File.save()`'s own guard; hydration failure records the id and the message forbids retry; the retry PUTs instead of POSTing; the copy loop preserves the captured id; `APIKey._create`'s 422 fallback re-raises the new `ResourceError` rather than swallowing it.

New: `tests/unit/v2/test_agent_save_server_fields.py` (13) — the full matrix above, end-to-end through `save()` as well as through `build_save_payload()`, including the key non-regression test that a locally built `Agent` still creates with `DEFAULT_LLM`.

`ruff check` and `ruff format` clean on the changed files; all pre-commit hooks pass.

Refs: [BUG-1093](https://aixplain.atlassian.net/browse/BUG-1093). Stacked on `bug-1094-v2-partial-results-and-failures` (same correctness audit) — its "report failures instead of success" precedent informed the decision to raise on finding 2 rather than swallow.



[BUG-1093]: https://aixplain.atlassian.net/browse/BUG-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ