### PR TITLE
fix: make five declared controls actually take effect (BUG-946)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,6 +49,25 @@ A `filterwarnings` entry in your `pytest.ini` or `pyproject.toml` works too.
 
 One ordering caveat: to make the notice visible at all, the SDK inserts a `default` filter for its own category while `aixplain` is being imported — but only when `sys.warnoptions` is empty, i.e. when you passed no `-W` and set no `PYTHONWARNINGS`. A bare `warnings.simplefilter("ignore")` issued *before* `import aixplain` is therefore overridden. Use the environment variable, use `-W`/`PYTHONWARNINGS`, or register your filter after the import — all three win.
 
+## `aixplain.aixplain_v2` is deprecated
+
+The module-level `aixplain_v2` client is deprecated and will be removed in a future release. Construct a client explicitly instead:
+
+```python
+# deprecated
+from aixplain import aixplain_v2
+agent = aixplain_v2.Agent.get("...")
+
+# use instead
+from aixplain import Aixplain
+aix = Aixplain()            # or Aixplain(api_key="...")
+agent = aix.Agent.get("...")
+```
+
+It used to be built at import time with the failure swallowed, so a missing `TEAM_API_KEY` left the symbol bound to `None` and the first use failed with `AttributeError: 'NoneType' object has no attribute 'Agent'` rather than the actual cause. It is now constructed on first access and raises the real error (`API key is required. Pass api_key=... to Aixplain() or set TEAM_API_KEY or AIXPLAIN_API_KEY.`), and the first access emits a `DeprecationWarning`.
+
+`from aixplain import aixplain_v2` still works. It is no longer part of `from aixplain import *`, so a star import no longer needs a credential.
+
 ## Factory map at a glance
 
 | v1 factory | v2 equivalent | Status |

--- a/aixplain/__init__.py
+++ b/aixplain/__init__.py
@@ -56,11 +56,51 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=LOG_LEVEL)
 
 
-aixplain_v2 = None
-try:
-    aixplain_v2 = Aixplain()
-except Exception:
-    pass
+_AIXPLAIN_V2_DEPRECATION = (
+    "'aixplain.aixplain_v2' is deprecated and will be removed in a future release. "
+    "Construct a client explicitly instead: 'from aixplain import Aixplain; aix = Aixplain()'."
+)
 
 
-__all__ = ["Aixplain", "File", "aixplain_v2"]
+def __getattr__(name: str):
+    """Lazily construct the deprecated module-level ``aixplain_v2`` client.
+
+    Constructing it at import time and swallowing the failure left a public
+    symbol bound to ``None``, so a missing credential surfaced much later as
+    ``AttributeError: 'NoneType' object has no attribute 'Agent'`` instead of the
+    actionable message ``Aixplain()`` already raises (BUG-946). Deferring the
+    construction to first access keeps ``import aixplain`` working without a key
+    -- which ``aixplain --help`` and unit-test collection rely on -- while
+    letting the real error reach whoever actually asks for the client.
+
+    Args:
+        name (str): Attribute being looked up on the package.
+
+    Returns:
+        Aixplain: The lazily constructed client, cached in module globals.
+
+    Raises:
+        AttributeError: If ``name`` is anything other than ``aixplain_v2``.
+    """
+    if name != "aixplain_v2":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import warnings
+
+    warnings.warn(_AIXPLAIN_V2_DEPRECATION, DeprecationWarning, stacklevel=2)
+    # Raises the real error (e.g. "API key is required...") when unconfigured.
+    client = Aixplain()
+    # Cache so repeated access returns the same client and skips this hook.
+    globals()["aixplain_v2"] = client
+    return client
+
+
+def __dir__():
+    """Keep the lazily provided ``aixplain_v2`` discoverable via ``dir()``."""
+    return sorted(set(globals()) | {"aixplain_v2"})
+
+
+# ``aixplain_v2`` is deliberately absent: it stays importable by name through
+# ``__getattr__`` above, but keeping it here would make ``from aixplain import *``
+# construct a client -- and therefore raise -- in a keyless environment.
+__all__ = ["Aixplain", "File"]

