### PR TITLE
test(v1): stop pinning safe_get's transport kwargs in the RAG URL test (BUG-945, BUG-939)

### DIFF
--- a/tests/unit/rlm_test.py
+++ b/tests/unit/rlm_test.py
@@ -1305,7 +1305,11 @@ class TestRagResolvesURLContext:
         with patch("requests.get", return_value=_fake_url_response(_RAG_DOC)) as mock_get:
             response, upserted = _run_v1_rag(rlm, _RAG_URL)
 
-        mock_get.assert_called_once_with(_RAG_URL, timeout=60)
+        # Assert the URL was fetched, not how ``safe_get`` shapes the request:
+        # its redirect and streaming kwargs are its own business (BUG-939).
+        mock_get.assert_called_once()
+        assert mock_get.call_args.args[0] == _RAG_URL
+        assert mock_get.call_args.kwargs["timeout"] == 60
         assert response.status == ResponseStatus.SUCCESS
         assert any(_RAG_DOC in record.value for record in upserted)
         assert not any(_RAG_URL in record.value for record in upserted)


### PR DESCRIPTION
## Summary

`development` fails one unit test after the three SEV2 branches landed. It is a cross-branch interaction that neither branch's CI could see, and it is a stale assertion rather than a defect in either change.

BUG-945 (#1078) added the `_resolve_url_context` call to v1 RAG mode and pinned the fetch with `mock_get.assert_called_once_with(_RAG_URL, timeout=60)`. BUG-939 (#1076) then routed that same call site through `safe_get`, which issues `requests.get(url, timeout=..., headers=None, stream=False, allow_redirects=False)` so it can re-validate every redirect hop. Each branch passed on its own; together the assertion is over-specified.

## Fix

Assert what the test is actually about — the URL is fetched exactly once, with the intended timeout — instead of pinning how `safe_get` shapes the request. Those transport kwargs are its own business and will change again as the SSRF guard evolves.

```python
mock_get.assert_called_once()
assert mock_get.call_args.args[0] == _RAG_URL
assert mock_get.call_args.kwargs["timeout"] == 60
```

The rest of the test is untouched and still pins the real BUG-945 contract: the indexed chunks contain the document and never the URL, and the synthesis prompt gets the document text.

## Testing

`python -m pytest tests/unit` — 2662 passed, 0 failed.

I also scanned `tests/unit` for the same brittleness against other guarded fetch sites; the only other exact-kwarg assertion is on `sync_poll`, which is not a guarded fetch and is unaffected.

## Jira

- https://aixplain.atlassian.net/browse/BUG-945
- https://aixplain.atlassian.net/browse/BUG-939
