### PR TITLE
fix(v2): honour or strip run kwargs instead of discarding them (BUG-1091)

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -2402,7 +2402,11 @@ class Agent(
         fields = ("max_cost", "max_duration_seconds", "max_iterations")
         if session_budget is None:
             has_cap = any(getattr(agent_budget, name, None) is not None for name in fields)
-            return agent_budget if has_cap else None
+            # Copy, never alias: ``agent.budget`` is documented as mutated in
+            # place (``agent.budget.max_cost = ...``), so handing the same object
+            # to the session would let a later agent-side edit silently rewrite
+            # the session's persisted cap.
+            return replace(agent_budget) if has_cap else None
         filled = {
             name: getattr(agent_budget, name, None)
             for name in fields

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from datetime import datetime
 from enum import Enum
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Any, Dict, Tuple, Union, Text
 from typing_extensions import Unpack, NotRequired, TypedDict, Literal
 from dataclasses_json import dataclass_json, config
@@ -2158,7 +2158,17 @@ class Agent(
         return payload
 
     def build_run_payload(self, **kwargs: Unpack[AgentRunParams]) -> dict:
-        """Build the payload for the run action."""
+        """Build the payload for the run action.
+
+        SDK-control kwargs (``_RUN_CONTROL_KEYS``: retries/timeouts, the
+        ``progress_*`` display trio, ``api_key`` / ``resource_path``, and the
+        header-only run metadata) are dropped up front. The run path already
+        filters them via ``_payload_kwargs_for_run``; repeating it here means the
+        catch-all snake_case→camelCase forwarder below cannot put them on the
+        wire even when this builder is called directly (BUG-1091).
+        """
+        kwargs = {k: v for k, v in kwargs.items() if k not in self._RUN_CONTROL_KEYS}
+
         # Extract execution_params if provided, otherwise use defaults
         execution_params = kwargs.pop("execution_params", {})
 
@@ -2365,8 +2375,42 @@ class Agent(
                         values[name] = value
         return values
 
-    @staticmethod
-    def _apply_run_overrides_to_session(session: "Session", kwargs: Dict[str, Any]) -> None:
+    # Per-run kwargs that map onto ``ExecutionConfig`` fields. ``budget`` is
+    # intentionally absent: it is not a run kwarg (``build_run_payload`` pops any
+    # stray one) and reaches the session via the agent's own budget instead.
+    _SESSION_EXECUTION_OVERRIDES: ClassVar[tuple] = (
+        "execution_params",
+        "criteria",
+        "evolve",
+        "identifier",
+        "run_response_generation",
+    )
+
+    def _budget_for_session(self, session_budget: Optional["Budget"]) -> Optional["Budget"]:
+        """Fill unset session budget caps from ``self.budget``; session values win.
+
+        A session's stored cap is an explicit, persisted ceiling: the agent's own
+        budget may only fill slots the session leaves unset, never widen or
+        replace one.
+
+        Returns *session_budget* itself (identity, so the caller can tell nothing
+        changed) when the agent has no budget or contributes no new cap.
+        """
+        agent_budget = getattr(self, "budget", None)
+        if agent_budget is None:
+            return session_budget
+        fields = ("max_cost", "max_duration_seconds", "max_iterations")
+        if session_budget is None:
+            has_cap = any(getattr(agent_budget, name, None) is not None for name in fields)
+            return agent_budget if has_cap else None
+        filled = {
+            name: getattr(agent_budget, name, None)
+            for name in fields
+            if getattr(session_budget, name, None) is None and getattr(agent_budget, name, None) is not None
+        }
+        return replace(session_budget, **filled) if filled else session_budget
+
+    def _apply_run_overrides_to_session(self, session: "Session", kwargs: Dict[str, Any]) -> None:
         """Apply per-run execution overrides onto a session.
 
         When a caller runs within a ``session`` but also passes
@@ -2379,37 +2423,40 @@ class Agent(
         result differs from what's stored, persist it so the overrides
         take effect.
 
+        The agent's own ``budget`` applies on this path too (it already does on
+        the direct run path), but only fills caps the session leaves unset.
+
         We warn because this mutates the session's ``executionConfig`` for
         every subsequent message in the session, not just this run.
         """
         from .session import ExecutionConfig
 
-        overrides = {
-            "execution_params": kwargs.get("execution_params"),
-            "criteria": kwargs.get("criteria"),
-            "evolve": kwargs.get("evolve"),
-            "identifier": kwargs.get("identifier"),
-            "run_response_generation": kwargs.get("run_response_generation"),
-        }
-        provided = {key: value for key, value in overrides.items() if value is not None}
-        if not provided:
+        provided = {key: kwargs[key] for key in self._SESSION_EXECUTION_OVERRIDES if kwargs.get(key) is not None}
+
+        current = ExecutionConfig.coerce(session.execution_config)
+
+        # Rebuild *from the stored config*, never from an enumerated field list:
+        # a hardcoded ``base`` dict omitted ``budget``, so every session run with
+        # any override silently deleted the session's persisted spend cap — and
+        # the same trap would reopen for any field added to ExecutionConfig
+        # (BUG-1091).
+        merged = replace(current, **provided) if current is not None else ExecutionConfig(**provided)
+
+        seeded = self._budget_for_session(merged.budget)
+        budget_seeded = seeded is not merged.budget
+        if budget_seeded:
+            merged = replace(merged, budget=seeded)
+
+        # Nothing to apply: keep today's semantics that a plain session run (no
+        # overrides, no cap the agent can contribute) performs no write.
+        if not provided and not budget_seeded:
             return
-
-        current = session.execution_config
-        base = {
-            "execution_params": getattr(current, "execution_params", None),
-            "criteria": getattr(current, "criteria", None),
-            "evolve": getattr(current, "evolve", None),
-            "identifier": getattr(current, "identifier", None),
-            "run_response_generation": getattr(current, "run_response_generation", None),
-        }
-        merged = ExecutionConfig(**{**base, **provided})
-
         if current is not None and merged.to_api_dict() == current.to_api_dict():
             return
 
+        changed = sorted(provided) + (["budget (from agent.budget)"] if budget_seeded else [])
         warnings.warn(
-            f"Per-run execution overrides ({', '.join(sorted(provided))}) were "
+            f"Per-run execution overrides ({', '.join(changed)}) were "
             f"passed alongside session '{session.id}'. Updating the session's "
             f"stored executionConfig so the overrides take effect; this also "
             f"applies to every subsequent message in this session.",

--- a/aixplain/v2/model.py
+++ b/aixplain/v2/model.py
@@ -746,41 +746,37 @@ class Model(
         else:
             super().__setattr__(name, value)
 
-    # Orchestration params the SDK consumes itself, plus every per-run header
-    # kwarg. The header half is derived from RunnableResourceMixin._RUN_HEADER_KEYS
-    # rather than re-listed, so a new header can't be added to the wire while
-    # still leaking into the v1/URL payloads (a merge once silently dropped such a
-    # duplicated entry — see the _RUN_HEADER_KEYS note).
-    _SDK_ONLY_PARAMS = frozenset(
-        {
-            "timeout",
-            "wait_time",
-            "show_progress",
-            "stream",
-            "run_retries",
-            "run_retry_wait",
-        }
-    ) | {key for key, _ in RunnableResourceMixin._RUN_HEADER_KEYS}
-
     # ``identifier`` is a per-run caller identity emitted as the ``x-user-id``
     # header (RunnableResourceMixin._headers_for_run), never a model/action
-    # input. Exclude it from the v2 payload builder here (and from the v1/URL
-    # builders via _SDK_ONLY_PARAMS above) so it cannot leak into model inputs
-    # or supplier-facing logs. Agent keeps it in the body by NOT overriding this.
+    # input. Exclude it from the payload builders here so it cannot leak into
+    # model inputs or supplier-facing logs. Agent keeps it in the body by NOT
+    # overriding this.
     #
     # ``session_id`` (→ ``x-session-id``) and ``agent_name`` (→ ``x-agent``) are
     # the same kind of per-run metadata but header-only for every runnable, so the
-    # base _RUN_CONTROL_KEYS already excludes them; _SDK_ONLY_PARAMS above covers
-    # them again for the v1/URL builder paths.
-    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier"}
+    # base _RUN_CONTROL_KEYS already excludes them.
+    #
+    # ``stream`` selects the streaming *path* (see ``run``) and is expressed on
+    # the wire as ``options.stream`` by ``run_stream`` — never as a top-level
+    # body field.
+    _RUN_CONTROL_KEYS = RunnableResourceMixin._RUN_CONTROL_KEYS | {"identifier", "stream"}
+
+    # The v1/URL builder path (``_run_async_v1``) and ``build_run_payload`` filter
+    # with the *same* set rather than a second hand-maintained literal: a merge
+    # once dropped a duplicated entry and silently put ``session_id`` back on the
+    # wire (BUG-1091). Kept as a distinct name because it is referenced by
+    # existing tests and by ``build_run_payload``'s docstring.
+    _SDK_ONLY_PARAMS = _RUN_CONTROL_KEYS
 
     def build_run_payload(self, **kwargs: Unpack[ModelRunParams]) -> dict:
         """Build the JSON payload for a model execution request.
 
         Strips SDK-only orchestration params (``timeout``, ``wait_time``,
-        ``show_progress``, ``stream``, ``run_retries``, ``run_retry_wait``) and
-        the header-only run metadata (``identifier``, ``session_id``,
-        ``agent_name``) so they are never forwarded to the backend API.
+        ``show_progress``, ``progress_*``, ``stream``, ``run_retries``,
+        ``run_retry_wait``), the request-dispatch params (``api_key``,
+        ``resource_path``) and the header-only run metadata (``identifier``,
+        ``session_id``, ``agent_name``) so they are never forwarded to the
+        backend API.
         """
         filtered = {k: v for k, v in kwargs.items() if k not in self._SDK_ONLY_PARAMS}
         return super().build_run_payload(**filtered)
@@ -828,13 +824,24 @@ class Model(
         # Use v2 endpoint - it uses "results" as the items key (default)
         return super().search(**kwargs)
 
-    def run(self, **kwargs: Unpack[ModelRunParams]) -> ModelResult:
+    def run(self, **kwargs: Unpack[ModelRunParams]) -> Union[ModelResult, "ModelResponseStreamer"]:
         """Run the model with dynamic parameter validation and default handling.
 
         This method routes the execution based on the model's connection type:
         - Sync models: Uses V2 endpoint directly (returns result immediately)
         - Async models: Uses V2 endpoint and polls until completion
+
+        Returns:
+            ModelResult, or a :class:`ModelResponseStreamer` when ``stream=True``
+            — the flag selects the streaming path rather than being silently
+            dropped (BUG-1091).
         """
+        # ``stream`` selects the path, so it is consumed here rather than
+        # forwarded: run_stream sets ``options.stream`` on the wire itself and
+        # runs its own merge/validation, so passing it on would be redundant.
+        if kwargs.pop("stream", None):
+            return self.run_stream(**kwargs)
+
         # Merge dynamic attributes with provided kwargs
         effective_params = self._merge_with_dynamic_attrs(**kwargs)
 
@@ -929,9 +936,16 @@ class Model(
         v1_base_url = self.context.model_url.replace("/api/v2/", "/api/v1/")
         url = f"{v1_base_url}/{self.id}"
 
+        # Same identity headers as the sync path: this fallback is still a run,
+        # so its caller must stay attributable downstream (BUG-1091).
+        request_kwargs: dict = {"data": json_payload}
+        headers = self._headers_for_run(kwargs)
+        if headers:
+            request_kwargs["headers"] = headers
+
         # Use the v2 client's raw request method (raises APIError on non-2xx)
         try:
-            r = self.context.client.request_raw("post", url, data=json_payload)
+            r = self.context.client.request_raw("post", url, **request_kwargs)
             resp = r.json()
         except Exception as e:
             logger.error(f"Error in V1 async request: {e}")
@@ -1017,7 +1031,12 @@ class Model(
 
         self._ensure_valid_state()
 
-        payload = self.build_run_payload(**effective_params)
+        # Same body filter and identity headers as the sync path: a stream is
+        # still a run, so ``api_key`` must not reach the model input and the
+        # caller must stay attributable downstream (BUG-1091).
+        payload_input = self._payload_kwargs_for_run(effective_params)
+
+        payload = self.build_run_payload(**payload_input)
 
         if "options" not in payload:
             payload["options"] = {}
@@ -1025,11 +1044,15 @@ class Model(
         if payload.get("tools") is not None:
             payload["options"]["raw"] = True
 
-        run_url = self.build_run_url(**effective_params)
+        run_url = self.build_run_url(**payload_input)
 
         logger.debug(f"Model Run Stream: Start service for {run_url}")
 
-        response = self.context.client.request_stream("POST", run_url, json=payload)
+        request_kwargs: dict = {"json": payload}
+        headers = self._headers_for_run(effective_params)
+        if headers:
+            request_kwargs["headers"] = headers
+        response = self.context.client.request_stream("POST", run_url, **request_kwargs)
 
         return ModelResponseStreamer(response)
 

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -668,12 +668,31 @@ class BaseResource:
         return encode_resource_id(self.id)
 
 
+# Keys the SDK consumes itself when *dispatching* a request (choosing the path,
+# authenticating). They are declared on ``BaseParams`` for every operation, so
+# they can arrive on any call — and must never be forwarded to a backend body or
+# to ``requests.Session.request``, which would raise ``TypeError``.
+#
+# ``api_key`` authenticates nothing: ``Client.request_raw`` always overlays
+# ``_auth_headers()`` from the Aixplain context, so a per-call ``api_key``'s only
+# observable effect was riding into the model input body (BUG-1091).
+_SDK_REQUEST_KEYS: frozenset[str] = frozenset({"api_key", "resource_path"})
+
+
 class BaseParams(TypedDict):
     """Base class for parameters that include API key and resource path.
 
     Attributes:
-        api_key: str: The API key for authentication.
-        resource_path: str: Custom resource path for actions (optional).
+        api_key: Accepted for backward compatibility and **ignored**.
+            Authentication always comes from the ``Aixplain`` context
+            (``Client._auth_headers``), which overrides any per-call value. It is
+            stripped from every request so it can never reach a model input body
+            or a supplier's prompt logs. Configure credentials via
+            ``Aixplain(api_key=...)`` or ``TEAM_API_KEY`` / ``AIXPLAIN_API_KEY``
+            instead.
+        resource_path: Custom resource path for actions (optional). Consumed by
+            the URL builders; never forwarded to the backend body or to
+            ``requests``.
     """
 
     api_key: NotRequired[str]
@@ -1246,6 +1265,11 @@ class GetResourceMixin(BaseMixin, Generic[GetParamsT, ResourceT]):
         if host is not None:
             kwargs["params"] = {"host": host}
 
+        # ``api_key`` is inert (the client supplies auth) and is not a ``requests``
+        # kwarg; ``resource_path`` was already popped above. Same root cause as
+        # ``delete`` (BUG-1091).
+        kwargs = {k: v for k, v in kwargs.items() if k not in _SDK_REQUEST_KEYS}
+
         obj = context.client.get(path, **kwargs)
 
         # Flatten assetInfo structure before deserialization
@@ -1389,8 +1413,14 @@ class DeleteResourceMixin(BaseMixin, Generic[DeleteParamsT, DeleteResultT]):
         # Build the delete URL
         delete_url = self.build_delete_url(**kwargs)
 
+        # ``resource_path`` was consumed by build_delete_url and ``api_key`` is
+        # inert (the client supplies auth); neither is a ``requests`` kwarg.
+        # Forwarding them made ``delete(resource_path=…)`` raise TypeError deep
+        # inside requests (BUG-1091).
+        request_kwargs = {k: v for k, v in kwargs.items() if k not in _SDK_REQUEST_KEYS}
+
         # Execute the delete operation (delete endpoints don't return JSON)
-        response = self.context.client.request_raw("delete", delete_url, **kwargs)
+        response = self.context.client.request_raw("delete", delete_url, **request_kwargs)
 
         # Handle the response using the extensible response handler
         return self.handle_delete_response(response, **kwargs)
@@ -1530,16 +1560,34 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     # top-level ``session_id`` kwarg is purely the per-run correlation channel
     # emitted as ``x-session-id``; ``agent_name`` is likewise only the calling
     # agent's name, emitted as ``x-agent``.
-    _RUN_CONTROL_KEYS: frozenset[str] = frozenset(
-        {
-            "run_retries",
-            "run_retry_wait",
-            "timeout",
-            "wait_time",
-            "show_progress",
-            "session_id",
-            "agent_name",
-        }
+    #
+    # ``api_key`` / ``resource_path`` (``_SDK_REQUEST_KEYS``) are excluded for a
+    # different reason: they are declared on ``BaseParams`` for *every* operation,
+    # so they can arrive on a run call, and neither is a backend body field.
+    # ``api_key`` in particular authenticated nothing — its only observable effect
+    # was riding into the model input body and the supplier's prompt logs
+    # (BUG-1091).
+    #
+    # The ``progress_*`` trio configures the client-side progress display (the
+    # ``show_progress`` toggle already lived here). ``before_run`` / ``after_run``
+    # still receive the *unfiltered* kwargs, so the tracker keeps seeing them —
+    # only the payload/URL builders are filtered.
+    _RUN_CONTROL_KEYS: frozenset[str] = (
+        frozenset(
+            {
+                "run_retries",
+                "run_retry_wait",
+                "timeout",
+                "wait_time",
+                "show_progress",
+                "progress_format",
+                "progress_verbosity",
+                "progress_truncate",
+                "session_id",
+                "agent_name",
+            }
+        )
+        | _SDK_REQUEST_KEYS
     )
 
     @staticmethod

--- a/aixplain/v2/session.py
+++ b/aixplain/v2/session.py
@@ -423,6 +423,36 @@ class ExecutionConfig:
         return out
 
     @classmethod
+    def _lift_wire_budget(cls, kvs: Any) -> Any:
+        """Lift a wire ``executionParams.budget`` back into the ``budget`` slot.
+
+        ``to_api_dict`` serializes ``budget`` *into* ``executionParams.budget``,
+        but nothing decoded it back out — so a session loaded from the backend
+        came back with ``budget=None`` and the real cap buried inside
+        ``execution_params``. Anything that then set ``budget`` (e.g. the run
+        path seeding it from ``agent.budget``) would silently overwrite that
+        persisted cap on the next ``to_api_dict``. Decoding is now symmetric with
+        encoding, so there is exactly one representation of the cap in memory.
+
+        An explicit top-level ``budget`` wins; the standalone nested key is
+        always dropped so it cannot be emitted twice. Returns a copy; the
+        caller's dict is untouched.
+        """
+        if not isinstance(kvs, dict):
+            return kvs
+        key = "executionParams" if "executionParams" in kvs else "execution_params"
+        ep = kvs.get(key)
+        if not isinstance(ep, dict) or ep.get("budget") is None:
+            return kvs
+        kvs = dict(kvs)  # shallow copy; never mutate the caller's dict
+        ep = dict(ep)
+        nested = ep.pop("budget")
+        if kvs.get("budget") is None:
+            kvs["budget"] = nested
+        kvs[key] = ep
+        return kvs
+
+    @classmethod
     def _fold_legacy_max_iterations(cls, kvs: Any) -> Any:
         """Fold a legacy ``executionParams.maxIterations`` into ``budget`` silently.
 
@@ -476,7 +506,7 @@ _dataclass_json_execution_config_from_dict = ExecutionConfig.from_dict.__func__
 
 
 def _execution_config_from_dict(cls, kvs: Any, *, infer_missing: bool = False) -> "ExecutionConfig":
-    kvs = cls._fold_legacy_max_iterations(kvs)
+    kvs = cls._fold_legacy_max_iterations(cls._lift_wire_budget(kvs))
     return _dataclass_json_execution_config_from_dict(cls, kvs, infer_missing=infer_missing)
 
 
@@ -548,7 +578,7 @@ class Session(
         if isinstance(kvs, dict):
             ec = kvs.get("executionConfig") or kvs.get("execution_config")
             if isinstance(ec, dict):
-                folded = ExecutionConfig._fold_legacy_max_iterations(ec)
+                folded = ExecutionConfig._fold_legacy_max_iterations(ExecutionConfig._lift_wire_budget(ec))
                 if folded is not ec:  # only copy when a fold actually happened
                     kvs = dict(kvs)
                     if "executionConfig" in kvs:

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -479,3 +479,159 @@ class TestRunPathWarningStacklevel:
         conflict = [w for w in caught if w.category is UserWarning and "precedence" in str(w.message)]
         assert conflict, "expected a run-path conflict UserWarning"
         assert conflict[0].filename == __file__, conflict[0].filename
+
+
+class TestSessionBudgetPreservation:
+    """A per-run override must never delete a session's persisted spend cap.
+
+    ``_apply_run_overrides_to_session`` used to rebuild ``ExecutionConfig`` from a
+    hardcoded five-field ``base`` dict that omitted ``budget``, then ``save()``
+    the loss — so the session (and every later message in it) ran uncapped
+    (BUG-1091). The merge now rebuilds from the stored config object, and the
+    agent's own budget may only *fill* caps the session leaves unset.
+    """
+
+    @staticmethod
+    def _session(execution_config=None):
+        from aixplain.v2.session import Session
+
+        session = MagicMock(spec=Session)
+        session.id = "sess_abc"
+        session.execution_config = execution_config
+        session.save = MagicMock()
+        return session
+
+    @staticmethod
+    def _apply(agent, session, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            agent._apply_run_overrides_to_session(session, kwargs)
+
+    def test_override_preserves_session_budget(self):
+        """Row 1: session cap, no agent cap → the cap survives the override."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        session = self._session(ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0, max_iterations=7)))
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.criteria == "be terse"
+        assert session.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert session.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 7,
+        }
+        assert session.save.call_count == 1
+
+    def test_preserves_every_other_execution_config_field(self):
+        """The same trap would reopen for any other field, so pin them all."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        stored = ExecutionConfig(
+            execution_params={"maxTokens": 64},
+            criteria="old",
+            evolve="{}",
+            identifier="corr-1",
+            run_response_generation=True,
+            budget=Budget(max_cost=5.0),
+        )
+        session = self._session(stored)
+
+        self._apply(agent, session, criteria="be terse")
+
+        merged = session.execution_config
+        assert merged.execution_params == {"maxTokens": 64}
+        assert merged.evolve == "{}"
+        assert merged.identifier == "corr-1"
+        assert merged.run_response_generation is True
+        assert merged.budget == Budget(max_cost=5.0)
+
+    def test_session_cap_wins_over_agent_cap(self):
+        """Row 2: a persisted session cap is never widened or replaced."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0)))
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget == Budget(max_cost=5.0)
+
+    def test_agent_cap_fills_unset_session_slot(self):
+        """Row 3: the agent's budget only fills caps the session leaves unset."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_iterations=7)
+        session = self._session(ExecutionConfig(budget=Budget(max_cost=5.0)))
+
+        self._apply(agent, session)
+
+        assert session.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert session.save.call_count == 1
+
+    def test_agent_budget_applies_when_session_has_none(self):
+        """Row 4: ``agent.budget`` was applied on the direct run path only."""
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(None)
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget == Budget(max_cost=1.0)
+        assert session.execution_config.criteria == "be terse"
+        assert session.save.call_count == 1
+
+    def test_empty_agent_budget_contributes_nothing(self):
+        """Row 5: the default empty ``Budget()`` must stay inert."""
+        agent = _create_agent()
+        session = self._session(None)
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.budget is None
+
+    def test_no_overrides_and_no_new_cap_does_not_save(self):
+        """Row 6: a plain session run must still perform no write."""
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        session = self._session(ExecutionConfig(criteria="be brief", budget=Budget(max_cost=5.0)))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            agent._apply_run_overrides_to_session(session, {})
+
+        session.save.assert_not_called()
+
+    def test_no_overrides_and_no_config_does_not_save(self):
+        agent = _create_agent()
+        session = self._session(None)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            agent._apply_run_overrides_to_session(session, {})
+
+        session.save.assert_not_called()
+        assert session.execution_config is None
+
+    def test_warning_names_the_seeded_budget(self):
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=1.0)
+        session = self._session(None)
+
+        with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
+            agent._apply_run_overrides_to_session(session, {"criteria": "be terse"})
+
+    def test_accepts_a_dict_execution_config(self):
+        """Sessions hydrated from the backend may carry a raw dict."""
+        agent = _create_agent()
+        session = self._session({"criteria": "old", "budget": {"maxCost": 5.0}})
+
+        self._apply(agent, session, criteria="be terse")
+
+        assert session.execution_config.criteria == "be terse"
+        assert session.execution_config.budget == Budget(max_cost=5.0)

--- a/tests/unit/v2/test_agent_budget.py
+++ b/tests/unit/v2/test_agent_budget.py
@@ -293,18 +293,14 @@ class TestDeprecatedRunTimeMaxIterations:
     def test_folds_into_execution_budget(self):
         agent = _create_agent()
         with pytest.warns(DeprecationWarning):
-            payload = agent.build_run_payload(
-                query="q", execution_params={"max_iterations": 7}
-            )
+            payload = agent.build_run_payload(query="q", execution_params={"max_iterations": 7})
         assert payload["executionParams"]["budget"] == {"maxIterations": 7}
         assert "maxIterations" not in payload["executionParams"]
 
     def test_camel_case_exec_param_also_folds(self):
         agent = _create_agent()
         with pytest.warns(DeprecationWarning):
-            payload = agent.build_run_payload(
-                query="q", execution_params={"maxIterations": 7}
-            )
+            payload = agent.build_run_payload(query="q", execution_params={"maxIterations": 7})
         assert payload["executionParams"]["budget"] == {"maxIterations": 7}
         assert "maxIterations" not in payload["executionParams"]
 
@@ -411,9 +407,7 @@ class TestFromDictLegacyMaxIterations:
                 "id": "a",
                 "name": "t",
                 "maxIterations": 3,
-                "tasks": [
-                    {"name": "task1", "description": "desc", "expectedOutput": "o"}
-                ],
+                "tasks": [{"name": "task1", "description": "desc", "expectedOutput": "o"}],
             }
         )
         assert agent.budget.max_iterations == 3
@@ -625,6 +619,30 @@ class TestSessionBudgetPreservation:
 
         with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
             agent._apply_run_overrides_to_session(session, {"criteria": "be terse"})
+
+    def test_backend_hydrated_session_cap_still_wins(self):
+        """The session's cap must win even when it arrives in the wire shape.
+
+        ``to_api_dict`` nests the cap inside ``executionParams.budget``. If the
+        decoder leaves it there, ``execution_config.budget`` reads as ``None``,
+        the agent's budget looks like it is filling an unset slot, and the next
+        ``to_api_dict`` overwrites the session's persisted cap wholesale
+        (BUG-1091).
+        """
+        from aixplain.v2.session import ExecutionConfig
+
+        agent = _create_agent()
+        agent.budget = Budget(max_cost=0.01, max_iterations=3)
+        wire = ExecutionConfig(execution_params={"maxTokens": 64}, budget=Budget(max_cost=5.0)).to_api_dict()
+        session = self._session(ExecutionConfig.from_dict(wire))
+
+        self._apply(agent, session, criteria="be terse")
+
+        # Session's max_cost survives; the agent only fills the unset slot.
+        assert session.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 3,
+        }
 
     def test_accepts_a_dict_execution_config(self):
         """Sessions hydrated from the backend may carry a raw dict."""

--- a/tests/unit/v2/test_agent_progress.py
+++ b/tests/unit/v2/test_agent_progress.py
@@ -1,5 +1,8 @@
 """Unit tests for the v2 agent progress formatter."""
 
+from unittest.mock import MagicMock
+
+from aixplain.v2.agent import Agent
 from aixplain.v2.agent_progress import AgentProgressTracker
 
 
@@ -61,3 +64,71 @@ def test_completion_message_includes_arrow_style_totals(capsys):
 
     captured = capsys.readouterr().out
     assert "↓510 ↑536 (1046)" in captured
+
+
+class TestProgressKwargsStayOffTheWire:
+    """``progress_*`` configure the client-side display, never the run body.
+
+    They were in no filter, so ``build_run_payload``'s catch-all snake_case →
+    camelCase forwarder put them in the run POST — coupling the SDK's display
+    options to the backend's input contract (BUG-1091). The tracker must keep
+    receiving them: ``before_run`` sees the *unfiltered* kwargs.
+    """
+
+    PROGRESS_KWARGS = {"progress_format": "logs", "progress_verbosity": 2, "progress_truncate": False}
+
+    @staticmethod
+    def _runnable_agent():
+        agent = Agent.from_dict({"id": "a1", "name": "t"})
+        agent.context = MagicMock()
+        agent.status = None
+        fake_result = MagicMock()
+        fake_result.url = None
+        fake_result.completed = True
+        agent.handle_run_response = lambda response, **kw: fake_result
+        return agent
+
+    def test_progress_kwargs_absent_from_build_run_payload(self):
+        agent = self._runnable_agent()
+        payload = agent.build_run_payload(query="hi", **self.PROGRESS_KWARGS)
+
+        for key in self.PROGRESS_KWARGS:
+            assert key not in payload
+
+    def test_progress_kwargs_absent_from_the_posted_body(self):
+        agent = self._runnable_agent()
+        agent.run(query="hi", **self.PROGRESS_KWARGS)
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        for key in self.PROGRESS_KWARGS:
+            assert key not in body
+        assert body["query"] == {"input": "hi"}
+
+    def test_tracker_still_receives_the_progress_kwargs(self):
+        agent = self._runnable_agent()
+        observed = {}
+
+        def capture(kwargs):
+            observed.update({k: kwargs.get(k) for k in self.PROGRESS_KWARGS})
+
+        agent._start_progress_tracker = capture
+        agent.run(query="hi", **self.PROGRESS_KWARGS)
+
+        assert observed == self.PROGRESS_KWARGS
+
+
+class TestSdkRequestKwargsStayOffTheAgentWire:
+    """``api_key`` / ``resource_path`` are dispatch params, never model input."""
+
+    @staticmethod
+    def _runnable_agent():
+        return TestProgressKwargsStayOffTheWire._runnable_agent()
+
+    def test_api_key_never_reaches_the_agent_run_body(self):
+        agent = self._runnable_agent()
+        agent.run(query="hi", api_key="SECRET", resource_path="sdk/agents")
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert "SECRET" not in str(body)

--- a/tests/unit/v2/test_agent_via_session.py
+++ b/tests/unit/v2/test_agent_via_session.py
@@ -259,6 +259,71 @@ class TestRunWithSessionOverrides:
             agent.run("hi again", session="sess_abc", criteria="be brief")
         existing.save.assert_not_called()
 
+    def test_override_does_not_delete_the_session_budget(self):
+        """A per-run override must not silently drop the session's spend cap.
+
+        The merge used to rebuild ExecutionConfig from a hardcoded field list
+        that omitted ``budget`` and then ``save()`` the loss, so the session ran
+        uncapped from that point on (BUG-1091).
+        """
+        from aixplain.v2.agent import Budget
+
+        ctx = _make_mock_context()
+
+        existing = Mock(spec=Session)
+        existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = ExecutionConfig(criteria="old", budget=Budget(max_cost=5.0, max_iterations=7))
+        existing.save = Mock()
+        existing.add_message = Mock(return_value=_user_message(request_id="req_budget"))
+
+        ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_budget")
+
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent._update_saved_state()
+
+        with pytest.warns(UserWarning, match="session 'sess_abc'"):
+            agent.run("hi again", session="sess_abc", criteria="be brief")
+
+        existing.save.assert_called_once()
+        assert existing.execution_config.criteria == "be brief"
+        assert existing.execution_config.budget == Budget(max_cost=5.0, max_iterations=7)
+        assert existing.execution_config.to_api_dict()["executionParams"]["budget"] == {
+            "maxCost": 5.0,
+            "maxIterations": 7,
+        }
+
+    def test_agent_budget_seeds_a_session_without_one(self):
+        """``agent.budget`` applied on the direct run path only; now on both."""
+        from aixplain.v2.agent import Budget
+
+        ctx = _make_mock_context()
+
+        existing = Mock(spec=Session)
+        existing.id = "sess_abc"
+        existing.context = ctx
+        existing.execution_config = None
+        existing.save = Mock()
+        existing.add_message = Mock(return_value=_user_message(request_id="req_seed"))
+
+        ctx.Session = Mock()
+        ctx.Session.get = Mock(return_value=existing)
+        ctx.client.get.return_value = _success_result(session_id="sess_abc", request_id="req_seed")
+
+        BoundAgent = _bound_agent(ctx)
+        agent = BoundAgent(id="agent_99", name="A")
+        agent.budget = Budget(max_cost=1.0)
+        agent._update_saved_state()
+
+        with pytest.warns(UserWarning, match=r"budget \(from agent\.budget\)"):
+            agent.run("hi again", session="sess_abc")
+
+        existing.save.assert_called_once()
+        assert existing.execution_config.budget == Budget(max_cost=1.0)
+
 
 # ---------------------------------------------------------------------------
 # 4. Attachments / files / audio-as-prompt

--- a/tests/unit/v2/test_model.py
+++ b/tests/unit/v2/test_model.py
@@ -6,6 +6,8 @@ This module tests Model-specific functionality including:
 - V1 payload conversion for sync-only models
 """
 
+import json
+
 import pytest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -341,8 +343,15 @@ class TestModelRunRouting:
         mock_super_run_async.assert_called_once()
         assert result.status == "IN_PROGRESS"
 
-    def test_build_run_payload_strips_sdk_params(self):
-        """build_run_payload should exclude timeout, wait_time, show_progress, stream."""
+    def test_build_run_payload_keeps_sdk_control_keys_out_of_the_body(self):
+        """SDK-control kwargs must not ride in the model *input body*.
+
+        ``stream`` in particular is a path selector expressed on the wire as
+        ``options.stream`` by ``run_stream`` — see
+        ``TestModelStreamDispatch`` for the dispatch half. Stripping it here is
+        correct but is *not* on its own evidence that ``run(stream=True)``
+        streams (BUG-1091).
+        """
         model = self._create_model_with_mocks(connection_type=["asynchronous"])
         payload = model.build_run_payload(
             text="hello",
@@ -506,6 +515,184 @@ class TestRunHeaderKeysAreSingleSourceOfTruth:
 
     def test_header_kwargs_covered_by_sdk_only_params(self):
         assert {key for key, _ in Model._RUN_HEADER_KEYS} <= Model._SDK_ONLY_PARAMS
+
+    def test_sdk_only_params_is_derived_not_duplicated(self):
+        """``_SDK_ONLY_PARAMS`` must *be* ``_RUN_CONTROL_KEYS``, not a copy of it.
+
+        Two hand-maintained literals is how ``session_id`` was once filtered on
+        one path and shipped on the other. Identity here makes that drift
+        impossible rather than merely absent (BUG-1091).
+        """
+        assert Model._SDK_ONLY_PARAMS == Model._RUN_CONTROL_KEYS
+
+    @pytest.mark.parametrize("path", ["run", "run_stream", "_run_async_v1"])
+    def test_every_header_kwarg_rides_as_header_on_every_request_path(self, path):
+        """Each ``_RUN_HEADER_KEYS`` entry must become a header — and stay out of
+        the body — on *all three* request-issuing model paths.
+
+        ``run_stream`` and ``_run_async_v1`` build their own requests, which is
+        exactly where the shared filters silently stopped applying (BUG-1091).
+        """
+        for key, header in Model._RUN_HEADER_KEYS:
+            model = _model_with_mock_client(sync_only=(path != "run"))
+            client = model.context.client
+            kwargs = {"text": "hi", key: "v"}
+
+            if path == "run":
+                model.run(**kwargs)
+                call = client.request.call_args
+                body = call.kwargs["json"]
+            elif path == "run_stream":
+                model.run_stream(**kwargs)
+                call = client.request_stream.call_args
+                body = call.kwargs["json"]
+            else:
+                model._run_async_v1(**kwargs)
+                call = client.request_raw.call_args
+                body = json.loads(call.kwargs["data"])
+
+            assert call.kwargs["headers"][header] == "v", f"{path} dropped {header}"
+            assert key not in body, f"{path} leaked {key} into the body"
+
+
+def _model_with_mock_client(sync_only: bool = True) -> Model:
+    """A Model wired to a mock client that answers every request-issuing path."""
+    model = Model.__new__(Model)
+    model.id = "test-model-id"
+    model.name = "Test Model"
+    model.connection_type = ["synchronous"] if sync_only else ["asynchronous"]
+    model.params = None
+    model.supports_streaming = True
+    model.__post_init__()
+    model.context = Mock()
+    model.context.model_url = "https://models.aixplain.com/api/v2/execute"
+    model.context.client.request.return_value = {"status": "SUCCESS", "completed": True, "data": "ok"}
+    model.context.client.request_raw.return_value.json.return_value = {
+        "status": "IN_PROGRESS",
+        "data": "https://models.aixplain.com/api/v1/data/poll-id",
+    }
+    return model
+
+
+class TestModelStreamDispatch:
+    """``run(stream=True)`` must actually stream (BUG-1091).
+
+    The flag was declared, documented in four shipped places (including the
+    ``Model`` docstring and the bundled skill), stripped from the payload — and
+    never read by ``run``, so callers silently got a blocking ``ModelResult``.
+    """
+
+    def test_stream_true_dispatches_to_run_stream(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello", stream=True)
+
+        assert isinstance(result, ModelResponseStreamer)
+        assert model.context.client.request_stream.call_count == 1
+        assert model.context.client.request.call_count == 0
+
+    def test_stream_true_sets_options_stream_on_the_wire(self):
+        """The flag is expressed as ``options.stream``, never as a body field."""
+        model = _model_with_mock_client()
+        model.run(text="hello", stream=True)
+
+        body = model.context.client.request_stream.call_args.kwargs["json"]
+        assert body["options"]["stream"] is True
+        assert "stream" not in body
+
+    def test_stream_false_runs_normally(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello", stream=False)
+
+        assert isinstance(result, ModelResult)
+        assert model.context.client.request_stream.call_count == 0
+        assert model.context.client.request.call_count == 1
+        assert "stream" not in model.context.client.request.call_args.kwargs["json"]
+
+    def test_run_without_stream_kwarg_unchanged(self):
+        model = _model_with_mock_client()
+        result = model.run(text="hello")
+
+        assert isinstance(result, ModelResult)
+        assert model.context.client.request_stream.call_count == 0
+        assert model.context.client.request.call_args.kwargs["json"] == {"text": "hello"}
+
+    def test_stream_dispatch_forwards_remaining_kwargs(self):
+        """Model params and identity metadata survive the hand-off to run_stream."""
+        model = _model_with_mock_client()
+        model.run(text="hello", temperature=0.7, stream=True, identifier="alice")
+
+        call = model.context.client.request_stream.call_args
+        assert call.kwargs["json"]["temperature"] == 0.7
+        assert call.kwargs["headers"] == {"x-user-id": "alice"}
+
+
+class TestModelStreamPathFilters:
+    """``run_stream`` is still a run: same body filter, same identity headers."""
+
+    def test_run_stream_sends_identity_headers(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi", identifier="alice", session_id="sess-1", agent_name="Researcher")
+
+        headers = model.context.client.request_stream.call_args.kwargs["headers"]
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
+    def test_run_stream_omits_headers_when_no_metadata(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi")
+
+        assert "headers" not in model.context.client.request_stream.call_args.kwargs
+
+    def test_run_stream_strips_api_key_from_body(self):
+        model = _model_with_mock_client()
+        model.run_stream(text="hi", api_key="SECRET", resource_path="v2/models")
+
+        body = model.context.client.request_stream.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert body["text"] == "hi"
+
+
+class TestRunAsyncV1Headers:
+    """The sync-only async fallback builds its own request — it must still send
+    the identity headers the sync path sends (BUG-1091)."""
+
+    def test_run_async_v1_sends_identity_headers(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi", identifier="alice", session_id="sess-1", agent_name="Researcher")
+
+        headers = model.context.client.request_raw.call_args.kwargs["headers"]
+        assert headers == {"x-user-id": "alice", "x-session-id": "sess-1", "x-agent": "Researcher"}
+
+    def test_run_async_v1_omits_headers_when_no_metadata(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi")
+
+        assert "headers" not in model.context.client.request_raw.call_args.kwargs
+
+    def test_run_async_v1_strips_sdk_keys_from_body(self):
+        model = _model_with_mock_client()
+        model._run_async_v1(text="hi", api_key="SECRET", resource_path="v2/models", temperature=0.7)
+
+        body = json.loads(model.context.client.request_raw.call_args.kwargs["data"])
+        assert body == {"data": "hi", "temperature": 0.7}
+
+
+class TestOpenEndedModelParamsStillPassThrough:
+    """Model parameters are declared per-model by the backend and ship without an
+    SDK release, so ``run()`` deliberately does **not** reject unknown kwargs —
+    only the known SDK-control keys are stripped.
+
+    Pinned so a later tidy-up cannot quietly close the open channel and break
+    ``temperature`` / ``max_tokens`` / every future backend parameter. See the
+    BUG-1091 PR body for the deviation rationale.
+    """
+
+    def test_known_and_unknown_model_params_are_both_forwarded(self):
+        model = _model_with_mock_client()
+        model.run(text="hi", temperature=0.7, maxTokns=100)
+
+        body = model.context.client.request.call_args.kwargs["json"]
+        assert body == {"text": "hi", "temperature": 0.7, "maxTokns": 100}
 
 
 class TestRunHeaderValuesMustBeAscii:

--- a/tests/unit/v2/test_run_kwargs_stripped.py
+++ b/tests/unit/v2/test_run_kwargs_stripped.py
@@ -1,0 +1,204 @@
+"""SDK-control run kwargs must never reach the wire body (BUG-1091).
+
+``api_key`` and ``resource_path`` are declared on ``BaseParams``, so they can
+arrive on *any* v2 call. Neither is a backend body field:
+
+- ``api_key`` authenticates nothing — ``Client.request_raw`` always overlays
+  ``_auth_headers()`` from the Aixplain context — so its only observable effect
+  was riding into the model input body and, from there, the supplier's prompt
+  logs.
+- ``resource_path`` is consumed by the URL builders.
+
+Both are also not ``requests`` kwargs, which is why the same root cause made
+``delete(resource_path=…)`` and ``get(id, api_key=…)`` raise deep inside
+``requests``.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from dataclasses_json import dataclass_json
+
+from aixplain.v2.actions import Action, Actions, Inputs
+from aixplain.v2.agent import Agent
+from aixplain.v2.integration import ActionInputSpec
+from aixplain.v2.model import Model
+from aixplain.v2.resource import (
+    BaseDeleteParams,
+    BaseResource,
+    DeleteResourceMixin,
+    DeleteResult,
+    GetResourceMixin,
+    RunnableResourceMixin,
+)
+from aixplain.v2.tool import Tool
+
+SDK_REQUEST_KWARGS = {"api_key": "SECRET-TEAM-KEY", "resource_path": "v2/custom"}
+
+
+def _model(cls=Model):
+    model = cls.__new__(cls)
+    model.id = "test-model-id"
+    model.name = "Test Model"
+    model.connection_type = ["synchronous"]
+    model.params = None
+    model.__post_init__()
+    model.context = Mock()
+    model.context.model_url = "https://models.aixplain.com/api/v2/execute"
+    model.context.client.request.return_value = {"status": "SUCCESS", "completed": True, "data": "ok"}
+    return model
+
+
+def _tool():
+    """A Tool with one allowed action, wired to a mock client."""
+    tool = _model(Tool)
+    tool.description = "Tool description"
+    tool.allowed_actions = ["search"]
+    tool._dynamic_attrs = {}
+    spec = ActionInputSpec(
+        name="Query", code="query", datatype="string", default_value=[], required=False, description="Query"
+    )
+    action = Action(name="search", inputs=Inputs.from_action_input_specs([spec]))
+    tool.__dict__["actions"] = Actions(actions={"search": action})
+    return tool
+
+
+def _agent():
+    agent = Agent.from_dict({"id": "a1", "name": "t"})
+    agent.context = MagicMock()
+    agent.status = None
+    fake_result = MagicMock()
+    fake_result.url = None
+    fake_result.completed = True
+    agent.handle_run_response = lambda response, **kw: fake_result
+    return agent
+
+
+class TestControlKeysAreDeclaredOnce:
+    """One authoritative set, inherited by every runnable."""
+
+    def test_base_mixin_strips_the_dispatch_keys(self):
+        assert {"api_key", "resource_path"} <= RunnableResourceMixin._RUN_CONTROL_KEYS
+
+    def test_base_mixin_strips_the_progress_display_keys(self):
+        assert {
+            "show_progress",
+            "progress_format",
+            "progress_verbosity",
+            "progress_truncate",
+        } <= RunnableResourceMixin._RUN_CONTROL_KEYS
+
+    @pytest.mark.parametrize("cls", [Model, Tool, Agent])
+    def test_every_runnable_inherits_them(self, cls):
+        assert {"api_key", "resource_path"} <= cls._RUN_CONTROL_KEYS
+
+
+class TestApiKeyNeverReachesARunBody:
+    def test_model_build_run_payload(self):
+        assert _model().build_run_payload(text="hi", **SDK_REQUEST_KWARGS) == {"text": "hi"}
+
+    def test_tool_build_run_payload(self):
+        assert _model(Tool).build_run_payload(text="hi", **SDK_REQUEST_KWARGS) == {"text": "hi"}
+
+    def test_model_posted_body(self):
+        model = _model()
+        model.run(text="hi", **SDK_REQUEST_KWARGS)
+
+        body = model.context.client.request.call_args.kwargs["json"]
+        assert body == {"text": "hi"}
+
+    def test_tool_posted_body(self):
+        tool = _tool()
+        tool.run(data={"query": "hi"}, **SDK_REQUEST_KWARGS)
+
+        body = tool.context.client.request.call_args.kwargs["json"]
+        assert body == {"action": "search", "data": {"query": "hi"}}
+
+    def test_agent_posted_body(self):
+        agent = _agent()
+        agent.run(query="hi", **SDK_REQUEST_KWARGS)
+
+        body = agent.context.client.request.call_args.kwargs["json"]
+        assert "api_key" not in body
+        assert "resource_path" not in body
+        assert SDK_REQUEST_KWARGS["api_key"] not in str(body)
+
+    def test_resource_path_still_selects_the_run_url(self):
+        """Stripping it from the *body* must not stop it steering the URL."""
+        model = _model()
+        model.run(text="hi", **SDK_REQUEST_KWARGS)
+
+        url = model.context.client.request.call_args[0][1]
+        assert url.endswith("/test-model-id")
+
+
+class TestDeleteAcceptsTheDispatchKeys:
+    """``delete()`` forwarded every kwarg to ``requests``, so passing either key
+    raised ``TypeError`` inside ``session.request()``."""
+
+    def _resource(self):
+        @dataclass_json
+        @dataclass
+        class DeletableResource(BaseResource, DeleteResourceMixin[BaseDeleteParams, DeleteResult]):
+            RESOURCE_PATH = "deletable"
+
+        resource = DeletableResource(id="123", name="to delete")
+        resource.context = Mock()
+        resource.context.client.request_raw = Mock(return_value=Mock())
+        return resource
+
+    def test_delete_with_resource_path_succeeds_and_uses_it(self):
+        resource = self._resource()
+
+        resource.delete(resource_path="sdk/agents")
+
+        call_args = resource.context.client.request_raw.call_args
+        assert call_args[0][0] == "delete"
+        assert "sdk/agents/123" in call_args[0][1]
+        assert "resource_path" not in call_args.kwargs
+
+    def test_delete_with_api_key_succeeds(self):
+        resource = self._resource()
+
+        resource.delete(api_key="SECRET-TEAM-KEY")
+
+        call_args = resource.context.client.request_raw.call_args
+        assert "deletable/123" in call_args[0][1]
+        assert "api_key" not in call_args.kwargs
+
+    def test_delete_still_forwards_genuine_request_kwargs(self):
+        resource = self._resource()
+
+        resource.delete(timeout=30)
+
+        assert resource.context.client.request_raw.call_args.kwargs["timeout"] == 30
+
+
+class TestGetAcceptsTheDispatchKeys:
+    def _cls(self):
+        @dataclass_json
+        @dataclass
+        class Gettable(BaseResource, GetResourceMixin[dict, "Gettable"]):
+            RESOURCE_PATH = "gettable"
+
+        Gettable.context = Mock()
+        Gettable.context.client.get = Mock(return_value={"id": "123", "name": "got"})
+        return Gettable
+
+    def test_get_with_api_key_succeeds(self):
+        cls = self._cls()
+
+        instance = cls.get("123", api_key="SECRET-TEAM-KEY")
+
+        assert instance.id == "123"
+        call_args = cls.context.client.get.call_args
+        assert call_args[0][0] == "gettable/123"
+        assert "api_key" not in call_args.kwargs
+
+    def test_get_still_forwards_genuine_request_kwargs(self):
+        cls = self._cls()
+
+        cls.get("123", timeout=30)
+
+        assert cls.context.client.get.call_args.kwargs["timeout"] == 30

--- a/tests/unit/v2/test_session.py
+++ b/tests/unit/v2/test_session.py
@@ -1242,6 +1242,43 @@ class TestExecutionConfigBudget:
             )
         assert cfg.to_api_dict()["executionParams"]["budget"]["maxIterations"] == 9
 
+    def test_from_dict_lifts_nested_budget_out_of_execution_params(self):
+        """Decoding must mirror encoding: ``executionParams.budget`` -> ``budget``.
+
+        ``to_api_dict`` nests the cap inside ``executionParams``, but nothing
+        decoded it back out, so a backend-loaded session had ``budget=None`` with
+        the real cap buried in ``execution_params``. Anything that then set
+        ``budget`` (the run path seeds it from ``agent.budget``) silently
+        overwrote the persisted cap on the next send (BUG-1091).
+        """
+        sent = ExecutionConfig(execution_params={"maxTokens": 64}, budget=Budget(max_cost=5.0)).to_api_dict()
+
+        cfg = ExecutionConfig.from_dict(sent)
+
+        assert cfg.budget == Budget(max_cost=5.0)
+        assert cfg.execution_params == {"maxTokens": 64}
+        assert cfg.to_api_dict() == sent  # round-trip is stable
+
+    def test_from_dict_nested_budget_defers_to_an_explicit_top_level_one(self):
+        cfg = ExecutionConfig.from_dict(
+            {"executionParams": {"budget": {"maxCost": 5.0}}, "budget": {"maxCost": 1.0}}
+        )
+
+        assert cfg.budget == Budget(max_cost=1.0)
+        assert cfg.to_api_dict() == {"executionParams": {"budget": {"maxCost": 1.0}}}
+
+    def test_session_from_dict_lifts_nested_budget(self):
+        session = Session.from_dict(
+            {
+                "id": "s1",
+                "agentId": "a1",
+                "executionConfig": {"executionParams": {"maxTokens": 64, "budget": {"maxCost": 5.0}}},
+            }
+        )
+
+        assert session.execution_config.budget == Budget(max_cost=5.0)
+        assert session.execution_config.execution_params == {"maxTokens": 64}
+
     def test_session_from_dict_legacy_execution_config_no_warning(self):
         # Loading a Session whose nested executionConfig carries a legacy
         # maxIterations must not warn and must fold into budget.


### PR DESCRIPTION
## Summary

Six caller-supplied `run()` kwargs in the v2 SDK were accepted without error and then either dropped on the floor or forwarded verbatim into the model input body. `stream=True` was declared, documented and stripped from the payload, but never read — callers silently got a blocking `ModelResult`. `api_key` authenticated nothing (the client always overlays context auth) and its only observable effect was riding into the model input and the supplier's prompt logs. A per-run execution override deleted a session's persisted spend cap. `run_stream` and the sync-only v1 async fallback built their own requests and sent no identity headers, while the body filter still removed those keys — so `x-user-id` / `x-session-id` / `x-agent` vanished entirely on those paths.

This PR honours the kwargs that mean something and strips the ones that are SDK-internal, so nothing is accepted and then quietly discarded. Filters are now derived from one authoritative set rather than duplicated literals, which closes the drift class that once put `session_id` back on the wire.

Base branch is `bug-1093-v2-save-after-delete-create-hyd`; the diff below is against that base, not `development`.

## Per-finding status

| # | Finding | Status | Notes |
|---|---------|--------|-------|
| 1 | `stream=True` accepted, stripped, never dispatched | Fixed | `Model.run` now pops `stream` and returns `self.run_stream(**kwargs)`; return type widened to `Union[ModelResult, ModelResponseStreamer]`. `stream` moved into `_RUN_CONTROL_KEYS` so the flag is expressed on the wire only as `options.stream` by `run_stream`. The test that locked the bug in (`test_build_run_payload_strips_sdk_params`) was renamed and re-documented to say that stripping the key is not evidence of dispatch, with the dispatch half covered by a new `TestModelStreamDispatch`. The four shipped doc references (class docstring example, bundled `aixplain-builder` skill) already promised streaming and needed no edit — the code now matches them. |
| 2 | `api_key` / `resource_path` shipped inside the model input body; `delete(resource_path=...)` raises `TypeError` | Fixed | New `_SDK_REQUEST_KEYS = {"api_key", "resource_path"}` in `resource.py`, folded into `RunnableResourceMixin._RUN_CONTROL_KEYS`, so neither key can reach a run body on any runnable (Model, Tool, Agent). `DeleteResourceMixin.delete` and `GetResourceMixin.get` now filter the same two keys before handing kwargs to `requests`, fixing the `TypeError`. `get()` had the identical root cause and is fixed alongside `delete()` (the ticket named only `delete`). `BaseParams.api_key` is re-documented as accepted-for-compatibility and ignored, pointing at `Aixplain(api_key=...)` / `TEAM_API_KEY` / `AIXPLAIN_API_KEY`. `resource_path` still steers the run URL — only the body and the `requests` call are filtered. |
| 3 | Session run deletes the session's persisted spend cap; `agent.budget` never applied on the session path | Fixed | `_apply_run_overrides_to_session` now rebuilds with `dataclasses.replace(current, **provided)` from the stored `ExecutionConfig` instead of a hardcoded five-field `base`, so `budget` — and any field added to `ExecutionConfig` later — survives an override. Overrides come from a named `_SESSION_EXECUTION_OVERRIDES` tuple. New `_budget_for_session` applies `agent.budget` on the session path as well, filling only caps the session leaves unset (a session's stored cap always wins) and copying rather than aliasing the agent's `Budget`, which is documented as mutated in place. The no-op case still performs no write, and the existing warning now names `budget (from agent.budget)` when the agent contributed a cap. |
| 4 | `run_stream` and the sync-only async fallback drop `x-user-id` / `x-session-id` | Fixed | Both paths now call `_headers_for_run` and pass `headers=` alongside their request, matching the sync path. `run_stream` additionally routes its body and URL through `_payload_kwargs_for_run`, so a stream gets the same body filtering as a normal run. Covered by a parametrised test that drives all three request-issuing paths (`run`, `run_stream`, `_run_async_v1`) for every `_RUN_HEADER_KEYS` entry and asserts the key becomes a header and stays out of the body. |
| 5 | `progress_format` / `progress_verbosity` / `progress_truncate` leak onto the wire | Fixed | The three keys joined `_RUN_CONTROL_KEYS` next to the existing `show_progress`, so the payload and URL builders drop them. `before_run` / `after_run` still receive the unfiltered kwargs, so the client-side progress tracker keeps working — pinned by a test asserting the tracker still sees them while the posted body does not. |
| 6 | Unknown / misspelled run kwargs shipped verbatim | Deliberately not implemented as specified (partial) | Known SDK-control keys are now stripped, which removes every case in this ticket where a *documented* kwarg reached the wire. Arbitrary unknown kwargs are still forwarded by design — see below. Pinned by `test_known_and_unknown_model_params_are_both_forwarded`, which asserts `run(text="hi", temperature=0.7, maxTokns=100)` forwards all three, so the behaviour is a recorded decision rather than an oversight. |
| + | `ExecutionConfig` budget round-trip was asymmetric (found in review, not in the ticket) | Fixed | `to_api_dict` nests the cap under `executionParams.budget`, but nothing lifted it back out, so a backend-hydrated session came back with `budget=None` and the real cap buried in `execution_params`. Seeding from `agent.budget` then looked like filling an unset slot and overwrote the persisted cap on the next send. New `ExecutionConfig._lift_wire_budget` makes decoding symmetric with encoding (explicit top-level `budget` wins; the nested key is always dropped so it cannot be emitted twice), wired into both `ExecutionConfig.from_dict` and `Session.from_dict`. |
| + | `Model._SDK_ONLY_PARAMS` was a second hand-maintained literal | Fixed | It is now defined as `_RUN_CONTROL_KEYS` itself rather than a parallel copy, with a test asserting the identity. This is the exact drift that previously filtered `session_id` on one path and shipped it on the other. |

## Deviation from acceptance criterion 4 (finding 6)

The ticket's acceptance criteria ask that "an unknown run kwarg is rejected, not forwarded". This PR deliberately does not do that.

`run()` kwargs are the model's own parameters. Model parameters are declared per-model by the backend and ship without an SDK release — `temperature`, `max_tokens`, `top_p` and every parameter a supplier adds later arrive through this same channel. `run()` has no reliable schema to validate against: for an unhydrated model the SDK does not know the parameter list at all, and even when it does, the list is backend-owned and can change between releases. A closed allowlist would therefore reject valid parameters, and would break silently at the worst possible moment — when a supplier adds a parameter users want to pass.

The `Inputs.__setattr__` sibling cited in the ticket can reject unknown names precisely because it validates against a *known, fetched* action schema; `run()` has no equivalent.

What the ticket's underlying complaint actually asks for — that a value the caller supplies is either honoured or explicitly rejected, never silently discarded — is satisfied for every documented kwarg: each one is now consumed by the SDK (`stream`, `progress_*`, `api_key`, `resource_path`, retries/timeouts, header metadata) or forwarded on purpose. A typo like `maxTokns` still reaches the backend, which is where the parameter schema lives and where the rejection belongs. If typo-catching is still wanted, the follow-up shape would be an opt-in strict mode validated against the hydrated model's declared parameters, not a closed allowlist in `run()`.

## Testing

```
python -m pytest tests/unit/v2/test_run_kwargs_stripped.py tests/unit/v2/test_model.py \
  tests/unit/v2/test_agent_budget.py tests/unit/v2/test_session.py \
  tests/unit/v2/test_agent_progress.py tests/unit/v2/test_agent_via_session.py -q
```

Result: **353 passed**, 3 warnings, in 1.40s (the warnings are the pre-existing `files` deprecation notice from `session.py`).

Full unit suite, no network:

```
python -m pytest tests/unit -q
```

Result: **2164 passed**, 146 warnings, in 35.76s — no failures, no skips.

New and updated test coverage: `tests/unit/v2/test_run_kwargs_stripped.py` (new — control keys declared once and inherited by every runnable; `api_key` absent from Model/Tool/Agent bodies; `resource_path` still steering the run URL; `delete()` and `get()` accepting both dispatch keys without `TypeError` while still forwarding genuine request kwargs), `test_model.py` (stream dispatch, `options.stream` on the wire, headers on all three request paths, `_SDK_ONLY_PARAMS` identity, the pinned open-ended-params behaviour), `test_agent_budget.py` and `test_agent_via_session.py` (budget preservation, session-cap-wins precedence, agent cap filling unset slots, no-op cases performing no save, hydrated-session merge), `test_agent_progress.py` (progress kwargs off the wire but still reaching the tracker), and `test_session.py` (nested-budget lift round-trip and top-level precedence).

## Jira

https://aixplain.atlassian.net/browse/BUG-1091