--- a/aixplain/v1/modules/team_agent/__init__.py
+++ b/aixplain/v1/modules/team_agent/__init__.py
@@ -703,7 +703,13 @@ class TeamAgent(Model, DeployableMixin[Agent]):
                 return response
             poll_url = response["url"]
             end = time.time()
-            result = self.sync_poll(poll_url, name=name, timeout=timeout, wait_time=wait_time)
+            result = self.sync_poll(
+                poll_url,
+                name=name,
+                timeout=timeout,
+                wait_time=wait_time,
+                progress_verbosity=progress_verbosity,
+            )
             result_data = result.data or {}
             diagnostic_error_codes = result.diagnostic_error_codes
             if result.status == ResponseStatus.FAILED:

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -835,12 +835,6 @@ class Agent(
             ]
             self.files = current_ids
 
-        # TODO: Re-enable this validation after backend data consistency is fixed
-        # if self.agents and (self.tasks or self.tools):
-        #     raise ValueError(
-        #         "Team agents cannot have tasks or tools. Please remove the tasks or tools and try again."
-        #     )
-
     @staticmethod
     def _skill_reference_id(skill: Optional[Union[str, Dict[str, Any], "Skill"]]) -> Optional[str]:
         """Return the backend ID represented by one Skill reference."""

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -485,8 +485,13 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             data = kwargs.get("data", {})
             action_errors = action_obj.inputs.validate(data)
             errors.extend(action_errors)
-        except Exception:
-            pass
+        except Exception as e:
+            # A crashed validation is not a pass (BUG-946). An unknown action name
+            # reaches here as a ValueError from the lazy input loader -- Actions
+            # fabricates an ActionView rather than raising on __getitem__ -- and the
+            # empty list this used to return was indistinguishable from
+            # "validated clean", so the run proceeded to the backend unchecked.
+            errors.append(f"Could not validate inputs for '{action}': {e}")
 
         return errors
 

