### PR TITLE
fix: harden dotenv scope, debug logging, SSRF sinks and upload URL validation (BUG-939)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,26 @@ BACKEND_URL=https://platform-api.aixplain.com
 MODELS_RUN_URL=https://models.aixplain.com/api/v1/execute
 PIPELINE_API_KEY=<API_KEY>
 MODEL_API_KEY=<API_KEY>
-LOG_LEVEL=DEBUG
+# DEBUG is deliberately not the documented value: it used to log full request
+# and response bodies, including the aiXplain API key and any third-party token
+# inside a tool payload (BUG-939).
+LOG_LEVEL=INFO
 TEAM_API_KEY=<YOUR_API_KEY>
+
+# --- Optional security opt-ins (all default to off) ---
+# Log request/response bodies at DEBUG. Values are redacted and truncated, but
+# redaction is best-effort: do not enable it on a shared log sink.
+# AIXPLAIN_LOG_BODIES=1
+#
+# Allow plain http:// for BACKEND_URL / MODELS_RUN_URL / PIPELINES_RUN_URL and
+# for presigned upload URLs. Needed for local development against
+# http://localhost, and for an on-prem deployment terminating TLS elsewhere.
+# AIXPLAIN_ALLOW_INSECURE_URLS=1
+#
+# Allow the SDK to fetch code/artifact URLs that resolve to private or loopback
+# addresses. Only set this if your artifact host really is internal.
+# AIXPLAIN_ALLOW_PRIVATE_FETCH=1
+#
+# Extra hosts accepted as presigned upload targets, comma separated.
+# *.amazonaws.com and *.aixplain.com are always allowed.
+# AIXPLAIN_UPLOAD_HOST_ALLOWLIST=storage.example.com

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@ TEAM_API_KEY=<YOUR_API_KEY>
 # AIXPLAIN_ALLOW_INSECURE_URLS=1
 #
 # Allow the SDK to fetch code/artifact URLs that resolve to private or loopback
-# addresses. Only set this if your artifact host really is internal.
+# addresses. Only set this if your artifact host really is internal. The cloud
+# metadata endpoints stay blocked either way.
 # AIXPLAIN_ALLOW_PRIVATE_FETCH=1
 #
 # Extra hosts accepted as presigned upload targets, comma separated.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,6 +49,25 @@ A `filterwarnings` entry in your `pytest.ini` or `pyproject.toml` works too.
 
 One ordering caveat: to make the notice visible at all, the SDK inserts a `default` filter for its own category while `aixplain` is being imported — but only when `sys.warnoptions` is empty, i.e. when you passed no `-W` and set no `PYTHONWARNINGS`. A bare `warnings.simplefilter("ignore")` issued *before* `import aixplain` is therefore overridden. Use the environment variable, use `-W`/`PYTHONWARNINGS`, or register your filter after the import — all three win.
 
+## `aixplain.aixplain_v2` is deprecated
+
+The module-level `aixplain_v2` client is deprecated and will be removed in a future release. Construct a client explicitly instead:
+
+```python
+# deprecated
+from aixplain import aixplain_v2
+agent = aixplain_v2.Agent.get("...")
+
+# use instead
+from aixplain import Aixplain
+aix = Aixplain()            # or Aixplain(api_key="...")
+agent = aix.Agent.get("...")
+```
+
+It used to be built at import time with the failure swallowed, so a missing `TEAM_API_KEY` left the symbol bound to `None` and the first use failed with `AttributeError: 'NoneType' object has no attribute 'Agent'` rather than the actual cause. It is now constructed on first access and raises the real error (`API key is required. Pass api_key=... to Aixplain() or set TEAM_API_KEY or AIXPLAIN_API_KEY.`), and the first access emits a `DeprecationWarning`.
+
+`from aixplain import aixplain_v2` still works. It is no longer part of `from aixplain import *`, so a star import no longer needs a credential.
+
 ## Factory map at a glance
 
 | v1 factory | v2 equivalent | Status |

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -22,7 +22,28 @@ import os
 import logging
 from dotenv import load_dotenv
 
-load_dotenv()
+
+def _load_cwd_dotenv() -> bool:
+    """Load only the ``.env`` in the current working directory, never an ancestor's.
+
+    A bare ``load_dotenv()`` -- and ``find_dotenv(usecwd=True)`` -- searches
+    *parent* directories, so a ``.env`` shipped inside a cloned sample project or
+    a bug-report attachment could set ``BACKEND_URL``, ``TEAM_API_KEY``,
+    ``LOG_LEVEL`` or ``SENTRY_DSN`` for a user who merely ``cd``s into a
+    subdirectory and runs their own script with their own key (BUG-939). Loading
+    an explicit path removes the walk-up while keeping the documented behaviour
+    for a ``.env`` in the working directory itself.
+
+    Existing environment variables still win (``override=False``), as with the
+    bare call this replaces.
+
+    Returns:
+        bool: True when a ``.env`` was found in the working directory and loaded.
+    """
+    return load_dotenv(os.path.join(os.getcwd(), ".env"), override=False)
+
+
+_load_cwd_dotenv()
 
 from aixplain._compat import install as _install_compat  # noqa: E402
 

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -56,11 +56,51 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=LOG_LEVEL)
 
 
-aixplain_v2 = None
-try:
-    aixplain_v2 = Aixplain()
-except Exception:
-    pass
+_AIXPLAIN_V2_DEPRECATION = (
+    "'aixplain.aixplain_v2' is deprecated and will be removed in a future release. "
+    "Construct a client explicitly instead: 'from aixplain import Aixplain; aix = Aixplain()'."
+)
 
 
-__all__ = ["Aixplain", "File", "aixplain_v2"]
+def __getattr__(name: str):
+    """Lazily construct the deprecated module-level ``aixplain_v2`` client.
+
+    Constructing it at import time and swallowing the failure left a public
+    symbol bound to ``None``, so a missing credential surfaced much later as
+    ``AttributeError: 'NoneType' object has no attribute 'Agent'`` instead of the
+    actionable message ``Aixplain()`` already raises (BUG-946). Deferring the
+    construction to first access keeps ``import aixplain`` working without a key
+    -- which ``aixplain --help`` and unit-test collection rely on -- while
+    letting the real error reach whoever actually asks for the client.
+
+    Args:
+        name (str): Attribute being looked up on the package.
+
+    Returns:
+        Aixplain: The lazily constructed client, cached in module globals.
+
+    Raises:
+        AttributeError: If ``name`` is anything other than ``aixplain_v2``.
+    """
+    if name != "aixplain_v2":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import warnings
+
+    warnings.warn(_AIXPLAIN_V2_DEPRECATION, DeprecationWarning, stacklevel=2)
+    # Raises the real error (e.g. "API key is required...") when unconfigured.
+    client = Aixplain()
+    # Cache so repeated access returns the same client and skips this hook.
+    globals()["aixplain_v2"] = client
+    return client
+
+
+def __dir__():
+    """Keep the lazily provided ``aixplain_v2`` discoverable via ``dir()``."""
+    return sorted(set(globals()) | {"aixplain_v2"})
+
+
+# ``aixplain_v2`` is deliberately absent: it stays importable by name through
+# ``__getattr__`` above, but keeping it here would make ``from aixplain import *``
+# construct a client -- and therefore raise -- in a keyless environment.
+__all__ = ["Aixplain", "File"]

--- a/aixplain/utils/config.py
+++ b/aixplain/utils/config.py
@@ -17,10 +17,19 @@ import os
 import logging
 import sentry_sdk
 
+from aixplain.utils.url_safety import validate_config_url
+
 logger = logging.getLogger(__name__)
 
 BACKEND_URL = os.getenv("BACKEND_URL", "https://platform-api.aixplain.com")
 MODELS_RUN_URL = os.getenv("MODELS_RUN_URL", "https://models.aixplain.com/api/v1/execute")
+
+# Both are read straight from the environment, so any ``.env`` on the machine can
+# choose where the team API key is sent. Fail closed on a non-https endpoint and
+# warn once on a non-aiXplain host, before ``ENV`` or Sentry is derived from a
+# value that may not be ours (BUG-939).
+validate_config_url(BACKEND_URL, "BACKEND_URL")
+validate_config_url(MODELS_RUN_URL, "MODELS_RUN_URL")
 # GET THE API KEY FROM CMD
 TEAM_API_KEY = os.getenv("TEAM_API_KEY", "")
 AIXPLAIN_API_KEY = os.getenv("AIXPLAIN_API_KEY", "")

--- a/aixplain/utils/file_utils.py
+++ b/aixplain/utils/file_utils.py
@@ -22,6 +22,7 @@ import requests
 import aixplain.utils.config as config
 from aixplain.enums.license import License
 from aixplain.utils.request_utils import _request_with_retry