--- a/aixplain/v2/tool.py
+++ b/aixplain/v2/tool.py
@@ -175,8 +175,12 @@ class Tool(Model, DeleteResourceMixin[BaseDeleteParams, DeleteResult], ActionMix
             if self._ensure_integration():
                 try:
                     return self.integration._list_inputs(*actions)
-                except Exception:
-                    pass
+                except Exception as fallback_error:
+                    # Returning [] below makes the lazy input loader raise
+                    # "not found or has no input parameters defined", which
+                    # _validate_params now surfaces as a run failure (BUG-946).
+                    # Without this the real cause never reaches the caller.
+                    warnings.warn(f"Error listing inputs via the integration fallback: {fallback_error}.")
 
             return []
 

--- a/tests/unit/team_agent/test_progress_verbosity_passthrough.py
+++ b/tests/unit/team_agent/test_progress_verbosity_passthrough.py
@@ -1,0 +1,121 @@
+"""Guard: ``TeamAgent.run`` must forward ``progress_verbosity`` to ``sync_poll``.
+
+``run`` accepts and documents ``progress_verbosity`` -- *"full" (detailed),
+"compact" (brief), or None (no progress)"* -- but dropped it on the call to
+``sync_poll``, which defaults it to ``"compact"``. So ``run(progress_verbosity=None)``
+still printed progress to stdout (unsuppressable library output for anyone
+embedding the SDK in a service) and ``"full"`` still rendered compact (BUG-946).
+
+The sibling ``Agent.run`` has always passed it through correctly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from aixplain.modules.team_agent import TeamAgent
+from aixplain.modules.agent.agent_response import AgentResponse
+from aixplain.modules.agent.agent_response_data import AgentResponseData
+from aixplain.enums import ResponseStatus
+
+
+def _completed_response(**kwargs):
+    return AgentResponse(
+        status=ResponseStatus.SUCCESS,
+        completed=True,
+        data=AgentResponseData(input="hi", output="done"),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("verbosity", [None, "full", "compact"])
+def test_run_forwards_progress_verbosity_to_sync_poll(verbosity):
+    """Whatever the caller passes to ``run`` must reach ``sync_poll``."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "sync_poll", return_value=_completed_response()) as mock_sync_poll,
+    ):
+        team_agent.run(query="hi", progress_verbosity=verbosity)
+
+    assert mock_sync_poll.call_args.kwargs["progress_verbosity"] == verbosity
+
+
+def test_run_defaults_to_compact():
+    """The documented default must survive the passthrough."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "sync_poll", return_value=_completed_response()) as mock_sync_poll,
+    ):
+        team_agent.run(query="hi")
+
+    assert mock_sync_poll.call_args.kwargs["progress_verbosity"] == "compact"
+
+
+PROGRESS = {
+    "stage": "planning",
+    "message": "Breaking the task down",
+    "current_step": 1,
+    "total_steps": 3,
+}
+
+
+def _poll_sequence():
+    """One in-progress poll carrying progress data, then a completed one."""
+    in_progress = AgentResponse(
+        status=ResponseStatus.IN_PROGRESS,
+        completed=False,
+        data=AgentResponseData(input="hi"),
+        progress=dict(PROGRESS),
+    )
+    return [in_progress, _completed_response()]
+
+
+def test_sync_poll_none_produces_no_stdout(capsys):
+    """``progress_verbosity=None`` must suppress *all* stdout.
+
+    That includes the completion line printed after the polling loop.
+    """
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with patch.object(TeamAgent, "poll", side_effect=_poll_sequence()):
+        team_agent.sync_poll("http://poll", wait_time=0.01, progress_verbosity=None)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_sync_poll_full_renders_full(capsys):
+    """``"full"`` must render the detailed format, not the compact one."""
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with patch.object(TeamAgent, "poll", side_effect=_poll_sequence()):
+        team_agent.sync_poll("http://poll", wait_time=0.01, progress_verbosity="full")
+
+    out = capsys.readouterr().out
+    assert out, "'full' must produce progress output"
+
+    full_msg = team_agent._format_team_progress(PROGRESS, "full")
+    compact_msg = team_agent._format_team_progress(PROGRESS, "compact")
+    assert full_msg != compact_msg, "fixture must distinguish the two formats"
+    assert full_msg in out
+    assert compact_msg not in out
+
+
+def test_run_none_produces_no_stdout(capsys):
+    """End to end: ``run(progress_verbosity=None)`` must print nothing.
+
+    This is the acceptance criterion; it failed before the passthrough because
+    ``sync_poll`` fell back to its ``"compact"`` default.
+    """
+    team_agent = TeamAgent("123", "Test Team Agent")
+
+    with (
+        patch.object(TeamAgent, "run_async", return_value={"status": ResponseStatus.IN_PROGRESS, "url": "http://poll"}),
+        patch.object(TeamAgent, "poll", side_effect=_poll_sequence()),
+    ):
+        team_agent.run(query="hi", wait_time=0.01, progress_verbosity=None)
+
+    assert capsys.readouterr().out == ""

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -86,3 +86,31 @@ def test_dotenv_neutralisation_actually_works(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "''", f"a credential leaked into the subprocess: {result.stdout!r}"
+
+
+def test_cli_help_without_api_key(tmp_path):
+    """`aixplain --help` must render usage and exit 0 with no credential set.
+
+    The eight CLI commands each declare `--api-key`, which can only be the sole
+    source of the key if the process survives long enough for click to parse
+    argv. The import-time `validate_api_keys()` call killed it first (BUG-946),
+    so a first-run user got a traceback instead of usage text.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from aixplain.cli_groups import cli; cli(['--help'])",
+        ],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert "has been set" not in output, f"--help still requires a credential:\n{output[-4000:]}"
+    assert "Usage:" in result.stdout, f"no usage text:\n{output[-4000:]}"
+    assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"

--- a/tests/unit/utils/test_credential_free_collection.py
+++ b/tests/unit/utils/test_credential_free_collection.py
@@ -114,3 +114,50 @@ def test_cli_help_without_api_key(tmp_path):
     assert "has been set" not in output, f"--help still requires a credential:\n{output[-4000:]}"
     assert "Usage:" in result.stdout, f"no usage text:\n{output[-4000:]}"
     assert result.returncode == 0, f"exit code {result.returncode}:\n{output[-4000:]}"