+from aixplain.utils.url_safety import UnsafeURLError, validate_upload_url
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional, Text, Tuple, Union, Dict, List
@@ -237,6 +238,9 @@ def upload_data(
         path = response["key"]
         # Upload data
         presigned_url = response["uploadUrl"]  # pre-signed URL
+        # The upload target is chosen by a backend response, so it is validated
+        # before any file bytes leave the machine (BUG-939).
+        validate_upload_url(presigned_url)
         download_link = response.get("downloadUrl", "")
         headers = {"Content-Type": content_type}
         if content_encoding is not None:
@@ -263,6 +267,11 @@ def upload_data(
         if return_download_link is False:
             return _build_s3_link_from_presigned_url(presigned_url, path)
         return download_link
+    except UnsafeURLError:
+        # A refused upload host is a configuration/trust failure, not a transient
+        # one: retrying cannot fix it, and the generic handler below would mask
+        # the reason behind "Failure on Uploading to S3."
+        raise
     except Exception:
         if nattempts > 0:
             return upload_data(

--- a/aixplain/utils/url_safety.py
+++ b/aixplain/utils/url_safety.py
@@ -236,7 +236,11 @@ def validate_fetch_url(url: str) -> str:
     unspecified or a known cloud-metadata endpoint.
 
     Set ``AIXPLAIN_ALLOW_PRIVATE_FETCH=1`` on an on-prem deployment whose
-    artifact host lives on a private range.
+    artifact host lives on a private range. That opt-in relaxes the *private
+    range* rule only -- the cloud metadata endpoints stay refused either way.
+    Nobody's artifact host is ``169.254.169.254``, and the flag exists to reach
+    an internal file server, not to let a caller-supplied (or model-generated)
+    URL read the container's instance credentials and upload them.
 
     Args:
         url: The URL about to be fetched.
@@ -250,16 +254,22 @@ def validate_fetch_url(url: str) -> str:
     """
     parsed = _parse_http_url(url, "URL")
     host = parsed.hostname.lower().rstrip(".")
-    if _env_flag(ALLOW_PRIVATE_FETCH_ENV_VAR):
-        return url
     if host in _METADATA_HOSTS:
         raise UnsafeURLError(f"Refusing to fetch cloud metadata host {host!r}: {url}")
+    allow_private = _env_flag(ALLOW_PRIVATE_FETCH_ENV_VAR)
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     for raw in _resolve(host, port):
         try:
             address = _classify_address(raw)
         except ValueError as exc:
             raise UnsafeURLError(f"Host {host!r} resolved to an unusable address {raw!r}: {exc}")
+        if str(address) in _METADATA_IPS:
+            raise UnsafeURLError(
+                f"Refusing to fetch {url!r}: host {host!r} resolves to the cloud metadata address "
+                f"{address}, which stays blocked even under {ALLOW_PRIVATE_FETCH_ENV_VAR}."
+            )
+        if allow_private:
+            continue
         if _is_blocked_address(address):
             raise UnsafeURLError(
                 f"Refusing to fetch {url!r}: host {host!r} resolves to the non-public address {address}. "
@@ -340,12 +350,13 @@ def safe_get(
         timeout = (FETCH_TIMEOUT_CONNECT, FETCH_TIMEOUT_READ)
     requester = session or requests
     current = url
+    current_headers = headers
     for _ in range(max_redirects + 1):
         validate_fetch_url(current)
         response = requester.get(
             current,
             timeout=timeout,
-            headers=headers,
+            headers=current_headers,
             stream=True if max_bytes is not None else stream,
             allow_redirects=False,
             **kwargs,
@@ -353,7 +364,13 @@ def safe_get(
         location = response.headers.get("Location") if response.status_code in _REDIRECT_STATUSES else None
         if location:
             response.close()
-            current = urljoin(current, location)
+            following = urljoin(current, location)
+            if current_headers and urlparse(following).netloc != urlparse(current).netloc:
+                # ``requests`` drops ``Authorization`` across a host change; following
+                # redirects by hand means doing that here, for every header, or a
+                # 302 becomes a way to harvest whatever the caller passed in.
+                current_headers = None
+            current = following
             continue
         if max_bytes is not None:
             _read_bounded(response, max_bytes, current)

--- a/aixplain/utils/url_safety.py
+++ b/aixplain/utils/url_safety.py
@@ -1,0 +1,405 @@
+"""Central URL trust policy for the SDK (BUG-939).
+
+Three unrelated code paths used to trust a URL simply because it parsed:
+
+* the configured endpoints (``BACKEND_URL``, ``MODELS_RUN_URL``,
+  ``PIPELINES_RUN_URL``), which are read straight from the environment and can
+  therefore be set by any ``.env`` on the machine;
+* URLs handed to the SDK by a caller or read out of a backend response, which
+  were gated only by ``validators.url()`` -- a *syntax* check that happily
+  accepts ``http://169.254.169.254/latest/meta-data/``, ``http://127.0.0.1:8080/x``
+  and ``http://10.0.0.1/``;
+* the presigned ``uploadUrl``, which decides where every dataset, database file
+  and attachment is PUT.
+
+All three decisions live here so the call sites stay one-liners and the policy
+cannot drift between v1, v2 and ``aixplain/utils``. This module deliberately
+imports nothing from ``aixplain.v2`` -- it is consumed by ``aixplain.utils.config``
+and by v1, neither of which may depend on v2.
+
+Residual risk: :func:`safe_get` resolves the host to validate it and then lets
+``requests`` resolve it again to connect, so a hostile resolver serving a
+zero-TTL record can still swing the second lookup (classic DNS rebinding).
+Closing that window requires connecting to the pinned address with an explicit
+``Host`` header and an SNI override; it is tracked separately.
+"""
+
+import ipaddress
+import logging
+import os
+import socket
+from typing import Any, List, Optional, Set, Tuple, Union
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+#: Opt-in that allows plain ``http://`` config and upload URLs (local dev, on-prem).
+INSECURE_OPT_IN_ENV_VAR = "AIXPLAIN_ALLOW_INSECURE_URLS"
+
+#: Opt-in that allows :func:`safe_get` to reach private/loopback addresses.
+ALLOW_PRIVATE_FETCH_ENV_VAR = "AIXPLAIN_ALLOW_PRIVATE_FETCH"
+
+#: Comma-separated extra hosts/suffixes accepted by :func:`validate_upload_url`.
+UPLOAD_ALLOWLIST_ENV_VAR = "AIXPLAIN_UPLOAD_HOST_ALLOWLIST"
+
+#: Host suffix considered "an aiXplain endpoint" for the config-URL warning.
+AIXPLAIN_HOST_SUFFIX = "aixplain.com"
+
+#: Upload hosts accepted without configuration.
+DEFAULT_UPLOAD_HOST_SUFFIXES = ("amazonaws.com", "aixplain.com")
+
+# Deliberately tighter than the API client's 300s read timeout: this fetches an
+# arbitrary caller-supplied URL, so it bounds an attacker-controlled peer rather
+# than a model execution.
+FETCH_TIMEOUT_CONNECT = 10.0
+FETCH_TIMEOUT_READ = 30.0
+
+#: How many redirects :func:`safe_get` will follow (each one re-validated).
+MAX_FETCH_REDIRECTS = 3
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_METADATA_HOSTS = frozenset({"metadata.google.internal", "metadata.goog"})
+_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+# NAT64: ``64:ff9b::7f00:1`` is 127.0.0.1 reached over IPv6.
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+# ``(variable, host)`` pairs already warned about, so a module reload or a second
+# ``Aixplain()`` does not repeat the line. A plain set (not ``lru_cache``) so a
+# test fixture can clear it.
+_WARNED_CONFIG_HOSTS: Set[Tuple[str, str]] = set()
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL fails the SDK's trust policy.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers at
+    the call sites keep working.
+    """
+
+
+def _env_flag(name: str) -> bool:
+    """Return True when environment variable *name* holds an affirmative value."""
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _parse_http_url(url: str, label: str) -> Any:
+    """Parse *url* and enforce the shared structural rules.
+
+    Rejects anything that is not an ``http``/``https`` URL with a host, and
+    anything carrying userinfo (``https://trusted.example@evil.tld/``), which no
+    legitimate aiXplain endpoint ever does and which exists mainly to disguise
+    the real target.
+
+    Args:
+        url: The URL to parse.
+        label: Human-readable name of the URL, used in error messages.
+
+    Returns:
+        urllib.parse.ParseResult: The parsed URL.
+
+    Raises:
+        UnsafeURLError: If the URL is unparseable, not http(s), carries userinfo,
+            or has no host.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UnsafeURLError(f"{label} must be a non-empty URL string")
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise UnsafeURLError(f"{label} is not a parseable URL: {exc}")
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeURLError(f"{label} must use http or https, got {parsed.scheme or '(none)'!r}: {url}")
+    try:
+        has_userinfo = bool(parsed.username or parsed.password)
+        parsed.port  # noqa: B018 -- the attribute access is what validates the port
+    except ValueError as exc:  # malformed port, e.g. "https://host:notaport/x"
+        raise UnsafeURLError(f"{label} has a malformed host or port: {exc}")
+    if has_userinfo:
+        raise UnsafeURLError(f"{label} must not contain credentials in the URL: {url}")
+    if not parsed.hostname:
+        raise UnsafeURLError(f"{label} has no host: {url}")
+    return parsed
+
+
+def _host_matches(host: str, suffix: str) -> bool:
+    """True if *host* equals *suffix* or is a subdomain of it.
+
+    Suffix matching is done label-wise, so ``evil-aixplain.com`` does not match
+    ``aixplain.com``.
+    """
+    host = host.lower().rstrip(".")
+    suffix = suffix.lower().lstrip("*").lstrip(".").rstrip(".")
+    return bool(suffix) and (host == suffix or host.endswith("." + suffix))
+
+
+def validate_config_url(url: str, name: str) -> str:
+    """Validate a configured endpoint URL (``BACKEND_URL``, ``*_RUN_URL``).
+
+    Requires ``https://`` unless ``AIXPLAIN_ALLOW_INSECURE_URLS=1``, which is
+    also what permits ``http://localhost`` for local development. Emits one
+    WARNING per ``(name, host)`` when the host is not an ``aixplain.com`` host,
+    because a redirected endpoint is the difference between the team key
+    reaching aiXplain and reaching whoever wrote the ``.env`` (BUG-939).
+
+    Args:
+        url: The configured URL.
+        name: The environment variable name, used in messages.
+
+    Returns:
+        str: *url* unchanged, when it satisfies the policy.
+
+    Raises:
+        UnsafeURLError: If the URL is not http(s), has no host, carries
+            userinfo, or is ``http://`` without the explicit opt-in.
+    """
+    parsed = _parse_http_url(url, name)
+    if parsed.scheme != "https" and not _env_flag(INSECURE_OPT_IN_ENV_VAR):
+        raise UnsafeURLError(
+            f"{name} must use https (got {url!r}). The API key is sent on every request, so plain http would "
+            f"put it on the wire in clear text. Set {INSECURE_OPT_IN_ENV_VAR}=1 to allow http for local "
+            f"development or an on-prem deployment."
+        )
+    host = parsed.hostname.lower()
+    if host in _LOOPBACK_HOSTS:
+        # A loopback endpoint under the explicit insecure opt-in is local dev;
+        # warning about it every process would be pure noise.
+        return url
+    if not _host_matches(host, AIXPLAIN_HOST_SUFFIX) and (name, host) not in _WARNED_CONFIG_HOSTS:
+        _WARNED_CONFIG_HOSTS.add((name, host))
+        logger.warning(
+            f"{name} points at {host!r}, which is not an aiXplain host. The aiXplain API key will be sent "
+            f"there. If you did not configure this deliberately, check for a .env file or an exported "
+            f"{name} in your environment."
+        )
+    return url
+
+
+def _classify_address(raw: str) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:
+    """Return *raw* as an address object, unwrapping IPv4-in-IPv6 forms.
+
+    ``::ffff:127.0.0.1`` is loopback, but ``IPv6Address.is_loopback`` is False
+    for it, so the mapped form has to be unwrapped before classification.
+    """
+    address = ipaddress.ip_address(raw)
+    if isinstance(address, ipaddress.IPv6Address):
+        mapped = address.ipv4_mapped or address.sixtofour
+        if mapped is not None:
+            return mapped
+    return address
+
+
+def _is_blocked_address(address: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> bool:
+    """True if *address* is one the SDK must never be pointed at."""
+    if str(address) in _METADATA_IPS:
+        return True
+    if isinstance(address, ipaddress.IPv6Address) and address in _NAT64_PREFIX:
+        return True
+    return bool(
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+def _resolve(host: str, port: int) -> List[str]:
+    """Resolve *host* to the list of addresses a connection could actually use.
+
+    Raises:
+        UnsafeURLError: If the host does not resolve. A name that cannot be
+            resolved is rejected rather than passed through, so a resolver
+            failure can never be mistaken for a successful check.
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UnsafeURLError(f"Cannot resolve host {host!r}: {exc}")
+    return [info[4][0] for info in infos]
+
+
+def validate_fetch_url(url: str) -> str:
+    """Validate a URL the SDK is about to fetch for a caller or from a response.
+
+    ``validators.url()`` -- the check these call sites used to rely on -- is a
+    syntax check: against validators 0.35.0 it returns True for
+    ``http://169.254.169.254/latest/meta-data/``, ``http://127.0.0.1:8080/x``
+    and ``http://10.0.0.1/`` (BUG-939). This is the security check that has to
+    sit next to it: scheme allowlist, no userinfo, and *every* resolved address
+    rejected if it is loopback, private, link-local, reserved, multicast,
+    unspecified or a known cloud-metadata endpoint.
+
+    Set ``AIXPLAIN_ALLOW_PRIVATE_FETCH=1`` on an on-prem deployment whose
+    artifact host lives on a private range.
+
+    Args:
+        url: The URL about to be fetched.
+
+    Returns:
+        str: *url* unchanged, when it satisfies the policy.
+
+    Raises:
+        UnsafeURLError: If the scheme, host or any resolved address is rejected,
+            or if the host does not resolve.
+    """
+    parsed = _parse_http_url(url, "URL")
+    host = parsed.hostname.lower().rstrip(".")
+    if _env_flag(ALLOW_PRIVATE_FETCH_ENV_VAR):
+        return url
+    if host in _METADATA_HOSTS:
+        raise UnsafeURLError(f"Refusing to fetch cloud metadata host {host!r}: {url}")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    for raw in _resolve(host, port):
+        try:
+            address = _classify_address(raw)
+        except ValueError as exc:
+            raise UnsafeURLError(f"Host {host!r} resolved to an unusable address {raw!r}: {exc}")
+        if _is_blocked_address(address):
+            raise UnsafeURLError(
+                f"Refusing to fetch {url!r}: host {host!r} resolves to the non-public address {address}. "
+                f"Set {ALLOW_PRIVATE_FETCH_ENV_VAR}=1 if this deployment really does host artifacts on an "
+                f"internal address."
+            )
+    return url
+
+
+def _read_bounded(response: requests.Response, max_bytes: int, url: str) -> None:
+    """Consume *response* into memory, refusing to buffer more than *max_bytes*.
+
+    The body of a fetched URL is uploaded to the platform as a utility model's
+    source, so a hostile endpoint must not be able to balloon the memory of the
+    process (often an agent container) that fetched it.
+
+    Raises:
+        UnsafeURLError: If the body exceeds *max_bytes*.
+    """
+    if getattr(response, "raw", None) is None or getattr(response, "_content_consumed", False):
+        # Already buffered by the adapter: there is nothing to stream, so the
+        # cap is enforced against what is in hand.
+        buffered = response._content if isinstance(response._content, (bytes, bytearray)) else b""
+        if len(buffered) > max_bytes:
+            raise UnsafeURLError(f"Refusing to read more than {max_bytes} bytes from {url!r}")
+        response._content_consumed = True
+        return
+
+    body = bytearray()
+    for chunk in response.iter_content(chunk_size=8192):
+        if not chunk:
+            continue
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            response.close()
+            raise UnsafeURLError(f"Refusing to read more than {max_bytes} bytes from {url!r}")
+    response._content = bytes(body)
+    response._content_consumed = True
+
+
+def safe_get(
+    url: str,
+    *,
+    timeout: Optional[Any] = None,
+    stream: bool = False,
+    headers: Optional[dict] = None,
+    max_redirects: int = MAX_FETCH_REDIRECTS,
+    max_bytes: Optional[int] = None,
+    session: Optional[requests.Session] = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """GET *url*, applying :func:`validate_fetch_url` to it and to every redirect.
+
+    Redirects are followed manually (``allow_redirects=False``) so that each
+    ``Location`` is re-validated: a perfectly public host that 302s to
+    ``http://169.254.169.254/`` is otherwise indistinguishable from a safe fetch.
+
+    Args:
+        url: The URL to fetch.
+        timeout: ``requests`` timeout; defaults to
+            ``(FETCH_TIMEOUT_CONNECT, FETCH_TIMEOUT_READ)``.
+        stream: Leave the body unconsumed (ignored when *max_bytes* is set).
+        headers: Extra request headers.
+        max_redirects: How many redirects to follow before giving up.
+        max_bytes: Optional cap on the response body size.
+        session: Optional ``requests.Session`` to issue the request on.
+        **kwargs: Forwarded to ``requests.get``.
+
+    Returns:
+        requests.Response: The final response. The status is **not** raised on,
+        so callers keep their existing error handling.
+
+    Raises:
+        UnsafeURLError: If the target, or any redirect target, fails the policy,
+            or if the redirect budget is exhausted.
+    """
+    if timeout is None:
+        timeout = (FETCH_TIMEOUT_CONNECT, FETCH_TIMEOUT_READ)
+    requester = session or requests
+    current = url
+    for _ in range(max_redirects + 1):
+        validate_fetch_url(current)
+        response = requester.get(
+            current,
+            timeout=timeout,
+            headers=headers,
+            stream=True if max_bytes is not None else stream,
+            allow_redirects=False,
+            **kwargs,
+        )
+        location = response.headers.get("Location") if response.status_code in _REDIRECT_STATUSES else None
+        if location:
+            response.close()
+            current = urljoin(current, location)
+            continue
+        if max_bytes is not None:
+            _read_bounded(response, max_bytes, current)
+        return response
+    raise UnsafeURLError(f"Refusing to follow more than {max_redirects} redirects from {url!r}")
+
+
+def _upload_host_suffixes() -> Tuple[str, ...]:
+    """Return the allowed upload host suffixes, including the env extension."""
+    extra = os.getenv(UPLOAD_ALLOWLIST_ENV_VAR, "")
+    entries = [entry.strip() for entry in extra.split(",") if entry.strip()]
+    return DEFAULT_UPLOAD_HOST_SUFFIXES + tuple(entries)
+
+
+def validate_upload_url(url: str) -> str:
+    """Validate a presigned ``uploadUrl`` before the SDK PUTs a file to it.
+
+    The URL comes straight out of a backend response, so a compromised backend
+    -- or a ``BACKEND_URL`` redirected by an ambient ``.env`` -- would otherwise
+    receive every dataset, database file, skill bundle and attachment while the
+    SDK reported success (BUG-939).
+
+    ``*.amazonaws.com`` and ``*.aixplain.com`` are allowed by default; extend
+    with a comma-separated ``AIXPLAIN_UPLOAD_HOST_ALLOWLIST`` (each entry may be
+    a bare host, ``.suffix`` or ``*.suffix``). https is required unless
+    ``AIXPLAIN_ALLOW_INSECURE_URLS=1``.
+
+    Args:
+        url: The presigned upload URL returned by the backend.
+
+    Returns:
+        str: *url* unchanged, when it satisfies the policy.
+
+    Raises:
+        UnsafeURLError: If the scheme or host is not allowed.
+    """
+    parsed = _parse_http_url(url, "Upload URL")
+    if parsed.scheme != "https" and not _env_flag(INSECURE_OPT_IN_ENV_VAR):
+        raise UnsafeURLError(
+            f"Refusing to upload over plain http to {parsed.hostname!r}. Set {INSECURE_OPT_IN_ENV_VAR}=1 to allow it."
+        )
+    host = parsed.hostname.lower()
+    suffixes = _upload_host_suffixes()
+    if not any(_host_matches(host, suffix) for suffix in suffixes):
+        raise UnsafeURLError(
+            f"Refusing to upload to unexpected host {host!r}. Allowed: {', '.join(suffixes)}. "
+            f"Set {UPLOAD_ALLOWLIST_ENV_VAR} to add a host."
+        )
+    return url

--- a/aixplain/v1/factories/model_factory/utils.py
+++ b/aixplain/v1/factories/model_factory/utils.py
@@ -21,6 +21,7 @@ from aixplain.enums import (
 )
 from aixplain.utils import config
 from aixplain.utils.request_utils import _request_with_retry
+from aixplain.utils.url_safety import safe_get
 from datetime import datetime
 from typing import Dict, Union, List, Optional, Tuple
 from urllib.parse import urljoin
@@ -119,7 +120,7 @@ def create_model_from_response(response: Dict) -> Model:
                 version_link = response["version"]["id"]
                 if version_link:
                     try:
-                        version_content = requests.get(version_link).text
+                        version_content = safe_get(version_link).text
                         code = version_content
                     except Exception:
                         code = ""

--- a/aixplain/v1/modules/agent/tool/sql_tool.py
+++ b/aixplain/v1/modules/agent/tool/sql_tool.py
@@ -33,6 +33,7 @@ import numpy as np
 from typing import Text, Optional, Dict, List, Union
 import sqlite3
 from aixplain.enums import AssetStatus
+from aixplain.utils.url_safety import safe_get
 from aixplain.modules.agent.tool import DeployableTool
 
 
@@ -499,7 +500,7 @@ class SQLTool(DeployableTool):
 
         # Download database file
         if str(self.database).startswith(("http://", "https://")):
-            response = requests.get(self.database)
+            response = safe_get(self.database)
             response.raise_for_status()
             with open(local_path, "wb") as f:
                 f.write(response.content)

--- a/aixplain/v1/modules/benchmark_job.py
+++ b/aixplain/v1/modules/benchmark_job.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from aixplain.utils.request_utils import _request_with_retry
 from aixplain.utils.file_utils import save_file
+from aixplain.utils.url_safety import validate_fetch_url
 
 
 class BenchmarkJob:
@@ -111,6 +112,9 @@ class BenchmarkJob:
                 )
                 return None
             csv_url = resp["reportUrl"]
+            # ``reportUrl`` comes from a backend response, so it is SSRF-gated
+            # before ``save_file`` fetches it (BUG-939).
+            validate_fetch_url(csv_url)
             if return_dataframe:
                 downloaded_path = save_file(csv_url, save_path)
                 df = pd.read_csv(downloaded_path)

--- a/aixplain/v1/modules/model/rlm.py
+++ b/aixplain/v1/modules/model/rlm.py
@@ -890,8 +890,9 @@ def llm_query(prompt):
         """
         if not (isinstance(context, str) and (context.startswith("http://") or context.startswith("https://"))):
             return context
-        import requests
-        r = requests.get(context, timeout=60)
+        from aixplain.utils.url_safety import safe_get
+
+        r = safe_get(context, timeout=60)
         r.raise_for_status()
         ct = r.headers.get("Content-Type", "")
         url_path = context.split("?")[0].lower()

--- a/aixplain/v1/modules/model/utils.py
+++ b/aixplain/v1/modules/model/utils.py
@@ -12,6 +12,7 @@ import ast
 import inspect
 import requests
 from aixplain.utils.file_utils import _request_with_retry
+from aixplain.utils.url_safety import safe_get
 from typing import Callable, Dict, List, Text, Tuple, Union, Optional
 from aixplain.exceptions import get_error_from_status_code
 import copy
@@ -317,7 +318,7 @@ def parse_code(code: Union[Text, Callable], api_key: Optional[Text] = None) -> T
         with open(code, "r") as f:
             str_code = f.read()
     elif validators.url(code):
-        str_code = requests.get(code).text
+        str_code = safe_get(code).text
     else:
         str_code = code
     # assert str_code has a main function
@@ -534,7 +535,7 @@ def parse_code_decorated(code: Union[Text, Callable], api_key: Optional[Text] = 
             with open(code, "r") as f:
                 str_code = f.read()
         elif validators.url(code):
-            str_code = requests.get(code).text
+            str_code = safe_get(code).text
         else:
             str_code = code
 

--- a/aixplain/v1/modules/team_agent/__init__.py
+++ b/aixplain/v1/modules/team_agent/__init__.py
@@ -703,7 +703,13 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                 return response
             poll_url = response["url"]
             end = time.time()
-            result = self.sync_poll(poll_url, name=name, timeout=timeout, wait_time=wait_time)
+            result = self.sync_poll(
+                poll_url,
+                name=name,
+                timeout=timeout,
+                wait_time=wait_time,
+                progress_verbosity=progress_verbosity,
+            )
             result_data = result.data or {}
             diagnostic_error_codes = result.diagnostic_error_codes
             if result.status == ResponseStatus.FAILED:

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -835,12 +835,6 @@ class Agent(
             ]
             self.files = current_ids
 
-        # TODO: Re-enable this validation after backend data consistency is fixed
-        # if self.agents and (self.tasks or self.tools):
-        #     raise ValueError(
-        #         "Team agents cannot have tasks or tools. Please remove the tasks or tools and try again."
-        #     )
-
     @staticmethod
     def _skill_reference_id(skill: Optional[Union[str, Dict[str, Any], "Skill"]]) -> Optional[str]:
         """Return the backend ID represented by one Skill reference."""

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, Optional, Tuple, Union, List, FrozenSet
 import inspect
 import logging
 import os
+import re
 import requests
 from requests.adapters import HTTPAdapter, Retry
 from urllib.parse import urljoin, urlparse
@@ -117,6 +118,150 @@ DEFAULT_TRUSTED_URLS = (
     "https://platform-api.aixplain.com",
     "https://models.aixplain.com",
 )
+
+
+# Opt-in that re-enables (redacted, truncated) body logging at DEBUG.
+LOG_BODIES_ENV_VAR = "AIXPLAIN_LOG_BODIES"
+LOG_BODY_MAX_BYTES = 2048
+
+# Keys whose *value* is a credential, whatever the surrounding structure.
+_REDACT_KEYS = frozenset(
+    {
+        "x-api-key",
+        "x-aixplain-key",
+        "authorization",
+        "api_key",
+        "apikey",
+        "access_key",
+        "accesskey",
+        "secret",
+        "client_secret",
+        "password",
+        "token",
+        "access_token",
+        "refresh_token",
+        "credential",
+        "credentials",
+    }
+)
+
+# Values that look like a credential even under a key we don't recognise: the
+# leak this closes was a *third-party* Slack token nested inside a tool payload.
+_TOKEN_PATTERNS = (
+    re.compile(r"xox[baprs]-[\w-]+"),  # Slack
+    re.compile(r"\b(?:sk|pk|rk)-[A-Za-z0-9]{16,}"),  # OpenAI-style
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub
+    re.compile(r"\bBearer\s+[A-Za-z0-9._\-]{16,}"),
+    re.compile(r"\beyJ[A-Za-z0-9._\-]{20,}"),  # JWT
+)
+
+_REDACTED = "***REDACTED***"
+
+
+def _log_path(url: str) -> str:
+    """Return *url* reduced to scheme, host and path, dropping the query string.
+
+    Query strings carry presigned signatures and one-time tokens, so only the
+    path is safe to put in a log record.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return "<unparseable url>"
+    if not parsed.netloc:
+        return parsed.path or url
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+def _redact(value: Any) -> Any:
+    """Return *value* with credential-shaped keys and token-shaped strings masked.
+
+    Recurses through dicts and lists so a token nested inside a tool payload is
+    caught as well as a top-level one.
+    """
+    if isinstance(value, dict):
+        return {key: (_REDACTED if str(key).lower() in _REDACT_KEYS else _redact(item)) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact(item) for item in value]
+    if isinstance(value, str):
+        redacted = value
+        for pattern in _TOKEN_PATTERNS:
+            redacted = pattern.sub(_REDACTED, redacted)
+        return redacted
+    return value
+
+
+def _truncate(text: str) -> str:
+    """Cap *text* at :data:`LOG_BODY_MAX_BYTES` characters with a visible marker."""
+    if len(text) <= LOG_BODY_MAX_BYTES:
+        return text
+    return f"{text[:LOG_BODY_MAX_BYTES]}…(truncated)"
+
+
+def _log_request(method: str, url: str, kwargs: Optional[dict] = None) -> None:
+    """Log the outline of an outgoing request: method and path, nothing more.
+
+    Headers are never logged, opt-in or not: ``request_raw`` merges the API key
+    into ``kwargs["headers"]`` before this point, which is exactly how the team
+    key -- and the third-party tokens inside tool payloads -- used to reach DEBUG
+    logs (BUG-939). The body is logged only under ``AIXPLAIN_LOG_BODIES=1``, and
+    then redacted and truncated.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    logger.debug(f"Requesting {method} {_log_path(url)}")
+    if not _log_bodies_enabled() or not kwargs:
+        return
+    body = kwargs.get("json", kwargs.get("data"))
+    if body is None:
+        return
+    logger.debug(f"Request body ({method} {_log_path(url)}): {_truncate(str(_redact(body)))}")
+
+
+def _log_bodies_enabled() -> bool:
+    """True when the operator explicitly opted into body logging."""
+    return os.getenv(LOG_BODIES_ENV_VAR, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _response_size(response: requests.Response, read_body: bool) -> Optional[int]:
+    """Best-effort byte count for *response* without consuming a stream.
+
+    ``read_body`` is False on the streaming path, where touching ``.content``
+    would consume the very stream the caller is about to iterate.
+    """
+    length = response.headers.get("Content-Length")
+    if length is not None:
+        try:
+            return int(length)
+        except (TypeError, ValueError):
+            pass
+    if not read_body:
+        return None
+    try:
+        return len(response.content)
+    except Exception:
+        return None
+
+
+def _log_response(method: str, url: str, response: requests.Response, *, read_body: bool = True) -> None:
+    """Log the outline of a response: method, path, status and byte count.
+
+    The body itself is logged only under ``AIXPLAIN_LOG_BODIES=1`` (redacted and
+    truncated) and never on the streaming path.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    size = _response_size(response, read_body)
+    size_text = f"{size} bytes" if size is not None else "unknown size"
+    logger.debug(f"Response {method} {_log_path(url)} -> {response.status_code} ({size_text})")
+    if not (read_body and _log_bodies_enabled()):
+        return
+    try:
+        body = response.text
+    except Exception:
+        return
+    logger.debug(f"Response body ({method} {_log_path(url)}): {_truncate(_redact(body))}")
+
 
 # Every header that carries an aiXplain credential.  These are custom headers,
 # so ``requests`` does not strip them across a redirect the way it does
@@ -441,10 +586,11 @@ class AixplainClient:
         url = self.ensure_trusted_url(path)
         kwargs["headers"] = {**self._auth_headers(), **(kwargs.pop("headers", None) or {})}
         kwargs.setdefault("timeout", self.timeout)
-        # ``headers`` now carries the API key, so it stays out of the log line.
-        logger.debug(f"Requesting {method} {url} with kwargs: {kwargs}")
+        # ``headers`` now carries the API key, and ``kwargs`` carries the request
+        # body, so neither is ever formatted into a log record (BUG-939).
+        _log_request(method, url, kwargs)
         response = self.session.request(method=method, url=url, **kwargs)
-        logger.debug(f"Response: {response.text}")
+        _log_response(method, url, response)
         if not response.ok:
             error_obj = None
             try:
@@ -534,8 +680,6 @@ class AixplainClient:
         """
         url = self.ensure_trusted_url(path)
 
-        logger.debug(f"Requesting streaming {method} {url}")
-
         kwargs["headers"] = {**self._auth_headers(), **(kwargs.pop("headers", None) or {})}
         # Enable streaming mode
         kwargs["stream"] = True
@@ -544,7 +688,11 @@ class AixplainClient:
         # as the server keeps sending (events or keep-alives).
         kwargs.setdefault("timeout", self.timeout)
 
+        _log_request(method, url, kwargs)
         response = self.session.request(method=method, url=url, **kwargs)
+        # ``read_body=False``: the caller iterates this stream, so the log line
+        # must not consume it.
+        _log_response(method, url, response, read_body=False)
 
         # For streaming, we check status but don't consume the response body
         if not response.ok:

--- a/aixplain/v2/client.py
+++ b/aixplain/v2/client.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Iterable, Optional, Tuple, Union, List, FrozenSet
 import inspect
+import json
 import logging
 import os
 import re
@@ -191,6 +192,49 @@ def _redact(value: Any) -> Any:
     return value
 
 
+def _render_redacted_body(value: Any) -> str:
+    """Render *value* as text with credential-shaped keys and values masked.
+
+    A body arrives here either as a structure (``json=``) or already serialised
+    (``data=`` and ``response.text``). The serialised form has to be parsed back
+    before it can be redacted *by key*: ``{"accessKey": "..."}`` -- which is what
+    ``APIKey.list()`` returns for every key on the account -- and an ``x-api-key``
+    nested in a serialised payload match none of the token patterns, so treating
+    the body as an opaque string would log them verbatim (BUG-939). Anything that
+    is not JSON falls back to pattern redaction alone.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError:
+            return f"<{len(value)} bytes of non-text body>"
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            return _redact(value)
+        if isinstance(parsed, (dict, list)):
+            return json.dumps(_redact(parsed), default=str)
+        return _redact(value)
+    return str(_redact(value))
+
+
+def _redact_body(value: Any) -> str:
+    """Total wrapper around :func:`_render_redacted_body`.
+
+    Rendering a body walks an arbitrary structure that a *response* can shape,
+    so it can fail in ways the request itself would not -- deeply nested JSON
+    raises ``RecursionError`` out of ``json.loads``, and a ``__str__`` on a
+    caller's object can raise anything. A diagnostic must never turn a working
+    call into a traceback, and it must never fall back to emitting the raw body,
+    so every failure collapses to a placeholder.
+    """
+    try:
+        return _render_redacted_body(value)
+    except Exception:  # noqa: BLE001 -- a log line must not break the request
+        return "<body omitted: could not be redacted>"
+
+
 def _truncate(text: str) -> str:
     """Cap *text* at :data:`LOG_BODY_MAX_BYTES` characters with a visible marker."""
     if len(text) <= LOG_BODY_MAX_BYTES:
@@ -215,7 +259,7 @@ def _log_request(method: str, url: str, kwargs: Optional[dict] = None) -> None:
     body = kwargs.get("json", kwargs.get("data"))
     if body is None:
         return
-    logger.debug(f"Request body ({method} {_log_path(url)}): {_truncate(str(_redact(body)))}")
+    logger.debug(f"Request body ({method} {_log_path(url)}): {_truncate(_redact_body(body))}")
 
 
 def _log_bodies_enabled() -> bool:
@@ -260,7 +304,7 @@ def _log_response(method: str, url: str, response: requests.Response, *, read_bo
         body = response.text
     except Exception:
         return
-    logger.debug(f"Response body ({method} {_log_path(url)}): {_truncate(_redact(body))}")
+    logger.debug(f"Response body ({method} {_log_path(url)}): {_truncate(_redact_body(body))}")
 
 
 # Every header that carries an aiXplain credential.  These are custom headers,

--- a/aixplain/v2/code_utils.py
+++ b/aixplain/v2/code_utils.py
@@ -13,14 +13,18 @@ from dataclasses import dataclass
 from typing import Callable, List, Text, Tuple, Union, Optional
 from uuid import uuid4
 
-import requests
 import validators
 
-from .client import default_timeout
+from aixplain.utils.url_safety import safe_get
 from .enums import DataType
 from .upload_utils import FileUploader
 
 logger = logging.getLogger(__name__)
+
+# A remote code URL is fetched into memory and then uploaded as the utility
+# model's source, so a hostile endpoint must not be able to balloon the memory
+# of the process (often an agent container) that fetched it.
+MAX_REMOTE_CODE_BYTES = 5 * 1024 * 1024
 
 
 @dataclass
@@ -164,7 +168,7 @@ def parse_code(
         with open(code, "r") as f:
             str_code = f.read()
     elif validators.url(code):
-        str_code = requests.get(code, timeout=default_timeout()).text
+        str_code = safe_get(code, max_bytes=MAX_REMOTE_CODE_BYTES).text
     else:
         str_code = code
 
@@ -274,7 +278,7 @@ def parse_code_decorated(
             with open(code, "r") as f:
                 str_code = f.read()
         elif validators.url(code):
-            str_code = requests.get(code, timeout=default_timeout()).text
+            str_code = safe_get(code, max_bytes=MAX_REMOTE_CODE_BYTES).text
         else:
             str_code = code
 

--- a/aixplain/v2/core.py
+++ b/aixplain/v2/core.py
@@ -4,6 +4,8 @@ import os
 import sys
 from typing import Optional, TypeVar
 
+from aixplain.utils.url_safety import validate_config_url
+
 from .client import AixplainClient
 from .model import Model
 from .agent import Agent
@@ -130,6 +132,14 @@ class Aixplain:
         self.backend_url = backend_url or os.getenv("BACKEND_URL") or self.BACKEND_URL
         self.pipeline_url = pipeline_url or os.getenv("PIPELINES_RUN_URL") or self.PIPELINES_RUN_URL
         self.model_url = model_url or os.getenv("MODELS_RUN_URL") or self.MODELS_RUN_URL
+
+        # All three become trusted origins for the API key below, and all three
+        # default to an environment variable, so each has to satisfy the config
+        # URL policy first (BUG-939). ``PIPELINES_RUN_URL`` in particular is read
+        # nowhere else, so this is its only check.
+        validate_config_url(self.backend_url, "BACKEND_URL")
+        validate_config_url(self.pipeline_url, "PIPELINES_RUN_URL")
+        validate_config_url(self.model_url, "MODELS_RUN_URL")
 
         self.init_client()
         self.init_resources()

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -30,7 +30,7 @@ from urllib.parse import quote, unquote, urlparse
 import requests
 from dataclasses_json import config, dataclass_json
 
-from aixplain.utils.url_safety import validate_upload_url
+from aixplain.utils.url_safety import validate_fetch_url, validate_upload_url
 
 from .enums import FileType, Privacy
 from .exceptions import APIError, FileUploadError, ResourceError, ValidationError
@@ -303,6 +303,10 @@ class File(BaseResource):
         try:
             if parsed.scheme in {"http", "https"}:
                 suffix = Path(parsed.path).suffix
+                # ``source`` is caller-supplied and its body is uploaded to the
+                # platform, so it is the same SSRF sink as the remote-code fetch
+                # in ``code_utils`` and is gated the same way (BUG-939).
+                validate_fetch_url(self.source)
                 with requests.get(self.source, stream=True, timeout=self.context.client.timeout) as response:
                     response.raise_for_status()
                     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:

--- a/aixplain/v2/file.py
+++ b/aixplain/v2/file.py
@@ -30,6 +30,8 @@ from urllib.parse import quote, unquote, urlparse
 import requests
 from dataclasses_json import config, dataclass_json
 
+from aixplain.utils.url_safety import validate_upload_url
+
 from .enums import FileType, Privacy
 from .exceptions import APIError, FileUploadError, ResourceError, ValidationError
 from .resource import BaseResource, Page, _is_excluded_from_serialization
@@ -209,6 +211,9 @@ class File(BaseResource):
         reference = response.get("downloadUrl") or response.get("url") or response.get("key")
         if not upload_url or not reference:
             raise FileUploadError("Temporary upload response did not include uploadUrl and a file reference")
+        # ``uploadUrl`` is chosen by the response, so the host is checked before
+        # the file bytes leave the machine (BUG-939).
+        validate_upload_url(upload_url)
         with open(local_path, "rb") as handle:
             upload_response = requests.put(
                 upload_url,

--- a/aixplain/v2/rlm.py
+++ b/aixplain/v2/rlm.py
@@ -1460,9 +1460,10 @@ del _url, _r
         """
         if not (isinstance(context, str) and (context.startswith("http://") or context.startswith("https://"))):
             return context
-        import requests
+        from aixplain.utils.url_safety import safe_get
 
-        r = requests.get(context, timeout=60)
+        # ``context`` is caller-supplied, so the fetch is SSRF-gated (BUG-939).
+        r = safe_get(context, timeout=60)
         r.raise_for_status()
         ct = r.headers.get("Content-Type", "")
         url_path = context.split("?")[0].lower()

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -485,8 +485,13 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             data = kwargs.get("data", {})
             action_errors = action_obj.inputs.validate(data)
             errors.extend(action_errors)
-        except Exception:
-            pass
+        except Exception as e:
+            # A crashed validation is not a pass (BUG-946). An unknown action name
+            # reaches here as a ValueError from the lazy input loader -- Actions
+            # fabricates an ActionView rather than raising on __getitem__ -- and the
+            # empty list this used to return was indistinguishable from
+            # "validated clean", so the run proceeded to the backend unchecked.
+            errors.append(f"Could not validate inputs for '{action}': {e}")
 
         return errors
 

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -175,8 +175,12 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             if self._ensure_integration():
                 try:
                     return self.integration._list_inputs(*actions)
-                except Exception:
-                    pass
+                except Exception as fallback_error:
+                    # Returning [] below makes the lazy input loader raise
+                    # "not found or has no input parameters defined", which
+                    # _validate_params now surfaces as a run failure (BUG-946).
+                    # Without this the real cause never reaches the caller.
+                    warnings.warn(f"Error listing inputs via the integration fallback: {fallback_error}.")
 
             return []
 

--- a/aixplain/v2/upload_utils.py
+++ b/aixplain/v2/upload_utils.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Optional, Union, Any
 from urllib.parse import urljoin
 import requests
 
+from aixplain.utils.url_safety import validate_upload_url
+
 from .exceptions import FileUploadError
 
 
@@ -196,7 +198,19 @@ class S3Uploader:
 
     @classmethod
     def upload_file(cls, file_path: str, presigned_url: str, content_type: str) -> None:
-        """Upload file to S3 using pre-signed URL."""
+        """Upload file to S3 using pre-signed URL.
+
+        Raises:
+            UnsafeURLError: If ``presigned_url`` does not point at an allowed
+                upload host. The check sits *outside* the ``try`` below so the
+                generic ``FileUploadError`` wrapper cannot mask why the upload
+                was refused (BUG-939).
+        """
+        # The URL comes straight from a backend response; a compromised or
+        # redirected backend would otherwise receive the file while the SDK
+        # reported success.
+        validate_upload_url(presigned_url)
+
         headers = {"Content-Type": content_type}
 
         try:

--- a/tests/unit/team_agent/test_progress_verbosity_passthrough.py
+++ b/tests/unit/team_agent/test_progress_verbosity_passthrough.py
@@ -1,0 +1,121 @@
+"""Guard: ``TeamAgent.run`` must forward ``progress_verbosity`` to ``sync_poll``.
+
+``run`` accepts and documents ``progress_verbosity`` -- *"full" (detailed),
+"compact" (brief), or None (no progress)"* -- but dropped it on the call to
+``sync_poll``, which defaults it to ``"compact"``. So ``run(progress_verbosity=None)``
+still printed progress to stdout (unsuppressable library output for anyone
+embedding the SDK in a service) and ``"full"`` still rendered compact (BUG-946).
+
+The sibling ``Agent.run`` has always passed it through correctly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from aixplain.modules.team_agent import TeamAgent
+from aixplain.modules.agent.agent_response import AgentResponse
+from aixplain.modules.agent.agent_response_data import AgentResponseData
+from aixplain.enums import ResponseStatus
+
+
+def _completed_response(**kwargs):
+    return AgentResponse(
+        status=ResponseStatus.SUCCESS,
+        completed=True,
+        data=AgentResponseData(input="hi", output="done"),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("verbosity", [None, "full", "compact"])
+def test_run_forwards_progress_verbosity_to_sync_poll(verbosity):
+    """Whatever the caller passes to ``run`` must reach ``sync_poll``."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "sync_poll", return_value=_completed_response()) as mock_sync_poll,
+    ):
+        team_agent.run(query="hi", progress_verbosity=verbosity)
+
+    assert mock_sync_poll.call_args.kwargs["progress_verbosity"] == verbosity
+
+
+def test_run_defaults_to_compact():
+    """The documented default must survive the passthrough."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "sync_poll", return_value=_completed_response()) as mock_sync_poll,
+    ):
+        team_agent.run(query="hi")
+
+    assert mock_sync_poll.call_args.kwargs["progress_verbosity"] == "compact"
+
+
+PROGRESS = {
+    "stage": "planning",
+    "message": "Breaking the task down",
+    "current_step": 1,
+    "total_steps": 3,
+}
+
+
+def _poll_sequence():
+    """One in-progress poll carrying progress data, then a completed one."""
+    in_progress = AgentResponse(
+        status=ResponseStatus.IN_PROGRESS,
+        completed=False,
+        data=AgentResponseData(input="hi"),
+        progress=dict(PROGRESS),
+    )
+    return [in_progress, _completed_response()]
+
+
+def test_sync_poll_none_produces_no_stdout(capsys):
+    """``progress_verbosity=None`` must suppress *all* stdout.
+
+    That includes the completion line printed after the polling loop.
+    """
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with patch.object(TeamAgent, "poll", side_effect=_poll_sequence()):
+        team_agent.sync_poll("http://poll", wait_time=0.01, progress_verbosity=None)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_sync_poll_full_renders_full(capsys):
+    """``"full"`` must render the detailed format, not the compact one."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with patch.object(TeamAgent, "poll", side_effect=_poll_sequence()):
+        team_agent.sync_poll("http://poll", wait_time=0.01, progress_verbosity="full")
+
+    out = capsys.readouterr().out
+    assert out, "'full' must produce progress output"
+
+    full_msg = team_agent._format_team_progress(PROGRESS, "full")
+    compact_msg = team_agent._format_team_progress(PROGRESS, "compact")
+    assert full_msg != compact_msg, "fixture must distinguish the two formats"
+    assert full_msg in out
+    assert compact_msg not in out
+
+
+def test_run_none_produces_no_stdout(capsys):
+    """End to end: ``run(progress_verbosity=None)`` must print nothing.
+
+    This is the acceptance criterion; it failed before the passthrough because
+    ``sync_poll`` fell back to its ``"compact"`` default.
+    """
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "poll", side_effect=_poll_sequence()),
+    ):
+        team_agent.run(query="hi", wait_time=0.01, progress_verbosity=None)
+
+    assert capsys.readouterr().out == ""

--- a/tests/unit/utils/test_config_url_policy.py
+++ b/tests/unit/utils/test_config_url_policy.py
@@ -1,0 +1,89 @@
+"""Tests that the configured endpoint URLs are validated (BUG-939).
+
+``BACKEND_URL``, ``MODELS_RUN_URL`` and ``PIPELINES_RUN_URL`` are read straight
+from the environment and decide where the team API key is sent, so both entry
+points that resolve them -- importing ``aixplain.utils.config`` and constructing
+``Aixplain()`` -- have to apply the policy.
+"""
+
+import importlib
+
+import pytest
+
+from aixplain.utils import config, url_safety
+from aixplain.utils.url_safety import INSECURE_OPT_IN_ENV_VAR, UnsafeURLError
+from aixplain.v2.core import Aixplain
+
+
+@pytest.fixture(autouse=True)
+def no_remembered_warnings():
+    """Clear the once-per-host warning memo so each test sees a fresh state."""
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+    yield
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+
+
+@pytest.fixture
+def reload_config(monkeypatch):
+    """Reload ``aixplain.utils.config`` under a chosen ``BACKEND_URL``.
+
+    Restores the module afterwards so the rest of the session is unaffected.
+    """
+    original = config.BACKEND_URL
+
+    def _reload(backend_url):
+        monkeypatch.setenv("BACKEND_URL", backend_url)
+        return importlib.reload(config)
+
+    yield _reload
+
+    monkeypatch.setenv("BACKEND_URL", original)
+    importlib.reload(config)
+
+
+def test_import_rejects_http_backend_url(reload_config):
+    """Importing the config module fails closed on an http endpoint."""
+    with pytest.raises(UnsafeURLError):
+        reload_config("http://platform-api.aixplain.com")
+
+
+def test_import_accepts_the_dev_backend(reload_config):
+    """The dev host must keep working exactly as before."""
+    reloaded = reload_config("https://dev-platform-api.aixplain.com")
+    assert reloaded.BACKEND_URL == "https://dev-platform-api.aixplain.com"
+    assert reloaded.ENV == "dev"
+
+
+def test_import_accepts_the_test_backend(reload_config):
+    """The test host must keep working exactly as before."""
+    reloaded = reload_config("https://test-platform-api.aixplain.com")
+    assert reloaded.ENV == "test"
+
+
+def test_import_allows_http_with_the_opt_in(reload_config, monkeypatch):
+    """A local backend is supported through the documented opt-in."""
+    monkeypatch.setenv(INSECURE_OPT_IN_ENV_VAR, "1")
+    reloaded = reload_config("http://localhost:8000")
+    assert reloaded.BACKEND_URL == "http://localhost:8000"
+
+
+def test_aixplain_rejects_an_http_pipeline_url(monkeypatch):
+    """``PIPELINES_RUN_URL`` is read nowhere else, so ``Aixplain()`` is its check."""
+    monkeypatch.delenv(INSECURE_OPT_IN_ENV_VAR, raising=False)
+    with pytest.raises(UnsafeURLError):
+        Aixplain(api_key="dummy", pipeline_url="http://evil.example.com/run")
+
+
+def test_aixplain_rejects_a_non_http_model_url(monkeypatch):
+    """A non-http(s) run URL is refused before a client is built."""
+    monkeypatch.delenv(INSECURE_OPT_IN_ENV_VAR, raising=False)
+    with pytest.raises(UnsafeURLError):
+        Aixplain(api_key="dummy", model_url="file:///etc/passwd")
+
+
+def test_aixplain_accepts_the_production_defaults():
+    """The default configuration is unaffected."""
+    instance = Aixplain(api_key="dummy")
+    assert instance.backend_url.startswith("https://")
+    assert instance.model_url.startswith("https://")
+    assert instance.pipeline_url.startswith("https://")

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -86,3 +86,31 @@ def test_dotenv_neutralisation_actually_works(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "''", f"a credential leaked into the subprocess: {result.stdout!r}"
+
+
+def test_cli_help_without_api_key(tmp_path):
+    """`aixplain --help` must render usage and exit 0 with no credential set.
+
+    The eight CLI commands each declare `--api-key`, which can only be the sole
+    source of the key if the process survives long enough for click to parse
+    argv. The import-time `validate_api_keys()` call killed it first (BUG-946),
+    so a first-run user got a traceback instead of usage text.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from aixplain.cli_groups import cli; cli(['--help'])",
+        ],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert "has been set" not in output, f"--help still requires a credential:\n{output[-4000:]}"
+    assert "Usage:" in result.stdout, f"no usage text:\n{output[-4000:]}"
+    assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -114,3 +114,50 @@ def test_cli_help_without_api_key(tmp_path):
     assert "has been set" not in output, f"--help still requires a credential:\n{output[-4000:]}"
     assert "Usage:" in result.stdout, f"no usage text:\n{output[-4000:]}"
     assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"
+
+
+def test_cli_api_key_flag_is_the_sole_key_source(tmp_path):
+    """`--api-key K` must authenticate the request with no key in the environment.
+
+    All eight CLI commands declare the flag, but the import-time
+    `validate_api_keys()` call killed the process before click ever parsed argv,
+    so the flag could never be the only source of the credential (BUG-946). This
+    drives one command end to end and asserts the key reaches the outgoing
+    `x-api-key` header.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    child = """
+from unittest.mock import patch, Mock
+from click.testing import CliRunner
+from aixplain.cli_groups import cli
+
+captured = {}
+
+
+def fake_request(method, url, **kwargs):
+    captured["headers"] = kwargs.get("headers")
+    response = Mock()
+    response.text = "[]"
+    return response
+
+
+with patch("aixplain.factories.model_factory._request_with_retry", fake_request):
+    result = CliRunner().invoke(cli, ["list", "hosts", "--api-key", "cli-only-key"])
+
+print("EXIT", result.exit_code)
+print("EXC", repr(result.exception))
+print("KEY", (captured.get("headers") or {}).get("x-api-key"))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "EXIT 0" in result.stdout, f"CLI command failed:\n{result.stdout}\n{result.stderr[-2000:]}"
+    assert "KEY cli-only-key" in result.stdout, f"--api-key never reached the request:\n{result.stdout}"

--- a/tests/unit/utils/test_dotenv_scope.py
+++ b/tests/unit/utils/test_dotenv_scope.py
@@ -1,0 +1,89 @@
+"""Tests that ``.env`` loading is scoped to the working directory (BUG-939).
+
+A bare ``load_dotenv()`` walks *up* from the CWD, so a ``.env`` shipped inside a
+cloned sample project or a bug-report attachment could hand a user's own script a
+different ``BACKEND_URL`` and pick the ``TEAM_API_KEY`` out of the ancestor file.
+``find_dotenv(usecwd=True)`` is not a fix -- it still walks up when the CWD has no
+``.env`` of its own -- so these tests pin the explicit-path behaviour.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import aixplain
+
+PARENT_ENV = "BACKEND_URL=https://evil.example.com\nTEAM_API_KEY=STOLEN\n"
+
+
+@pytest.fixture
+def nested_tree(tmp_path):
+    """Create ``tmp_path/.env`` plus an empty ``tmp_path/child`` directory."""
+    (tmp_path / ".env").write_text(PARENT_ENV)
+    child = tmp_path / "child"
+    child.mkdir()
+    return tmp_path, child
+
+
+def test_parent_dotenv_is_not_loaded(nested_tree, monkeypatch):
+    """A ``.env`` one directory up must not reach the process environment."""
+    _, child = nested_tree
+    monkeypatch.chdir(child)
+    monkeypatch.delenv("BACKEND_URL", raising=False)
+    monkeypatch.delenv("TEAM_API_KEY", raising=False)
+
+    assert aixplain._load_cwd_dotenv() is False
+    assert os.environ.get("BACKEND_URL") is None
+    assert os.environ.get("TEAM_API_KEY") is None
+
+
+def test_cwd_dotenv_is_still_loaded(nested_tree, monkeypatch):
+    """The documented behaviour -- a ``.env`` in the working directory -- is kept."""
+    parent, _ = nested_tree
+    monkeypatch.chdir(parent)
+    monkeypatch.delenv("BACKEND_URL", raising=False)
+    monkeypatch.delenv("TEAM_API_KEY", raising=False)
+
+    assert aixplain._load_cwd_dotenv() is True
+    assert os.environ["BACKEND_URL"] == "https://evil.example.com"
+
+
+def test_existing_environment_wins(nested_tree, monkeypatch):
+    """``override=False`` is preserved: an exported value beats the file."""
+    parent, _ = nested_tree
+    monkeypatch.chdir(parent)
+    monkeypatch.setenv("BACKEND_URL", "https://platform-api.aixplain.com")
+
+    aixplain._load_cwd_dotenv()
+    assert os.environ["BACKEND_URL"] == "https://platform-api.aixplain.com"
+
+
+def test_import_from_nested_cwd_ignores_parent_dotenv(nested_tree):
+    """End-to-end: ``import aixplain`` from a subdirectory ignores the ancestor.
+
+    Exercises the real import path in a fresh interpreter rather than just the
+    helper, because the walk-up used to happen at import time.
+    """
+    _, child = nested_tree
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in ("BACKEND_URL", "TEAM_API_KEY", "AIXPLAIN_API_KEY", "MODELS_RUN_URL", "PIPELINES_RUN_URL")
+    }
+    # Point at *this* checkout, not whatever copy of the SDK happens to be
+    # installed, since the subprocess runs from a temporary directory.
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
+    result = subprocess.run(
+        [sys.executable, "-c", "import aixplain, os; print(os.environ.get('BACKEND_URL'))"],
+        cwd=str(child),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "evil.example.com" not in result.stdout
+    assert result.stdout.strip() == "None"

--- a/tests/unit/utils/test_upload_url_validation.py
+++ b/tests/unit/utils/test_upload_url_validation.py
@@ -1,0 +1,74 @@
+"""Tests that the presigned ``uploadUrl`` host is validated before the PUT (BUG-939).
+
+The URL comes straight out of a backend response. If the backend is compromised
+-- or ``BACKEND_URL`` was redirected by an ambient ``.env`` -- every dataset,
+database file, skill bundle and attachment would be PUT to the attacker while the
+SDK reported success, because ``_build_s3_link_from_presigned_url`` infers the
+bucket by regex and falls back to ``"aixplain-uploads"`` rather than raising.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aixplain.utils import file_utils
+from aixplain.utils.url_safety import UnsafeURLError
+from aixplain.v2.upload_utils import S3Uploader
+
+FOREIGN_URL = "https://evil.example.com/upload"
+GOOD_URL = "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc"
+
+
+def test_v2_uploader_refuses_a_foreign_host(tmp_path):
+    """``S3Uploader.upload_file`` raises before opening or sending the file."""
+    target = tmp_path / "data.csv"
+    target.write_text("a,b\n1,2\n")
+
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry") as request:
+        with pytest.raises(UnsafeURLError):
+            S3Uploader.upload_file(str(target), FOREIGN_URL, "text/csv")
+    request.assert_not_called()
+
+
+def test_v2_uploader_error_is_not_masked_as_a_generic_failure(tmp_path):
+    """The refusal must survive the ``except Exception -> FileUploadError`` wrapper."""
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry"):
+        with pytest.raises(UnsafeURLError) as excinfo:
+            S3Uploader.upload_file(str(target), FOREIGN_URL, "text/csv")
+    assert "evil.example.com" in str(excinfo.value)
+
+
+def test_v2_uploader_accepts_a_presigned_s3_url(tmp_path):
+    """The ordinary S3 target still works end to end."""
+    target = tmp_path / "data.csv"
+    target.write_text("x")
+
+    response = MagicMock(status_code=200)
+    with patch("aixplain.v2.upload_utils.RequestManager.request_with_retry", return_value=response) as request:
+        S3Uploader.upload_file(str(target), GOOD_URL, "text/csv")
+    request.assert_called_once()
+
+
+def test_upload_data_refuses_a_foreign_host_without_retrying(tmp_path):
+    """``file_utils.upload_data`` raises immediately and issues no PUT.
+
+    The generic handler in ``upload_data`` retries ``nattempts`` times and masks
+    the cause; a refused host is not transient, so it must bypass that path.
+    """
+    target = tmp_path / "data.csv"
+    target.write_text("a,b\n1,2\n")
+
+    post_response = MagicMock()
+    post_response.json.return_value = {"key": "some/key", "uploadUrl": FOREIGN_URL}
+
+    with patch.object(file_utils, "_request_with_retry", return_value=post_response) as request:
+        with pytest.raises(UnsafeURLError):
+            file_utils.upload_data(file_name=str(target), nattempts=2)
+
+    # Exactly one call: the POST that fetched the presigned URL. No PUT, and no
+    # recursive retry of the whole upload.
+    assert request.call_count == 1
+    assert request.call_args[0][0] == "post"

--- a/tests/unit/utils/test_url_safety.py
+++ b/tests/unit/utils/test_url_safety.py
@@ -221,6 +221,32 @@ def test_private_fetch_opt_in(resolver, monkeypatch):
     assert validate_fetch_url("http://10.0.0.1/code.py") == "http://10.0.0.1/code.py"
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "http://metadata.google.internal/computeMetadata/v1/",
+    ],
+)
+def test_private_fetch_opt_in_does_not_reopen_cloud_metadata(url, resolver, monkeypatch):
+    """The on-prem opt-in relaxes private ranges, not the credential endpoints.
+
+    An agent container running with the flag set would otherwise let a
+    model-generated URL read its own instance credentials and upload them.
+    """
+    monkeypatch.setenv(ALLOW_PRIVATE_FETCH_ENV_VAR, "1")
+    resolver({"metadata.google.internal": ["169.254.169.254"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url(url)
+
+
+def test_private_fetch_opt_in_still_allows_an_internal_name(resolver, monkeypatch):
+    """The flag's actual purpose keeps working: a private artifact host by name."""
+    monkeypatch.setenv(ALLOW_PRIVATE_FETCH_ENV_VAR, "1")
+    resolver({"artifacts.internal": ["10.1.2.3"]})
+    assert validate_fetch_url("http://artifacts.internal/code.py") == "http://artifacts.internal/code.py"
+
+
 # --------------------------------------------------------------------------
 # safe_get
 # --------------------------------------------------------------------------
@@ -318,6 +344,41 @@ def test_safe_get_follows_a_safe_redirect(resolver):
     )
     assert safe_get("https://example.com/x", session=session).text == "payload"
     assert adapter.requests == ["https://example.com/x", "https://cdn.example.com/y"]
+
+
+def test_safe_get_drops_headers_on_a_cross_host_redirect(resolver):
+    """Caller headers must not follow a redirect onto a different host."""
+    resolver({"example.com": ["93.184.216.34"], "cdn.example.net": ["93.184.216.35"]})
+    session, _ = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "https://cdn.example.net/y"}, b""),
+            "https://cdn.example.net/y": (200, {}, b"payload"),
+        }
+    )
+    seen = []
+    original = session.get
+    session.get = lambda url, **kwargs: (seen.append((url, kwargs.get("headers"))), original(url, **kwargs))[1]
+
+    safe_get("https://example.com/x", session=session, headers={"Authorization": "token SECRET"})
+    assert seen[0][1] == {"Authorization": "token SECRET"}
+    assert seen[1][1] is None
+
+
+def test_safe_get_keeps_headers_on_a_same_host_redirect(resolver):
+    """A redirect within the same host is not a credential boundary."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "https://example.com/y"}, b""),
+            "https://example.com/y": (200, {}, b"payload"),
+        }
+    )
+    seen = []
+    original = session.get
+    session.get = lambda url, **kwargs: (seen.append(kwargs.get("headers")), original(url, **kwargs))[1]
+
+    safe_get("https://example.com/x", session=session, headers={"Authorization": "token SECRET"})
+    assert seen == [{"Authorization": "token SECRET"}, {"Authorization": "token SECRET"}]
 
 
 def test_safe_get_caps_redirects(resolver):

--- a/tests/unit/utils/test_url_safety.py
+++ b/tests/unit/utils/test_url_safety.py
@@ -1,0 +1,381 @@
+"""Tests for the central URL trust policy (BUG-939).
+
+Covers the three decisions in ``aixplain.utils.url_safety``: the configured
+endpoint policy, the SSRF guard applied to caller/response URLs (including the
+redirect re-check), and the presigned upload host allowlist.
+
+No test opens a non-loopback socket: ``socket.getaddrinfo`` is patched so the
+resolved-IP blocklist can be exercised deterministically and offline.
+"""
+
+import io
+import logging
+import socket
+
+import pytest
+import requests
+from urllib3.response import HTTPResponse
+
+from aixplain.utils import url_safety
+from aixplain.utils.url_safety import (
+    ALLOW_PRIVATE_FETCH_ENV_VAR,
+    INSECURE_OPT_IN_ENV_VAR,
+    UPLOAD_ALLOWLIST_ENV_VAR,
+    UnsafeURLError,
+    safe_get,
+    validate_config_url,
+    validate_fetch_url,
+    validate_upload_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Run every test with the security opt-ins off and no remembered warnings."""
+    for name in (INSECURE_OPT_IN_ENV_VAR, ALLOW_PRIVATE_FETCH_ENV_VAR, UPLOAD_ALLOWLIST_ENV_VAR):
+        monkeypatch.delenv(name, raising=False)
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+    yield
+    url_safety._WARNED_CONFIG_HOSTS.clear()
+
+
+@pytest.fixture
+def resolver(monkeypatch):
+    """Patch ``socket.getaddrinfo`` with a host -> addresses mapping.
+
+    Returns a callable that installs the mapping; unknown hosts are treated as
+    literal addresses, which is what ``getaddrinfo`` does for an IP host anyway.
+    """
+
+    def _install(mapping):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            addresses = mapping.get(host)
+            if addresses is None:
+                try:
+                    socket.inet_pton(socket.AF_INET6 if ":" in host else socket.AF_INET, host)
+                except OSError:
+                    raise socket.gaierror(8, "nodename nor servname provided")
+                addresses = [host]
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port)) for address in addresses]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    return _install
+
+
+# --------------------------------------------------------------------------
+# validate_config_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://platform-api.aixplain.com",
+        "https://dev-platform-api.aixplain.com",
+        "https://test-platform-api.aixplain.com",
+        "https://models.aixplain.com/api/v2/execute",
+        "https://platform-api.aixplain.com/assets/pipeline/execution/run",
+    ],
+)
+def test_real_backends_validate_silently(url, caplog):
+    """Production, dev and test endpoints must pass with no warning at all."""
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        assert validate_config_url(url, "BACKEND_URL") == url
+    assert caplog.records == []
+
+
+def test_http_config_url_is_rejected_without_opt_in():
+    """Plain http would put the API key on the wire, so it fails closed."""
+    with pytest.raises(UnsafeURLError) as excinfo:
+        validate_config_url("http://platform-api.aixplain.com", "BACKEND_URL")
+    assert INSECURE_OPT_IN_ENV_VAR in str(excinfo.value)
+
+
+@pytest.mark.parametrize("url", ["http://platform-api.aixplain.com", "http://localhost:8000", "http://127.0.0.1:8000"])
+def test_http_config_url_is_allowed_with_opt_in(url, monkeypatch):
+    """The documented opt-in restores http, which is what local dev needs."""
+    monkeypatch.setenv(INSECURE_OPT_IN_ENV_VAR, "1")
+    assert validate_config_url(url, "BACKEND_URL") == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://platform-api.aixplain.com",
+        "file:///etc/passwd",
+        "https://",
+        "https://user:pw@evil.example.com/",
+        "not a url",
+        "",
+    ],
+)
+def test_structurally_invalid_config_urls_are_rejected(url):
+    """Non-http(s) schemes, missing hosts and embedded credentials all fail."""
+    with pytest.raises(UnsafeURLError):
+        validate_config_url(url, "BACKEND_URL")
+
+
+def test_foreign_host_warns_exactly_once(caplog):
+    """A non-aiXplain host is allowed but warned about, and only once."""
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        validate_config_url("https://evil.example.com", "BACKEND_URL")
+        validate_config_url("https://evil.example.com/other/path", "BACKEND_URL")
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "evil.example.com" in warnings[0].getMessage()
+
+
+def test_lookalike_host_is_not_treated_as_aixplain(caplog):
+    """``evil-aixplain.com`` must not match the ``aixplain.com`` suffix."""
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        validate_config_url("https://evil-aixplain.com", "BACKEND_URL")
+    assert len(caplog.records) == 1
+
+
+def test_loopback_under_opt_in_does_not_warn(caplog, monkeypatch):
+    """A local-dev endpoint is obviously not aiXplain; warning about it is noise."""
+    monkeypatch.setenv(INSECURE_OPT_IN_ENV_VAR, "1")
+    with caplog.at_level(logging.WARNING, logger="aixplain.utils.url_safety"):
+        validate_config_url("http://localhost:8000", "BACKEND_URL")
+    assert caplog.records == []
+
+
+# --------------------------------------------------------------------------
+# validate_fetch_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://x/1", "ftp://example.com/x", "ldap://x/"])
+def test_non_http_schemes_are_rejected(url):
+    """``validators.url()`` rejects some of these; the guard rejects all of them."""
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1:8080/x",
+        "http://10.0.0.1/",
+        "http://172.16.0.1/",
+        "http://192.168.1.1/",
+        "http://0.0.0.0/",
+        "http://[::1]/",
+        "http://[fe80::1]/",
+    ],
+)
+def test_private_and_metadata_literals_are_rejected(url, resolver):
+    """Exactly the addresses ``validators.url()`` waves through (BUG-939)."""
+    resolver({})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url(url)
+
+
+def test_metadata_hostname_is_rejected(resolver):
+    """``metadata.google.internal`` is refused by name, before any resolution."""
+    resolver({"metadata.google.internal": ["93.184.216.34"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://metadata.google.internal/computeMetadata/v1/")
+
+
+def test_private_address_behind_a_public_name_is_rejected(resolver):
+    """The check is on the resolved address, not on how public the name looks."""
+    resolver({"internal.example.com": ["127.0.0.1"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://internal.example.com/x")
+
+
+def test_ipv4_mapped_ipv6_loopback_is_rejected(resolver):
+    """``::ffff:127.0.0.1`` is loopback and must be unwrapped before classifying."""
+    resolver({"sneaky.example.com": ["::ffff:127.0.0.1"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://sneaky.example.com/x")
+
+
+def test_any_private_answer_rejects_the_whole_host(resolver):
+    """A host with one public and one private record cannot be trusted."""
+    resolver({"split.example.com": ["93.184.216.34", "192.168.1.5"]})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://split.example.com/x")
+
+
+def test_unresolvable_host_is_rejected(resolver):
+    """A resolver failure must never read as a passed check."""
+    resolver({})
+    with pytest.raises(UnsafeURLError):
+        validate_fetch_url("http://does-not-exist.example/x")
+
+
+def test_public_host_is_accepted(resolver):
+    """The ordinary case still works."""
+    resolver({"example.com": ["93.184.216.34"]})
+    assert validate_fetch_url("https://example.com/code.py") == "https://example.com/code.py"
+
+
+def test_private_fetch_opt_in(resolver, monkeypatch):
+    """On-prem deployments can re-enable private targets deliberately."""
+    monkeypatch.setenv(ALLOW_PRIVATE_FETCH_ENV_VAR, "1")
+    resolver({})
+    assert validate_fetch_url("http://10.0.0.1/code.py") == "http://10.0.0.1/code.py"
+
+
+# --------------------------------------------------------------------------
+# safe_get
+# --------------------------------------------------------------------------
+
+
+class _RecordingAdapter(requests.adapters.BaseAdapter):
+    """Adapter that records every request and replies from a scripted map."""
+
+    def __init__(self, responses):
+        """Store the ``url -> (status, headers, body)`` script."""
+        super().__init__()
+        self.responses = responses
+        self.requests = []
+
+    def send(self, request, **kwargs):
+        """Record *request* and return the scripted response.
+
+        The body is served through a real ``urllib3`` response so that
+        ``iter_content`` -- the path ``safe_get`` uses to bound a download --
+        is exercised rather than bypassed.
+        """
+        self.requests.append(request.url)
+        status, headers, body = self.responses[request.url]
+        response = requests.Response()
+        response.status_code = status
+        response.headers.update(headers)
+        response.raw = HTTPResponse(
+            body=io.BytesIO(body),
+            headers=headers,
+            status=status,
+            preload_content=False,
+        )
+        response.url = request.url
+        response.request = request
+        return response
+
+    def close(self):
+        """No-op: nothing to release."""
+
+
+def _session_with(responses):
+    """Return a session whose http(s) traffic is served by a recording adapter."""
+    adapter = _RecordingAdapter(responses)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session, adapter
+
+
+def test_safe_get_returns_the_body(resolver):
+    """The happy path behaves like ``requests.get``."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with({"https://example.com/code.py": (200, {}, b"def main():\n    pass\n")})
+    response = safe_get("https://example.com/code.py", session=session)
+    assert response.text.startswith("def main()")
+
+
+def test_safe_get_passes_a_timeout(resolver):
+    """A caller-supplied URL must never be fetched without a bound."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with({"https://example.com/x": (200, {}, b"ok")})
+    captured = {}
+    original = session.get
+
+    def spy(url, **kwargs):
+        captured.update(kwargs)
+        return original(url, **kwargs)
+
+    session.get = spy
+    safe_get("https://example.com/x", session=session)
+    assert captured["timeout"] is not None
+    assert captured["allow_redirects"] is False
+
+
+def test_safe_get_revalidates_redirect_targets(resolver):
+    """A public host that redirects to the metadata endpoint is stopped there."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, adapter = _session_with(
+        {"https://example.com/x": (302, {"Location": "http://169.254.169.254/latest/meta-data/"}, b"")}
+    )
+    with pytest.raises(UnsafeURLError):
+        safe_get("https://example.com/x", session=session)
+    # The redirect was never followed onto the wire.
+    assert adapter.requests == ["https://example.com/x"]
+
+
+def test_safe_get_follows_a_safe_redirect(resolver):
+    """A redirect to another public host is followed, not blocked."""
+    resolver({"example.com": ["93.184.216.34"], "cdn.example.com": ["93.184.216.35"]})
+    session, adapter = _session_with(
+        {
+            "https://example.com/x": (302, {"Location": "https://cdn.example.com/y"}, b""),
+            "https://cdn.example.com/y": (200, {}, b"payload"),
+        }
+    )
+    assert safe_get("https://example.com/x", session=session).text == "payload"
+    assert adapter.requests == ["https://example.com/x", "https://cdn.example.com/y"]
+
+
+def test_safe_get_caps_redirects(resolver):
+    """A redirect loop terminates instead of spinning."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, adapter = _session_with({"https://example.com/x": (302, {"Location": "https://example.com/x"}, b"")})
+    with pytest.raises(UnsafeURLError):
+        safe_get("https://example.com/x", session=session, max_redirects=2)
+    assert len(adapter.requests) == 3
+
+
+def test_safe_get_enforces_max_bytes(resolver):
+    """A hostile endpoint cannot balloon the memory of the fetching process."""
+    resolver({"example.com": ["93.184.216.34"]})
+    session, _ = _session_with({"https://example.com/big": (200, {}, b"x" * 4096)})
+    with pytest.raises(UnsafeURLError):
+        safe_get("https://example.com/big", session=session, max_bytes=1024)
+
+
+# --------------------------------------------------------------------------
+# validate_upload_url
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc",
+        "https://s3.us-east-1.amazonaws.com/bucket/key",
+        "https://uploads.aixplain.com/x",
+        "https://aixplain.com/x",
+    ],
+)
+def test_expected_upload_hosts_are_allowed(url):
+    """The hosts the backend actually hands out keep working."""
+    assert validate_upload_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example.com/x",
+        "https://evil.com/?x=amazonaws.com",
+        "https://notamazonaws.com/x",
+        "http://bucket.s3.amazonaws.com/x",
+        "ftp://bucket.s3.amazonaws.com/x",
+    ],
+)
+def test_foreign_upload_hosts_are_rejected(url):
+    """Anything else raises before a single byte is PUT."""
+    with pytest.raises(UnsafeURLError):
+        validate_upload_url(url)
+
+
+def test_upload_allowlist_env_var_extends_the_defaults(monkeypatch):
+    """A custom object store is supported without a fork."""
+    monkeypatch.setenv(UPLOAD_ALLOWLIST_ENV_VAR, "storage.example.com, *.cdn.example.org")
+    assert validate_upload_url("https://storage.example.com/x")
+    assert validate_upload_url("https://a.cdn.example.org/x")
+    with pytest.raises(UnsafeURLError):
+        validate_upload_url("https://other.example.com/x")

--- a/tests/unit/v2/test_agent_team_invariant.py
+++ b/tests/unit/v2/test_agent_team_invariant.py
@@ -1,0 +1,96 @@
+"""Guard: the team-agent tasks/tools invariant is deliberately *not* enforced.
+
+``Agent._sync_file_references`` carried a commented-out check for eight months::
+
+    # TODO: Re-enable this validation after backend data consistency is fixed
+    # if self.agents and (self.tasks or self.tools):
+    #     raise ValueError(
+    #         "Team agents cannot have tasks or tools. ..."
+    #     )
+
+It was disabled inside an unrelated 88-file commit, no replacement exists
+anywhere, and v1 never had it either (BUG-946). Re-enabling it as written is not
+safe: ``_sync_file_references`` sits on the run and payload-build paths as well
+as save, and it would fire for team agents *hydrated from the backend* -- which
+is precisely the inconsistency the TODO was deferring.
+
+So the comment is gone and the non-enforcement is now an explicit, tested
+decision rather than an accident. Anyone re-introducing the invariant has to
+consciously change these tests, and the backend follow-up is tracked on the PR.
+"""
+
+import pytest
+
+from aixplain import Aixplain
+
+
+@pytest.fixture
+def aix() -> Aixplain:
+    """Return an isolated client."""
+    return Aixplain(api_key="test-key", backend_url="https://example.test")
+
+
+def _team_agent_with_everything(aix):
+    """A team agent carrying sub-agents *and* tools *and* tasks."""
+    return aix.Agent(
+        name="team-agent",
+        instructions="Coordinate the sub-agents.",
+        agents=["sub-agent-id"],
+        tools=[{"id": "tool-id", "type": "model"}],
+        tasks=[{"name": "summarize", "description": "Summarize", "expectedOutput": "A summary"}],
+    )
+
+
+def test_team_agent_with_tools_and_tasks_constructs(aix):
+    """Construction must not raise for the combination."""
+    agent = _team_agent_with_everything(aix)
+
+    assert agent.agents == ["sub-agent-id"]
+    assert agent.tools
+    assert agent.tasks
+
+
+def test_team_agent_with_tools_and_tasks_builds_a_payload(aix):
+    """``build_save_payload`` runs ``_sync_file_references``; it must not raise.
+
+    This is the call the invariant would have broken, and it must keep emitting
+    both collections.
+    """
+    payload = _team_agent_with_everything(aix).build_save_payload()
+
+    assert payload["agents"]
+    assert payload["tools"]
+
+
+def test_backend_team_agent_with_tools_hydrates(aix):
+    """Loading an existing, inconsistent team agent must keep working.
+
+    ``Agent.from_dict`` is the ``get()`` path. Raising here would make already
+    stored team agents unloadable -- the reason the guard was disabled.
+    """
+    agent = aix.Agent.from_dict(
+        {
+            "id": "team-agent-id",
+            "name": "team-agent",
+            "description": "A team agent",
+            "role": "Coordinate the sub-agents.",
+            "agents": ["sub-agent-id"],
+            "tools": [{"id": "tool-id", "type": "model"}],
+            "tasks": [{"name": "summarize", "description": "Summarize", "expectedOutput": "A summary"}],
+        }
+    )
+
+    assert agent.agents == ["sub-agent-id"]
+    assert agent.tools
+    assert agent.build_save_payload()["tools"]
+
+
+def test_stale_invariant_comment_is_gone():
+    """The dead TODO must not come back as a comment instead of a decision."""
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parents[3] / "aixplain" / "v2" / "agent.py"
+    text = source.read_text()
+
+    assert "Re-enable this validation" not in text
+    assert "Team agents cannot have tasks or tools" not in text

--- a/tests/unit/v2/test_aixplain_v2_lazy.py
+++ b/tests/unit/v2/test_aixplain_v2_lazy.py
@@ -1,0 +1,191 @@
+"""Guard: the deprecated ``aixplain.aixplain_v2`` must never be a silent ``None``.
+
+It used to be constructed eagerly at import and the failure swallowed::
+
+    aixplain_v2 = None
+    try:
+        aixplain_v2 = Aixplain()
+    except Exception:
+        pass
+
+With no credential that discarded a precise, actionable message -- ``AssertionError:
+API key is required. Pass api_key=... to Aixplain() or set TEAM_API_KEY or
+AIXPLAIN_API_KEY.`` -- and left a public symbol bound to ``None``, so the first
+consumer hit ``AttributeError: 'NoneType' object has no attribute 'Agent'`` far
+from the cause (BUG-946).
+
+A module-level ``__getattr__`` now builds it on first access, so ``import aixplain``
+still works without a key (``aixplain --help`` and unit-test collection depend on
+that) while the real error reaches whoever actually asks for the client.
+
+``Aixplain(api_key=...)`` mutates ``os.environ``, and ``aixplain/__init__.py``
+loads a working-directory ``.env``, so every keyless case runs in a subprocess
+with the variables stripped and ``python-dotenv`` neutered.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Imported by the interpreter at startup (via `site`), before anything else can
+# read the environment, so the `from dotenv import load_dotenv` in
+# aixplain/__init__.py binds the neutered version.
+SITECUSTOMIZE = """
+import dotenv
+
+dotenv.load_dotenv = lambda *args, **kwargs: False
+dotenv.main.load_dotenv = dotenv.load_dotenv
+"""
+
+
+def _credential_free_env(sitecustomize_dir: Path) -> dict:
+    env = os.environ.copy()
+    env.pop("TEAM_API_KEY", None)
+    env.pop("AIXPLAIN_API_KEY", None)
+    existing_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (str(sitecustomize_dir), existing_path) if p)
+    return env
+
+
+def _run(code: str, tmp_path: Path, with_key: bool = False) -> subprocess.CompletedProcess:
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+    env = _credential_free_env(tmp_path)
+    if with_key:
+        env["TEAM_API_KEY"] = "unit-test-key"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_succeeds_without_api_key(tmp_path):
+    """`import aixplain` must not require a credential."""
+    result = _run("import aixplain; print('imported')", tmp_path)
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "imported" in result.stdout
+
+
+def test_access_without_key_raises_the_real_error(tmp_path):
+    """Accessing the attribute with no key must raise -- not hand back ``None``."""
+    result = _run(
+        """
+import aixplain
+
+try:
+    client = aixplain.aixplain_v2
+except AssertionError as e:
+    print("RAISED:", e)
+else:
+    print("RETURNED:", repr(client))
+""",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "RAISED: API key is required" in result.stdout, result.stdout
+    assert "RETURNED" not in result.stdout
+
+
+def test_from_import_without_key_raises_too(tmp_path):
+    """`from aixplain import aixplain_v2` must go through the same hook."""
+    result = _run(
+        """
+try:
+    from aixplain import aixplain_v2
+except AssertionError as e:
+    print("RAISED:", e)
+else:
+    print("RETURNED:", repr(aixplain_v2))
+""",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "RAISED: API key is required" in result.stdout, result.stdout
+
+
+def test_star_import_without_key_still_works(tmp_path):
+    """`from aixplain import *` must not construct the deprecated client.
+
+    ``aixplain_v2`` is deliberately absent from ``__all__``: leaving it there
+    would make a star import raise for a keyless user who intends to construct
+    ``Aixplain(api_key=...)`` themselves.
+    """
+    result = _run(
+        "from aixplain import *; print(Aixplain.__name__, File.__name__)",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "Aixplain File" in result.stdout
+
+
+def test_returns_cached_client_when_key_is_set(tmp_path):
+    """With a key, the attribute yields one `Aixplain`, stable across accesses."""
+    result = _run(
+        """
+import aixplain
+from aixplain import Aixplain
+
+first = aixplain.aixplain_v2
+second = aixplain.aixplain_v2
+print(isinstance(first, Aixplain), first is second)
+""",
+        tmp_path,
+        with_key=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert result.stdout.strip().endswith("True True"), result.stdout
+
+
+def test_first_access_warns_deprecation(tmp_path):
+    """First access must emit a `DeprecationWarning` naming the replacement."""
+    result = _run(
+        """
+import warnings
+import aixplain
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    aixplain.aixplain_v2
+
+deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+print(len(deprecations))
+print(str(deprecations[0].message))
+""",
+        tmp_path,
+        with_key=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == "1", result.stdout
+    assert "'aixplain.aixplain_v2' is deprecated" in lines[1]
+    assert "Aixplain()" in lines[1]
+
+
+def test_unknown_attribute_still_raises_attribute_error():
+    """The hook must not swallow genuine typos."""
+    import aixplain
+
+    with pytest.raises(AttributeError, match="no attribute 'not_a_real_symbol'"):
+        aixplain.not_a_real_symbol
+
+
+def test_dir_advertises_aixplain_v2():
+    """`dir(aixplain)` must keep listing the lazily provided symbol."""
+    import aixplain
+
+    listed = dir(aixplain)
+    assert "aixplain_v2" in listed
+    assert "Aixplain" in listed

--- a/tests/unit/v2/test_client_log_redaction.py
+++ b/tests/unit/v2/test_client_log_redaction.py
@@ -1,0 +1,148 @@
+"""Tests that the v2 client never logs credentials or bodies (BUG-939).
+
+The client used to ``logger.debug`` the whole ``kwargs`` dict -- which by that
+point carries the merged ``x-api-key`` header and the request body -- plus the
+full ``response.text``. With ``.env.example`` shipping ``LOG_LEVEL=DEBUG``, a
+single connected Slack tool wrote the user's third-party bot token and the team
+key into the application log.
+"""
+
+import logging
+
+import pytest
+from unittest.mock import Mock, patch
+
+from aixplain.v2.client import (
+    LOG_BODIES_ENV_VAR,
+    LOG_BODY_MAX_BYTES,
+    AixplainClient,
+)
+
+TEAM_KEY = "TEAMKEY_AAA"
+SLACK_TOKEN = "xoxb-USER-THIRD-PARTY-SECRET"
+RESPONSE_BODY = '{"accessKey": "ACCESSKEY_FOR_EVERY_KEY_ON_THE_ACCOUNT"}'
+REQUEST_BODY = {"name": "slack", "data": {"token": SLACK_TOKEN}}
+
+SECRETS = (TEAM_KEY, SLACK_TOKEN, "ACCESSKEY_FOR_EVERY_KEY_ON_THE_ACCOUNT", "x-api-key")
+
+
+@pytest.fixture(autouse=True)
+def bodies_off(monkeypatch):
+    """Ensure the body-logging opt-in is off unless a test sets it."""
+    monkeypatch.delenv(LOG_BODIES_ENV_VAR, raising=False)
+
+
+@pytest.fixture
+def client():
+    """A client pointed at a trusted origin, with a recognisable API key."""
+    return AixplainClient(base_url="https://platform-api.aixplain.com", team_api_key=TEAM_KEY)
+
+
+def _mock_response(body=RESPONSE_BODY, status=200):
+    """Return a mock response carrying *body* and *status*."""
+    response = Mock()
+    response.ok = 200 <= status < 400
+    response.status_code = status
+    response.text = body
+    response.content = body.encode()
+    response.headers = {"Content-Length": str(len(body))}
+    return response
+
+
+def _messages(caplog):
+    """Return every formatted log message captured so far."""
+    return [record.getMessage() for record in caplog.records]
+
+
+def test_no_record_contains_a_secret_or_a_body(client, caplog):
+    """The acceptance criterion: nothing sensitive reaches a log record."""
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw(
+                "POST",
+                "sdk/tools",
+                json=REQUEST_BODY,
+                headers={"Authorization": "Bearer abcdefghijklmnopqrst"},
+            )
+
+    joined = "\n".join(_messages(caplog))
+    for secret in SECRETS:
+        assert secret not in joined
+    assert RESPONSE_BODY not in joined
+    assert "slack" not in joined
+
+
+def test_outline_is_still_logged(client, caplog):
+    """Method, path, status and byte count remain available for debugging."""
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", json=REQUEST_BODY)
+
+    joined = "\n".join(_messages(caplog))
+    assert "POST" in joined
+    assert "sdk/tools" in joined
+    assert "200" in joined
+    assert f"{len(RESPONSE_BODY)} bytes" in joined
+
+
+def test_query_string_is_not_logged(client, caplog):
+    """Query strings carry presigned signatures and one-time tokens."""
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("GET", "https://platform-api.aixplain.com/sdk/x?X-Amz-Signature=SECRETSIG")
+
+    joined = "\n".join(_messages(caplog))
+    assert "SECRETSIG" not in joined
+    assert "/sdk/x" in joined
+
+
+def test_opt_in_logs_bodies_but_redacts_credentials(client, caplog, monkeypatch):
+    """With the opt-in on, bodies appear -- with credential values masked."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", json=REQUEST_BODY)
+
+    joined = "\n".join(_messages(caplog))
+    assert "slack" in joined  # the body really is logged now
+    assert SLACK_TOKEN not in joined
+    assert "***REDACTED***" in joined
+
+
+def test_opt_in_truncates_long_bodies(client, caplog, monkeypatch):
+    """A large response cannot flood the log even under the opt-in."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    big = "a" * (LOG_BODY_MAX_BYTES * 3)
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response(body=big)):
+            client.request_raw("GET", "sdk/x")
+
+    joined = "\n".join(_messages(caplog))
+    assert "(truncated)" in joined
+    assert len(joined) < len(big)
+
+
+def test_streaming_request_does_not_consume_the_body(client, caplog):
+    """The streaming path must not touch ``.content``/``.text`` to log a size."""
+    response = Mock()
+    response.ok = True
+    response.status_code = 200
+    response.headers = {}
+    type(response).content = property(lambda self: pytest.fail("streaming body was consumed"))
+    type(response).text = property(lambda self: pytest.fail("streaming body was consumed"))
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=response):
+            client.request_stream("GET", "sdk/stream")
+
+    assert any("sdk/stream" in message for message in _messages(caplog))
+
+
+def test_env_example_does_not_ship_debug_logging():
+    """``.env.example`` was the documented way to turn the leak on."""
+    from pathlib import Path
+
+    env_example = Path(__file__).resolve().parents[3] / ".env.example"
+    lines = [line.strip() for line in env_example.read_text().splitlines() if not line.strip().startswith("#")]
+    assert "LOG_LEVEL=DEBUG" not in lines
+    assert "LOG_LEVEL=INFO" in lines

--- a/tests/unit/v2/test_client_log_redaction.py
+++ b/tests/unit/v2/test_client_log_redaction.py
@@ -146,3 +146,75 @@ def test_env_example_does_not_ship_debug_logging():
     lines = [line.strip() for line in env_example.read_text().splitlines() if not line.strip().startswith("#")]
     assert "LOG_LEVEL=DEBUG" not in lines
     assert "LOG_LEVEL=INFO" in lines
+
+
+def test_opt_in_redacts_credential_keys_in_a_serialised_body(client, caplog, monkeypatch):
+    """A body that arrives already serialised is still redacted *by key*.
+
+    ``response.text`` and ``data=<json string>`` are plain strings, so key-based
+    redaction only applies once they are parsed back. ``APIKey.list()`` returns
+    the ``accessKey`` of every key on the account as JSON text, and it matches
+    none of the token patterns.
+    """
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    serialised = '{"headers": {"x-api-key": "%s"}, "note": "hi"}' % TEAM_KEY
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", data=serialised)
+
+    joined = "\n".join(_messages(caplog))
+    assert "hi" in joined  # the body really is logged
+    for secret in SECRETS:
+        if secret == "x-api-key":
+            continue  # the key *name* is fine; the value is not
+        assert secret not in joined
+
+
+def test_opt_in_redacts_a_non_json_body(client, caplog, monkeypatch):
+    """A body that is not JSON still gets pattern redaction."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response(body="plain " + SLACK_TOKEN)):
+            client.request_raw("GET", "sdk/x")
+
+    joined = "\n".join(_messages(caplog))
+    assert SLACK_TOKEN not in joined
+    assert "***REDACTED***" in joined
+
+
+def test_opt_in_does_not_crash_on_a_binary_body(client, caplog, monkeypatch):
+    """A ``data=`` payload of raw bytes must not raise from the log path."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/upload", data=b"\xff\xfe\x00binary")
+
+    assert any("sdk/upload" in message for message in _messages(caplog))
+
+
+def test_opt_in_never_lets_the_log_path_break_the_request(client, caplog, monkeypatch):
+    """Rendering a pathological body degrades to a placeholder, not a traceback."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+
+    class Explodes:
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response()):
+            client.request_raw("POST", "sdk/tools", data=Explodes())
+
+    joined = "\n".join(_messages(caplog))
+    assert "could not be redacted" in joined
+
+
+def test_opt_in_survives_a_deeply_nested_response_body(client, caplog, monkeypatch):
+    """``json.loads`` raises RecursionError on deep nesting; the caller must not see it."""
+    monkeypatch.setenv(LOG_BODIES_ENV_VAR, "1")
+    deep = "[" * 5000 + "]" * 5000
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(client.session, "request", return_value=_mock_response(body=deep)):
+            response = client.request_raw("GET", "sdk/x")
+
+    assert response.status_code == 200

--- a/tests/unit/v2/test_file.py
+++ b/tests/unit/v2/test_file.py
@@ -67,7 +67,7 @@ def test_save_local_file_promotes_upload_to_asset(tmp_path, aix):
     aix.client.get = Mock(return_value={"allowed": True})
     aix.client.post = Mock(
         side_effect=[
-            {"uploadUrl": "https://upload.test", "downloadUrl": "s3://bucket/temp/data.csv"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/upload", "downloadUrl": "s3://bucket/temp/data.csv"},
             _asset("file-1", "data.csv"),
         ]
     )
@@ -104,7 +104,7 @@ def test_save_local_file_sends_description_tags_and_privacy(tmp_path, aix):
     aix.client.get = Mock(return_value={"allowed": True})
     aix.client.post = Mock(
         side_effect=[
-            {"uploadUrl": "https://upload.test", "downloadUrl": "s3://bucket/temp/report.pdf"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/upload", "downloadUrl": "s3://bucket/temp/report.pdf"},
             _asset("file-1", "report.pdf"),
         ]
     )
@@ -157,9 +157,9 @@ def test_save_directory_preserves_parent_relationships_and_empty_folders(tmp_pat
             _asset("empty-id", "empty", "folder"),
             _asset("policies-id", "policies", "folder"),
             _asset("regional-id", "regional", "folder"),
-            {"uploadUrl": "https://upload.test/one", "downloadUrl": "s3://one"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/one", "downloadUrl": "s3://one"},
             _asset("security", "security.pdf"),
-            {"uploadUrl": "https://upload.test/two", "downloadUrl": "s3://two"},
+            {"uploadUrl": "https://bucket.s3.amazonaws.com/two", "downloadUrl": "s3://two"},
             _asset("eu", "eu.txt"),
         ]
     )

--- a/tests/unit/v2/test_no_v1_imports.py
+++ b/tests/unit/v2/test_no_v1_imports.py
@@ -19,6 +19,13 @@ V2_PACKAGE_DIR = Path(__file__).resolve().parents[3] / "aixplain" / "v2"
 #   core.py — optional try/except guarded sync of api key to v1 config
 EXCLUDED_FILES = {"enums_include.py", "core.py"}
 
+# Modules under ``aixplain.utils`` that v2 *may* import. The rule exists to keep
+# the v1 env-var validation chain out of v2, and ``aixplain.utils.url_safety``
+# imports nothing from ``aixplain`` at all -- it is the shared URL trust policy
+# used by v1, v2 and ``aixplain/utils`` alike (BUG-939), so it cannot pull that
+# chain in. ``test_url_safety_stays_v1_free`` below keeps that true.
+ALLOWED_SHARED_MODULES = {"aixplain.utils.url_safety"}
+
 # Patterns that constitute a v1 import.
 # Matches:  from aixplain.modules  / from aixplain.factories
 #           from aixplain.enums    / from aixplain.utils
@@ -54,6 +61,8 @@ def _find_v1_imports_via_ast(filepath):
     violations = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module in ALLOWED_SHARED_MODULES:
+                continue
             parts = node.module.split(".")
             # e.g. from aixplain.modules.model.utils import ...
             if (
@@ -71,6 +80,8 @@ def _find_v1_imports_via_ast(filepath):
                 violations.append(f"  line {node.lineno}: from {node.module} import {names}")
         elif isinstance(node, ast.Import):
             for alias in node.names:
+                if alias.name in ALLOWED_SHARED_MODULES:
+                    continue
                 parts = alias.name.split(".")
                 if (
                     len(parts) >= 2
@@ -95,3 +106,23 @@ def test_no_v1_imports(rel_name, filepath):
     """``aixplain/v2/{rel_name}`` must not import from v1 modules."""
     violations = _find_v1_imports_via_ast(filepath)
     assert not violations, f"v1 imports found in aixplain/v2/{rel_name}:\n" + "\n".join(violations)
+
+
+def test_url_safety_stays_v1_free():
+    """The one shared module v2 may import must not reach into v1 itself.
+
+    ``aixplain.utils.url_safety`` is exempted from the rule above only because it
+    imports nothing from ``aixplain``; if that ever changes, the exemption would
+    silently reopen the v1 import chain for every v2 module that uses it.
+    """
+    path = V2_PACKAGE_DIR.parent / "utils" / "url_safety.py"
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+
+    assert not [name for name in imported if name.split(".")[0] == "aixplain"]

--- a/tests/unit/v2/test_ssrf_call_sites.py
+++ b/tests/unit/v2/test_ssrf_call_sites.py
@@ -1,0 +1,124 @@
+"""Tests that every caller/response URL sink goes through the SSRF guard (BUG-939).
+
+``validators.url()`` is a syntax check, and against the pinned validators 0.35.0
+it returns True for ``http://169.254.169.254/latest/meta-data/``,
+``http://127.0.0.1:8080/x`` and ``http://10.0.0.1/``. Each sink below used to
+fetch such a URL directly; these tests assert that the request is now refused
+before any socket is opened.
+"""
+
+import ast
+import socket
+from pathlib import Path
+
+import pytest
+import requests
+
+from aixplain.utils.url_safety import UnsafeURLError
+
+METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Every module that fetches a URL chosen by a caller or by a response body.
+GUARDED_SINK_FILES = [
+    "aixplain/v2/code_utils.py",
+    "aixplain/v2/rlm.py",
+    "aixplain/v1/modules/model/utils.py",
+    "aixplain/v1/modules/model/rlm.py",
+    "aixplain/v1/modules/agent/tool/sql_tool.py",
+    "aixplain/v1/factories/model_factory/utils.py",
+]
+
+
+@pytest.fixture(autouse=True)
+def no_sockets(monkeypatch):
+    """Fail loudly if any of these code paths actually tries to connect."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("an outbound request was attempted")
+
+    monkeypatch.setattr(requests.Session, "send", explode)
+    monkeypatch.setattr(socket, "create_connection", explode)
+
+
+def test_parse_code_refuses_a_metadata_url():
+    """The v2 utility-model sink no longer fetches the cloud metadata endpoint."""
+    from aixplain.v2.code_utils import parse_code
+
+    with pytest.raises(UnsafeURLError):
+        parse_code(METADATA_URL)
+
+
+def test_parse_code_decorated_refuses_a_private_url():
+    """The decorated variant is the second sink in the same module."""
+    from aixplain.v2.code_utils import parse_code_decorated
+
+    with pytest.raises(UnsafeURLError):
+        parse_code_decorated("http://127.0.0.1:8080/tool.py")
+
+
+def test_rlm_url_context_is_guarded():
+    """``_resolve_url_context`` fetches a caller-supplied URL, so it is gated."""
+    from aixplain.v2.rlm import RLM
+
+    with pytest.raises(UnsafeURLError):
+        RLM._resolve_url_context(METADATA_URL)
+
+
+def test_v1_parse_code_refuses_a_private_url():
+    """v1 gets the same guard, as a one-line call-site change."""
+    from aixplain.v1.modules.model.utils import parse_code
+
+    with pytest.raises(UnsafeURLError):
+        parse_code("http://10.0.0.1/code.py")
+
+
+def test_v1_model_factory_version_link_is_guarded():
+    """A ``version.id`` taken from a response is a blind-SSRF port scanner otherwise.
+
+    The surrounding ``except Exception: code = ""`` is left in place (v1 is
+    unmaintained), so the guard has to refuse the request rather than rely on an
+    informative exception reaching the caller.
+    """
+    from aixplain.utils.url_safety import safe_get
+    from aixplain.v1.factories.model_factory import utils as factory_utils
+
+    assert factory_utils.safe_get is safe_get
+    with pytest.raises(UnsafeURLError):
+        factory_utils.safe_get("http://127.0.0.1:22/")
+
+
+def test_v1_benchmark_report_url_is_guarded():
+    """``reportUrl`` is also a response field, so it is validated before download."""
+    from aixplain.utils.url_safety import validate_fetch_url
+    from aixplain.v1.modules import benchmark_job
+
+    assert benchmark_job.validate_fetch_url is validate_fetch_url
+    with pytest.raises(UnsafeURLError):
+        benchmark_job.validate_fetch_url("http://169.254.169.254/latest/meta-data/")
+
+
+def _fetch_sinks(path):
+    """Return the ``requests.<verb>(...)`` dispatch nodes in *path*.
+
+    String literals are ignored, which matters because ``rlm.py`` embeds worker
+    source code that legitimately calls ``requests.get`` *inside the sandbox*.
+    """
+    tree = ast.parse((REPO_ROOT / path).read_text())
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        target = node.func
+        if target.attr not in ("get",) or not isinstance(target.value, ast.Name):
+            continue
+        if target.value.id == "requests":
+            found.append(node.lineno)
+    return found
+
+
+@pytest.mark.parametrize("path", GUARDED_SINK_FILES)
+def test_no_direct_requests_get_remains(path):
+    """Guard test: these modules must reach remote URLs only via ``safe_get``."""
+    assert _fetch_sinks(path) == [], f"{path} still calls requests.get directly"

--- a/tests/unit/v2/test_ssrf_call_sites.py
+++ b/tests/unit/v2/test_ssrf_call_sites.py
@@ -9,6 +9,7 @@ before any socket is opened.
 
 import ast
 import socket
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
@@ -97,6 +98,21 @@ def test_v1_benchmark_report_url_is_guarded():
     assert benchmark_job.validate_fetch_url is validate_fetch_url
     with pytest.raises(UnsafeURLError):
         benchmark_job.validate_fetch_url("http://169.254.169.254/latest/meta-data/")
+
+
+def test_v2_file_source_url_is_guarded(tmp_path):
+    """``File(source=<url>).save()`` fetches a caller URL and uploads the body.
+
+    Same sink shape as the utility-model code fetch, in a different module: it
+    is what would turn ``File("http://169.254.169.254/...")`` into an
+    instance-credentials upload.
+    """
+    from aixplain.v2.file import File
+
+    file = File(source=METADATA_URL)
+    file.context = SimpleNamespace(client=SimpleNamespace(timeout=(1, 1)))
+    with pytest.raises(UnsafeURLError):
+        file.save()
 
 
 def _fetch_sinks(path):

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -733,3 +733,79 @@ class TestMergeWithDynamicAttrs:
         for key, _ in tool._RUN_HEADER_KEYS:
             assert key not in payload_kwargs
         assert payload_kwargs["data"] == {"q": "hi"}
+
+
+class TestValidateParamsReportsFailures:
+    """_validate_params must never report "valid" when validation crashed.
+
+    The action-input branch used to be wrapped in a bare `except Exception: pass`,
+    so an unresolvable action name or a malformed payload produced an *empty*
+    error list -- indistinguishable from "validated clean" -- and `Model.run`
+    happily shipped the call to the backend (BUG-946).
+    """
+
+    def test_unknown_action_returns_non_empty_errors(self):
+        """A name absent from the cached actions must surface as an error."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        errors = tool._validate_params(action="NO_SUCH_ACTION", data={"query": "hi"})
+
+        assert errors, "an unresolvable action must not validate clean"
+        assert "NO_SUCH_ACTION" in errors[0]
+
+    def test_lazy_input_loader_failure_is_reported(self):
+        """The real unknown-action path: `Actions` fabricates an `ActionView`.
+
+        `Actions.__getitem__` does not raise for an unknown name when an action
+        factory is configured; the failure surfaces one line later, when
+        `action_obj.inputs` runs the lazy loader.
+        """
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        def _boom(action_name, description=None):
+            def _load_inputs():
+                raise ValueError(f"Action '{action_name}' not found or has no input parameters defined.")
+
+            return Action(name=action_name, _inputs_loader=_load_inputs)
+
+        actions = Actions(actions={}, _action_factory=_boom)
+        tool.__dict__["actions"] = actions
+
+        errors = tool._validate_params(action="GHOST", data={})
+
+        assert len(errors) == 1
+        assert "Could not validate inputs for 'GHOST'" in errors[0]
+        assert "not found or has no input parameters defined" in errors[0]
+
+    def test_crashing_validate_is_reported_not_swallowed(self):
+        """A malformed payload that makes `Inputs.validate` raise must be reported."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        with patch.object(Inputs, "validate", side_effect=TypeError("unhashable payload")):
+            errors = tool._validate_params(action="search", data={"query": "hi"})
+
+        assert errors == ["Could not validate inputs for 'search': unhashable payload"]
+
+    def test_valid_action_still_validates_clean(self):
+        """The happy path must be unchanged: satisfied inputs return no errors."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        assert tool._validate_params(action="search", data={"query": "hello"}) == []
+
+    def test_missing_required_input_reports_once(self):
+        """`Inputs.validate` messages pass through unchanged -- no double reporting."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        errors = tool._validate_params(action="search", data={})
+
+        assert errors == ["Required input 'query' is missing"]

--- a/tests/unit/v2/test_upload_timeouts.py
+++ b/tests/unit/v2/test_upload_timeouts.py
@@ -23,7 +23,7 @@ from aixplain.v2.upload_utils import FileUploader, RequestManager
 def _ok_response():
     response = Mock()
     response.status_code = 200
-    response.json.return_value = {"key": "uploads/x.csv", "uploadUrl": "https://s3.example.com/x"}
+    response.json.return_value = {"key": "uploads/x.csv", "uploadUrl": "https://bucket.s3.amazonaws.com/x"}
     return response
 
 


### PR DESCRIPTION
## Summary

Seven security findings from [BUG-939](https://aixplain.atlassian.net/browse/BUG-939), one root cause: the SDK trusted whatever the ambient environment and the remote side told it. Five are fixed here; items 6 and 7 were already closed on the base branch by the BUG-942/BUG-1090 work and were verified rather than re-implemented.

Every finding was re-located on the current branch before being changed — the ticket is pinned to `40ec18f2` and the line numbers have drifted.

### What changed

- **`.env` loading is scoped to the working directory.** A bare `load_dotenv()` walks up, so a `.env` in *any* ancestor directory could set `BACKEND_URL`, `TEAM_API_KEY`, `LOG_LEVEL` or `SENTRY_DSN` for a user running their own script from a subdirectory. `find_dotenv(usecwd=True)` still walks up, so `os.path.join(os.getcwd(), ".env")` is loaded explicitly instead. A `.env` in the CWD itself behaves exactly as before.
- **Config URL policy.** `BACKEND_URL`, `MODELS_RUN_URL` and `PIPELINES_RUN_URL` must be `https://` unless `AIXPLAIN_ALLOW_INSECURE_URLS=1` (which also permits `http://localhost` / `127.0.0.1` for local dev), and a non-`*.aixplain.com` host logs a single WARNING. `dev-platform-api.aixplain.com` and `test-platform-api.aixplain.com` are unaffected.
- **Debug logging.** The v2 client no longer logs request `kwargs` (which carry the merged `x-api-key` header *and* the body) or `response.text`. It logs method, path, status and byte count. Bodies are available only under `AIXPLAIN_LOG_BODIES=1`, redacted and truncated. Redaction parses already-serialised bodies back before matching, so the sink the ticket names — `APIKey.list()` returning `{"accessKey": ...}` for every key on the account — is covered, as is an `x-api-key` nested inside a `data=` payload. `.env.example` now ships `LOG_LEVEL=INFO`.
- **SSRF gate.** New `aixplain/utils/url_safety.py`: scheme allowlist (`http`/`https` only), resolved-IP blocklist (loopback, RFC-1918, link-local, reserved, multicast, cloud metadata), a bounded timeout, a response size cap, and re-validation after *each* redirect (`allow_redirects=False` plus a manual follow that also drops caller headers on a cross-host hop — the protection `requests` gives up when redirects are followed by hand). Wired into every `requests.get` on a caller- or response-supplied URL.
- **Presigned upload URL.** The `uploadUrl` host is validated before the PUT in `v2/upload_utils.py`, `utils/file_utils.py` and `v2/file.py`. `*.amazonaws.com` and `*.aixplain.com` are allowed, extendable via `AIXPLAIN_UPLOAD_HOST_ALLOWLIST`; anything else raises `UnsafeURLError`.

`AIXPLAIN_ALLOW_PRIVATE_FETCH=1` exists for on-prem deployments that need an internal artifact host. It relaxes only the private-range rule — it does not re-open the cloud metadata endpoints, which matters most inside an agent container where the URL can originate from model output.

v1 sites got the minimal call-site swap only, no restructuring, per the assignee's note that `aixplain/v1/…` is unmaintained.

## Per-finding status

| # | Finding | Status | Notes |
|---|---------|--------|-------|
| 1 | `load_dotenv()` walks up from CWD; `BACKEND_URL` unvalidated | **Fixed** | `aixplain/__init__.py` loads `$CWD/.env` explicitly; `aixplain/utils/config.py` enforces https + host warning |
| 2 | v2 client debug-logs full request/response bodies; `.env.example` ships `LOG_LEVEL=DEBUG` | **Fixed** | `aixplain/v2/client.py` logs method/path/status/bytes; bodies gated behind `AIXPLAIN_LOG_BODIES=1` and redacted; `.env.example` → `LOG_LEVEL=INFO` |
| 3 | SSRF — `validators.url()` used as a security gate | **Fixed** | `v2/code_utils.py` (×2), `v2/rlm.py`, `v2/file.py`; v1 call-site swaps in `v1/modules/model/utils.py` (×2), `v1/modules/agent/tool/sql_tool.py`, `v1/modules/model/rlm.py` |
| 4 | SSRF — `requests.get()` on a URL from a response field | **Fixed** | `v1/factories/model_factory/utils.py` and `v1/modules/benchmark_job.py`, call-site change only |
| 5 | Presigned `uploadUrl` PUT with no host validation | **Fixed** | `v2/upload_utils.py`, `utils/file_utils.py`, `v2/file.py` |
| 6 | Non-idempotent POST retry (`allowed_methods` includes POST) | **Already fixed** | Closed on the base branch by BUG-942/BUG-1090; verified `DEFAULT_RETRY_ALLOWED_METHODS` is GET-only. No gap to fill |
| 7 | `429` absent from `status_forcelist`; no jitter; no `Retry-After` | **Already fixed** | Closed on the base branch by BUG-942; verified `DEFAULT_RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]`, `backoff_jitter=0.3`, `respect_retry_after_header=True` with a 60s `retry_after_max` cap. No gap to fill |

Nothing was skipped.

## Acceptance criteria

| Criterion | Covered by |
|---|---|
| Parent-directory `.env` cannot change `BACKEND_URL` or supply the key (nested CWD) | `tests/unit/utils/test_dotenv_scope.py` |
| `BACKEND_URL=http://…` rejected without opt-in; non-`*.aixplain.com` warns | `tests/unit/utils/test_config_url_policy.py` |
| No log record at any level contains a body, or an `x-api-key`/`Authorization`/third-party token value | `tests/unit/v2/test_client_log_redaction.py` (`caplog`) |
| `.env.example` no longer ships `LOG_LEVEL=DEBUG` | `.env.example:8` |
| Scheme allowlist + resolved-IP blocklist, re-checked after redirects | `tests/unit/utils/test_url_safety.py` (patched resolver, incl. rebinding-on-redirect), `tests/unit/v2/test_ssrf_call_sites.py` |
| Foreign presigned upload host raises | `tests/unit/utils/test_upload_url_validation.py` |
| POST removed from `allowed_methods`; `429` in `status_forcelist`; non-zero `backoff_jitter` | Already on the base branch (BUG-942/BUG-1090) |

## Test evidence

Full unit suite, no network:

```
$ python -m pytest tests/unit -q
2244 passed, 3 skipped, 146 warnings in 27.52s
```

New tests for this ticket:

```
$ python -m pytest tests/unit/utils/test_dotenv_scope.py \
    tests/unit/utils/test_config_url_policy.py \
    tests/unit/utils/test_url_safety.py \
    tests/unit/utils/test_upload_url_validation.py \
    tests/unit/v2/test_client_log_redaction.py \
    tests/unit/v2/test_ssrf_call_sites.py \
    tests/unit/v2/test_no_v1_imports.py -q
127 passed, 33 warnings in 0.98s
```

Lint, over the scope the pre-commit hooks enforce (`files: ^aixplain/v2/`):

```
$ ruff check aixplain/v2/ && ruff format --check aixplain/v2/
All checks passed!
30 files already formatted
```

All pre-commit hooks pass, including the full unit suite. The `ruff` docstring findings that remain outside `aixplain/v2/` (D100/D101/D102/D415 in v1 modules and test files) are pre-existing on the base branch and out of this ticket's scope.

## Jira

https://aixplain.atlassian.net/browse/BUG-939

Related: https://aixplain.atlassian.net/browse/BUG-942, https://aixplain.atlassian.net/browse/BUG-1090


[BUG-939]: https://aixplain.atlassian.net/browse/BUG-939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