+
+
+def test_cli_api_key_flag_is_the_sole_key_source(tmp_path):
+    """`--api-key K` must authenticate the request with no key in the environment.
+
+    All eight CLI commands declare the flag, but the import-time
+    `validate_api_keys()` call killed the process before click ever parsed argv,
+    so the flag could never be the only source of the credential (BUG-946). This
+    drives one command end to end and asserts the key reaches the outgoing
+    `x-api-key` header.
+    """
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+
+    child = """
+from unittest.mock import patch, Mock
+from click.testing import CliRunner
+from aixplain.cli_groups import cli
+
+captured = {}
+
+
+def fake_request(method, url, **kwargs):
+    captured["headers"] = kwargs.get("headers")
+    response = Mock()
+    response.text = "[]"
+    return response
+
+
+with patch("aixplain.factories.model_factory._request_with_retry", fake_request):
+    result = CliRunner().invoke(cli, ["list", "hosts", "--api-key", "cli-only-key"])
+
+print("EXIT", result.exit_code)
+print("EXC", repr(result.exception))
+print("KEY", (captured.get("headers") or {}).get("x-api-key"))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=str(REPO_ROOT),
+        env=_credential_free_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "EXIT 0" in result.stdout, f"CLI command failed:\n{result.stdout}\n{result.stderr[-2000:]}"
+    assert "KEY cli-only-key" in result.stdout, f"--api-key never reached the request:\n{result.stdout}"

--- a/tests/unit/v2/test_agent_team_invariant.py
+++ b/tests/unit/v2/test_agent_team_invariant.py
@@ -1,0 +1,96 @@
+"""Guard: the team-agent tasks/tools invariant is deliberately *not* enforced.
+
+``Agent._sync_file_references`` carried a commented-out check for eight months::
+
+    # TODO: Re-enable this validation after backend data consistency is fixed
+    # if self.agents and (self.tasks or self.tools):
+    #     raise ValueError(
+    #         "Team agents cannot have tasks or tools. ..."
+    #     )
+
+It was disabled inside an unrelated 88-file commit, no replacement exists
+anywhere, and v1 never had it either (BUG-946). Re-enabling it as written is not
+safe: ``_sync_file_references`` sits on the run and payload-build paths as well
+as save, and it would fire for team agents *hydrated from the backend* -- which
+is precisely the inconsistency the TODO was deferring.
+
+So the comment is gone and the non-enforcement is now an explicit, tested
+decision rather than an accident. Anyone re-introducing the invariant has to
+consciously change these tests, and the backend follow-up is tracked on the PR.
+"""
+
+import pytest
+
+from aixplain import Aixplain
+
+
+@pytest.fixture
+def aix() -> Aixplain:
+    """Return an isolated client."""
+    return Aixplain(api_key="test-key", backend_url="https://example.test")
+
+
+def _team_agent_with_everything(aix):
+    """A team agent carrying sub-agents *and* tools *and* tasks."""
+    return aix.Agent(
+        name="team-agent",
+        instructions="Coordinate the sub-agents.",
+        agents=["sub-agent-id"],
+        tools=[{"id": "tool-id", "type": "model"}],
+        tasks=[{"name": "summarize", "description": "Summarize", "expectedOutput": "A summary"}],
+    )
+
+
+def test_team_agent_with_tools_and_tasks_constructs(aix):
+    """Construction must not raise for the combination."""
+    agent = _team_agent_with_everything(aix)
+
+    assert agent.agents == ["sub-agent-id"]
+    assert agent.tools
+    assert agent.tasks
+
+
+def test_team_agent_with_tools_and_tasks_builds_a_payload(aix):
+    """``build_save_payload`` runs ``_sync_file_references``; it must not raise.
+
+    This is the call the invariant would have broken, and it must keep emitting
+    both collections.
+    """
+    payload = _team_agent_with_everything(aix).build_save_payload()
+
+    assert payload["agents"]
+    assert payload["tools"]
+
+
+def test_backend_team_agent_with_tools_hydrates(aix):
+    """Loading an existing, inconsistent team agent must keep working.
+
+    ``Agent.from_dict`` is the ``get()`` path. Raising here would make already
+    stored team agents unloadable -- the reason the guard was disabled.
+    """
+    agent = aix.Agent.from_dict(
+        {
+            "id": "team-agent-id",
+            "name": "team-agent",
+            "description": "A team agent",
+            "role": "Coordinate the sub-agents.",
+            "agents": ["sub-agent-id"],
+            "tools": [{"id": "tool-id", "type": "model"}],
+            "tasks": [{"name": "summarize", "description": "Summarize", "expectedOutput": "A summary"}],
+        }
+    )
+
+    assert agent.agents == ["sub-agent-id"]
+    assert agent.tools
+    assert agent.build_save_payload()["tools"]
+
+
+def test_stale_invariant_comment_is_gone():
+    """The dead TODO must not come back as a comment instead of a decision."""
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parents[3] / "aixplain" / "v2" / "agent.py"
+    text = source.read_text()
+
+    assert "Re-enable this validation" not in text
+    assert "Team agents cannot have tasks or tools" not in text

--- a/tests/unit/v2/test_aixplain_v2_lazy.py
+++ b/tests/unit/v2/test_aixplain_v2_lazy.py
@@ -1,0 +1,191 @@
+"""Guard: the deprecated ``aixplain.aixplain_v2`` must never be a silent ``None``.
+
+It used to be constructed eagerly at import and the failure swallowed::
+
+    aixplain_v2 = None
+    try:
+        aixplain_v2 = Aixplain()
+    except Exception:
+        pass
+
+With no credential that discarded a precise, actionable message -- ``AssertionError:
+API key is required. Pass api_key=... to Aixplain() or set TEAM_API_KEY or
+AIXPLAIN_API_KEY.`` -- and left a public symbol bound to ``None``, so the first
+consumer hit ``AttributeError: 'NoneType' object has no attribute 'Agent'`` far
+from the cause (BUG-946).
+
+A module-level ``__getattr__`` now builds it on first access, so ``import aixplain``
+still works without a key (``aixplain --help`` and unit-test collection depend on
+that) while the real error reaches whoever actually asks for the client.
+
+``Aixplain(api_key=...)`` mutates ``os.environ``, and ``aixplain/__init__.py``
+loads a working-directory ``.env``, so every keyless case runs in a subprocess
+with the variables stripped and ``python-dotenv`` neutered.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Imported by the interpreter at startup (via `site`), before anything else can
+# read the environment, so the `from dotenv import load_dotenv` in
+# aixplain/__init__.py binds the neutered version.
+SITECUSTOMIZE = """
+import dotenv
+
+dotenv.load_dotenv = lambda *args, **kwargs: False
+dotenv.main.load_dotenv = dotenv.load_dotenv
+"""
+
+
+def _credential_free_env(sitecustomize_dir: Path) -> dict:
+    env = os.environ.copy()
+    env.pop("TEAM_API_KEY", None)
+    env.pop("AIXPLAIN_API_KEY", None)
+    existing_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (str(sitecustomize_dir), existing_path) if p)
+    return env
+
+
+def _run(code: str, tmp_path: Path, with_key: bool = False) -> subprocess.CompletedProcess:
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+    env = _credential_free_env(tmp_path)
+    if with_key:
+        env["TEAM_API_KEY"] = "unit-test-key"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_succeeds_without_api_key(tmp_path):
+    """`import aixplain` must not require a credential."""
+    result = _run("import aixplain; print('imported')", tmp_path)
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "imported" in result.stdout
+
+
+def test_access_without_key_raises_the_real_error(tmp_path):
+    """Accessing the attribute with no key must raise -- not hand back ``None``."""
+    result = _run(
+        """
+import aixplain
+
+try:
+    client = aixplain.aixplain_v2
+except AssertionError as e:
+    print("RAISED:", e)
+else:
+    print("RETURNED:", repr(client))
+""",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "RAISED: API key is required" in result.stdout, result.stdout
+    assert "RETURNED" not in result.stdout
+
+
+def test_from_import_without_key_raises_too(tmp_path):
+    """`from aixplain import aixplain_v2` must go through the same hook."""
+    result = _run(
+        """
+try:
+    from aixplain import aixplain_v2
+except AssertionError as e:
+    print("RAISED:", e)
+else:
+    print("RETURNED:", repr(aixplain_v2))
+""",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "RAISED: API key is required" in result.stdout, result.stdout
+
+
+def test_star_import_without_key_still_works(tmp_path):
+    """`from aixplain import *` must not construct the deprecated client.
+
+    ``aixplain_v2`` is deliberately absent from ``__all__``: leaving it there
+    would make a star import raise for a keyless user who intends to construct
+    ``Aixplain(api_key=...)`` themselves.
+    """
+    result = _run(
+        "from aixplain import *; print(Aixplain.__name__, File.__name__)",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert "Aixplain File" in result.stdout
+
+
+def test_returns_cached_client_when_key_is_set(tmp_path):
+    """With a key, the attribute yields one `Aixplain`, stable across accesses."""
+    result = _run(
+        """
+import aixplain
+from aixplain import Aixplain
+
+first = aixplain.aixplain_v2
+second = aixplain.aixplain_v2
+print(isinstance(first, Aixplain), first is second)
+""",
+        tmp_path,
+        with_key=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    assert result.stdout.strip().endswith("True True"), result.stdout
+
+
+def test_first_access_warns_deprecation(tmp_path):
+    """First access must emit a `DeprecationWarning` naming the replacement."""
+    result = _run(
+        """
+import warnings
+import aixplain
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    aixplain.aixplain_v2
+
+deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+print(len(deprecations))
+print(str(deprecations[0].message))
+""",
+        tmp_path,
+        with_key=True,
+    )
+
+    assert result.returncode == 0, result.stderr[-4000:]
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == "1", result.stdout
+    assert "'aixplain.aixplain_v2' is deprecated" in lines[1]
+    assert "Aixplain()" in lines[1]
+
+
+def test_unknown_attribute_still_raises_attribute_error():
+    """The hook must not swallow genuine typos."""
+    import aixplain
+
+    with pytest.raises(AttributeError, match="no attribute 'not_a_real_symbol'"):
+        aixplain.not_a_real_symbol
+
+
+def test_dir_advertises_aixplain_v2():
+    """`dir(aixplain)` must keep listing the lazily provided symbol."""
+    import aixplain
+
+    listed = dir(aixplain)
+    assert "aixplain_v2" in listed
+    assert "Aixplain" in listed

--- a/tests/unit/v2/test_tool.py
+++ b/tests/unit/v2/test_tool.py
@@ -733,3 +733,79 @@ class TestMergeWithDynamicAttrs:
         for key, _ in tool._RUN_HEADER_KEYS:
             assert key not in payload_kwargs
         assert payload_kwargs["data"] == {"q": "hi"}
+
+
+class TestValidateParamsReportsFailures:
+    """_validate_params must never report "valid" when validation crashed.
+
+    The action-input branch used to be wrapped in a bare `except Exception: pass`,
+    so an unresolvable action name or a malformed payload produced an *empty*
+    error list -- indistinguishable from "validated clean" -- and `Model.run`
+    happily shipped the call to the backend (BUG-946).
+    """
+
+    def test_unknown_action_returns_non_empty_errors(self):
+        """A name absent from the cached actions must surface as an error."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        errors = tool._validate_params(action="NO_SUCH_ACTION", data={"query": "hi"})
+
+        assert errors, "an unresolvable action must not validate clean"
+        assert "NO_SUCH_ACTION" in errors[0]
+
+    def test_lazy_input_loader_failure_is_reported(self):
+        """The real unknown-action path: `Actions` fabricates an `ActionView`.
+
+        `Actions.__getitem__` does not raise for an unknown name when an action
+        factory is configured; the failure surfaces one line later, when
+        `action_obj.inputs` runs the lazy loader.
+        """
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        def _boom(action_name, description=None):
+            def _load_inputs():
+                raise ValueError(f"Action '{action_name}' not found or has no input parameters defined.")
+
+            return Action(name=action_name, _inputs_loader=_load_inputs)
+
+        actions = Actions(actions={}, _action_factory=_boom)
+        tool.__dict__["actions"] = actions
+
+        errors = tool._validate_params(action="GHOST", data={})
+
+        assert len(errors) == 1
+        assert "Could not validate inputs for 'GHOST'" in errors[0]
+        assert "not found or has no input parameters defined" in errors[0]
+
+    def test_crashing_validate_is_reported_not_swallowed(self):
+        """A malformed payload that makes `Inputs.validate` raise must be reported."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        with patch.object(Inputs, "validate", side_effect=TypeError("unhashable payload")):
+            errors = tool._validate_params(action="search", data={"query": "hi"})
+
+        assert errors == ["Could not validate inputs for 'search': unhashable payload"]
+
+    def test_valid_action_still_validates_clean(self):
+        """The happy path must be unchanged: satisfied inputs return no errors."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        assert tool._validate_params(action="search", data={"query": "hello"}) == []
+
+    def test_missing_required_input_reports_once(self):
+        """`Inputs.validate` messages pass through unchanged -- no double reporting."""
+        query_spec = _make_action_input_spec(required=True)
+        tool = _make_minimal_tool_with_actions({"search": [query_spec]})
+        tool.validate_allowed_actions = Mock()
+
+        errors = tool._validate_params(action="search", data={})
+
+        assert errors == ["Required input 'query' is missing"]


### PR DESCRIPTION
## Summary

Five controls that were declared, documented, or invoked but had no effect — plus one review follow-up found while fixing them. Each item was re-located on the current branch and re-verified before being touched; one was already fixed upstream and is called out below.

Jira: https://aixplain.atlassian.net/browse/BUG-946

Base branch is the sibling bug-fix branch `bug-939-dotenv-walk-up-debug-body-loggin`, not `development`.

## Per-finding status

| # | Finding | Status | Notes |
|---|---------|--------|-------|
| 1 | `_validate_action_inputs` returns "valid" when validation crashes | **Fixed** | `aixplain/v2/tool.py:489` — `except Exception as e:` now appends `Could not validate inputs for '{action}': {e}` instead of `pass`. An unknown action name is exactly the case that lands here: `Actions.__getitem__` fabricates an `ActionView` rather than raising, so the failure surfaces one line later in the lazy input loader. Previously the empty list was indistinguishable from "validated clean" and `Model.run` shipped the call to the backend unchecked. |
| 2 | `progress_verbosity` accepted, documented, dropped | **Fixed** | `aixplain/v1/modules/team_agent/__init__.py:706` — passed through to `sync_poll`. Argument passthrough only; no other v1 change, per the "v1 unmaintained" rule. |
| 3 | `aixplain --help` crashes without an API key | **Already fixed** | The import-time `validate_api_keys()` call was already removed under ENG-3431 (present in this PR's base): `aixplain/utils/config.py` now only *normalises* eagerly and validates at point of use. Nothing covered the CLI entrypoint the ticket names as an acceptance criterion, so this PR adds that coverage — `--help` with no credential, and `--api-key K` as the sole key source, asserted end to end down to the outgoing `x-api-key` header. |
| 4 | `aixplain_v2` silently becomes `None` at import | **Fixed** (kept, not deleted) | The ticket suggested deleting it, but it is exported in `__all__`, so a hard removal is breaking. Instead `aixplain/__init__.py` grows a module-level `__getattr__` that constructs the client on **first access** and lets the real error through (`API key is required. Pass api_key=... or set TEAM_API_KEY…`), caching the result. `import aixplain` stays keyless-safe, which `aixplain --help` and unit-test collection depend on. It is removed from `__all__` so `from aixplain import *` no longer needs a credential; `from aixplain import aixplain_v2` still resolves. First access emits a `DeprecationWarning`, and `MIGRATION.md` documents the replacement. |
| 5 | Team-agent invariant commented out | **Comment removed; not re-enabled** | Per the ticket guidance, the guard is *not* restored. `_sync_file_references` sits on the run and payload-build paths as well as save, so the check would fire for team agents hydrated from the backend — precisely the inconsistency the original TODO deferred, and re-enabling it would break loading existing team agents. The dead comment is deleted from `aixplain/v2/agent.py` and the non-enforcement is now locked by tests, so it cannot regress silently. **Backend follow-up required** (see below). |
| — | `Tool._list_inputs` swallowed the integration-fallback exception | **Fixed** (review follow-up) | Found while fixing #1. The fallback returned `[]` on failure, which makes the lazy input loader raise `Action 'X' not found or has no input parameters defined` — so after fix #1 a transport error would reach the user as a bogus "unknown action" message with the real cause discarded. It now warns with the underlying exception. |

### Backend follow-up for item 5

A team agent with both sub-agents and tools/tasks remains constructible on both APIs; the invariant is enforced nowhere in the SDK and whatever inconsistency motivated the original guard surfaces server-side. Re-enabling it client-side requires the backend to stop returning team agents that violate it — otherwise hydration of existing records breaks. This needs a backend ticket before the SDK-side check can come back; flagging here for the assignee to file against the platform team, since it is not an SDK-side change.

## Test evidence

New/extended tests, 78 in the touched files:

- `tests/unit/v2/test_tool.py` — `TestValidateParamsReportsFailures`, 5 tests: unknown action returns a **non-empty** error list, lazy-input-loader failure is reported, a crashing `validate` is reported not swallowed, a valid action still validates clean, a missing required input reports exactly once.
- `tests/unit/team_agent/test_progress_verbosity_passthrough.py` — 7 tests: `run()` forwards each verbosity value to `sync_poll` (parametrised), defaults to `"compact"`, `run(progress_verbosity=None)` produces **no stdout**, `"full"` renders full.
- `tests/unit/utils/test_credential_free_collection.py` — 4 tests: the unit suite collects with no credential, `aixplain --help` exits 0 with no environment variables, and `--api-key K` authenticates as the sole key source. Each runs in a subprocess with both credential variables stripped and `python-dotenv` neutered via `sitecustomize`, so a `.env` above the checkout cannot mask a regression.
- `tests/unit/v2/test_aixplain_v2_lazy.py` — 8 tests: import succeeds without a key; attribute access, `from aixplain import aixplain_v2`, both raise the **real** error; `import *` stays keyless; the client is cached; first access warns `DeprecationWarning`; unknown attributes still raise `AttributeError`; `dir()` advertises the symbol.
- `tests/unit/v2/test_agent_team_invariant.py` — 4 tests: a team agent with tools and tasks constructs, builds a payload, and hydrates from backend data; plus a guard that the stale commented-out invariant has not reappeared.

```
$ env -u TEAM_API_KEY -u AIXPLAIN_API_KEY python -m pytest tests/unit -q
2270 passed, 3 skipped, 146 warnings in 31.59s
```

Full suite green **with no credential set**, which is itself the acceptance criterion for item 3.

```
$ ruff check aixplain/__init__.py aixplain/v1/modules/team_agent/__init__.py aixplain/v2/agent.py aixplain/v2/tool.py <new test files>
All checks passed!
$ ruff format --check <all changed files>
9 files already formatted
```

`ruff check tests/unit/v2/test_tool.py` reports 22 pre-existing docstring findings (`D102`/`D403`/`D205`) — byte-identical on the base branch, none in the added block. Pre-commit's ruff hooks are scoped to `^aixplain/v2/`, which is clean.

## Acceptance criteria

- [x] `_validate_action_inputs` with an unknown action name returns a non-empty error list
- [x] `TeamAgent.run(progress_verbosity=None)` produces no stdout; `"full"` renders full
- [x] `aixplain --help` succeeds with no environment variables set; `aixplain <cmd> --api-key K` works as the sole key source
- [x] `pytest tests/unit` collects (and passes) with no `TEAM_API_KEY`
- [x] `from aixplain import aixplain_v2` yields a working client or raises the real message — no silent `None`
- [x] The team-agent invariant's stale comment is removed; the backend follow-up is recorded above
