### PR TITLE
fix(v2): stop leaking the progress display thread on failed and concurrent runs (BUG-943)

### DIFF
--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1,6 +1,5 @@
 """Agent module for aiXplain v2 SDK."""
 
-import contextvars
 import json
 import logging
 import re
@@ -41,17 +40,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-# One progress tracker per *run*, never per Agent. It used to live on
-# ``self._progress_tracker``, so two concurrent ``run()`` calls on one shared
-# Agent overwrote each other: A's tracker was replaced by B's, and A's
-# ``finish()`` then stopped B's display thread while A's spun at 20 Hz until
-# process exit (BUG-943). A ContextVar is per-thread *and* per-asyncio-task, so
-# the slot is run-local by construction rather than by discipline.
-_ACTIVE_PROGRESS_TRACKER: contextvars.ContextVar[Optional[Any]] = contextvars.ContextVar(
-    "aixplain_active_progress_tracker", default=None
-)
 
 
 # Type definitions for conversation history
@@ -289,6 +277,9 @@ class AgentRunParams(BaseRunParams):
                         If None (default), progress tracking is disabled.
         progress_verbosity: Detail level - 1 (minimal), 2 (thoughts), 3 (full I/O)
         progress_truncate: Whether to truncate long text in progress display
+        _progress_tracker: Internal. The tracker owned by the ``run()`` /
+            ``sync_poll()`` call in progress, handed down to ``on_poll``.
+            Never sent to the backend.
     """
 
     session: NotRequired[Optional[Union["Session", Text]]]
@@ -308,6 +299,7 @@ class AgentRunParams(BaseRunParams):
     progress_format: NotRequired[Optional[Text]]
     progress_verbosity: NotRequired[Optional[int]]
     progress_truncate: NotRequired[Optional[bool]]
+    _progress_tracker: NotRequired[Optional[Any]]
 
 
 @dataclass_json
@@ -719,18 +711,6 @@ class Agent(
         metadata=config(field_name="contextOverflowStrategy"),
     )
 
-    @property
-    def _progress_tracker(self) -> Optional[Any]:
-        """Deprecated read-only alias for the active run's progress tracker.
-
-        The tracker moved off the instance and into a run-local ContextVar
-        (BUG-943); a per-instance slot is precisely what let concurrent runs
-        stop each other's display threads. Kept as a property so any
-        out-of-tree reader still sees a sensible value. Assignment is no longer
-        supported.
-        """
-        return _ACTIVE_PROGRESS_TRACKER.get()
-
     def __post_init__(self) -> None:
         """Initialize agent after dataclass creation."""
         self.tasks = [Task.from_dict(task) for task in self.tasks]
@@ -980,23 +960,22 @@ class Agent(
             return {"id": tool.get("id"), "type": tool.get("type")}
         return {"id": getattr(tool, "id", None), "type": getattr(tool, "type", None)}
 
-    def _start_progress_tracker(self, kwargs: Dict[str, Any]) -> Optional[Any]:
-        """Create, start and bind a run-local progress tracker.
+    # Run kwarg that carries the run's progress tracker from ``run()`` /
+    # ``sync_poll()`` down to ``on_poll``. Listed in ``_RUN_CONTROL_KEYS`` so
+    # it is stripped before the payload is built and never reaches the wire.
+    _PROGRESS_TRACKER_KWARG: ClassVar[str] = "_progress_tracker"
 
-        Returns the tracker so callers with real control flow (the session
-        path) can hand it straight back to :meth:`_finish_progress_tracker`;
-        the hook path resolves it from the ContextVar instead. Returns ``None``
-        when progress display was not requested.
-        """
+    def _start_progress_tracker(self, kwargs: Dict[str, Any]) -> Optional[Any]:
+        """Build and start a tracker from the progress kwargs; ``None`` if not requested."""
         progress_format = kwargs.get("progress_format")
         if progress_format is None:
             return None
 
         from .agent_progress import AgentProgressTracker, ProgressFormat
 
+        fmt = ProgressFormat(progress_format)
         progress_verbosity = kwargs.get("progress_verbosity", 1)
         progress_truncate = kwargs.get("progress_truncate", True)
-        fmt = ProgressFormat(progress_format)
 
         # ``poll_interval`` is deliberately not set: this tracker is driven by the
         # start/update/finish hooks off ``sync_poll``, which owns the interval.
@@ -1010,59 +989,25 @@ class Agent(
             verbosity=progress_verbosity,
             truncate=progress_truncate,
         )
-        # The reset token rides on the tracker: ``after_run`` receives the run's
-        # result but no run-scoped state of its own, and ``ContextVar.reset()``
-        # must be handed the token produced by the context that set it.
-        tracker._context_token = _ACTIVE_PROGRESS_TRACKER.set(tracker)
         return tracker
 
-    def _unbind_progress_tracker(self, tracker: Any) -> None:
-        """Clear *tracker* out of the run-local slot."""
-        token = getattr(tracker, "_context_token", None)
-        tracker._context_token = None
-        if token is not None:
-            try:
-                _ACTIVE_PROGRESS_TRACKER.reset(token)
-                return
-            except ValueError:
-                # Token minted in a different context (teardown ran on another
-                # thread than the start). Clearing our own slot is the right
-                # fallback -- the originating context is already gone.
-                pass
-        if _ACTIVE_PROGRESS_TRACKER.get() is tracker:
-            _ACTIVE_PROGRESS_TRACKER.set(None)
+    @staticmethod
+    def _finish_progress_tracker(tracker: Optional[Any], result: AgentRunResult) -> None:
+        """Render the completion summary; a render failure never discards *result*.
 
-    def _finish_progress_tracker(
-        self,
-        result: Union[AgentRunResult, BaseException],
-        tracker: Optional[Any] = None,
-    ) -> None:
-        """Finalize the run-local tracker; safe to call twice, or never started.
-
-        The display thread is stopped for *every* outcome. Only a non-exception
-        result renders a completion summary: stopping the thread and printing
-        the summary used to be the same call, so an errored run skipped both and
-        leaked a thread printing to stdout 20 times a second (BUG-943).
+        The run is complete and billed by now, so a ``UnicodeEncodeError`` on an
+        ascii console or a ``BrokenPipeError`` from the summary line is logged,
+        not raised. ``finish()`` stops the thread before printing and ``stop()``
+        is idempotent, so the ``finally`` only matters when the render raises.
         """
-        tracker = tracker if tracker is not None else _ACTIVE_PROGRESS_TRACKER.get()
         if tracker is None:
             return
         try:
-            if not isinstance(result, BaseException):
-                tracker.finish(result)
+            tracker.finish(result)
+        except Exception:
+            logger.warning("Progress display failed to render the completion summary", exc_info=True)
         finally:
             tracker.stop()
-            self._unbind_progress_tracker(tracker)
-
-    def _stop_progress_tracker(self, tracker: Optional[Any] = None) -> None:
-        """Stop the run-local tracker without rendering anything."""
-        tracker = tracker if tracker is not None else _ACTIVE_PROGRESS_TRACKER.get()
-        if tracker is None:
-            return
-        try:
-            tracker.stop()
-        finally:
-            self._unbind_progress_tracker(tracker)
 
     def before_run(self, *args: Any, **kwargs: Unpack[AgentRunParams]) -> Optional[AgentRunResult]:
         """Hook called before running the agent to validate and prepare state."""
@@ -1079,7 +1024,6 @@ class Agent(
             if self.is_modified:
                 raise ValueError("Agent is onboarded and cannot be modified unless you explicitly save it.")
 
-        self._start_progress_tracker(kwargs)
         return None
 
     def on_poll(self, response: AgentRunResult, **kwargs: Unpack[AgentRunParams]) -> None:
@@ -1091,7 +1035,7 @@ class Agent(
         """
         # Always update progress tracker, including on final completed response
         # This ensures the last step's completion state is displayed before finish() is called
-        tracker = _ACTIVE_PROGRESS_TRACKER.get()
+        tracker = kwargs.get(self._PROGRESS_TRACKER_KWARG)
         if tracker is not None:
             tracker.update(response)
 
@@ -1103,13 +1047,11 @@ class Agent(
     ) -> Optional[AgentRunResult]:
         """Hook called after running the agent for result transformation.
 
-        Also reached on the failure path (``result`` is the raised exception),
-        so progress teardown always runs -- ``run()`` used to skip this hook
-        entirely when ``sync_poll`` raised (BUG-943).
+        Also reached on the failure path, where ``result`` is the raised
+        exception (any ``BaseException``, ``KeyboardInterrupt`` included). The
+        progress display is not torn down here: ``run()`` owns it, so an
+        override that skips ``super()`` cannot leak the display thread.
         """
-        # Finish progress tracking if enabled
-        self._finish_progress_tracker(result)
-
         # Set the context on the result for debug() method support
         if not isinstance(result, BaseException):
             result._context = self.context
@@ -1236,7 +1178,21 @@ class Agent(
         if session is not None:
             return self._run_with_session(session, **kwargs)
 
-        return super().run(*args, **kwargs)
+        # This frame owns the progress display for the whole run: the tracker
+        # rides down to ``on_poll`` as a run kwarg, is stopped on every exit
+        # path and rendered only on success. Splitting that across the
+        # ``before_run`` / ``after_run`` hooks leaked the display thread
+        # whenever a hook was skipped or overridden (BUG-943). ``BaseException``
+        # so a Ctrl-C in a notebook cannot leak it either.
+        tracker = self._start_progress_tracker(kwargs)
+        try:
+            result = super().run(*args, **kwargs, _progress_tracker=tracker)
+        except BaseException:
+            if tracker is not None:
+                tracker.stop()
+            raise
+        self._finish_progress_tracker(tracker, result)
+        return result
 
     def run_async(self, *args: Any, **kwargs: Unpack[AgentRunParams]) -> AgentRunResult:
         """Run the agent asynchronously.
@@ -1252,6 +1208,15 @@ class Agent(
                 ``client.get(result.url)``. Do not construct
                 ``/sdk/runs/{execution_id}`` — that endpoint is not supported
                 for agent runs.
+
+        Note:
+            ``progress_format`` is ignored here and logged as a warning: this
+            call returns as soon as the run is submitted, so there is nothing
+            to display. To watch a run started this way, pass the progress
+            kwargs to the poll instead::
+
+                r = agent.run_async("hi")
+                agent.sync_poll(r.url, progress_format="status")
         """
         if len(args) > 0:
             kwargs["query"] = args[0]
@@ -1263,14 +1228,13 @@ class Agent(
                 "session.add_message() + session.messages() directly."
             )
 
-        # ``before_run`` starts a progress tracker, but there is no poll loop
-        # here and therefore no ``after_run``: nothing would ever update the
-        # display and nothing would ever stop its thread (BUG-943). Stop it as
-        # soon as the submission returns; the run itself is unaffected.
-        try:
-            return super().run_async(**kwargs)
-        finally:
-            self._stop_progress_tracker()
+        if kwargs.get("progress_format") is not None:
+            logger.warning(
+                "run_async() ignores progress_format: it returns once the run is submitted, so there is "
+                "nothing to display. Pass it to the poll instead: sync_poll(result.url, progress_format=...)."
+            )
+
+        return super().run_async(**kwargs)
 
     def _resolve_poll_url(self, poll_url: str) -> str:
         """Resolve a poll URL or bare execution ID to a full poll URL.
@@ -1321,11 +1285,30 @@ class Agent(
         Args:
             poll_url: Full poll URL or execution ID.
             **kwargs: Run parameters including ``timeout`` and ``wait_time``.
+                ``progress_format`` / ``progress_verbosity`` /
+                ``progress_truncate`` render a live progress display for the
+                duration of the poll, exactly as on :meth:`run`; this is how a
+                run started with :meth:`run_async` is watched.
 
         Returns:
             AgentRunResult with final execution status.
         """
-        return super().sync_poll(self._resolve_poll_url(poll_url), **kwargs)
+        poll_url = self._resolve_poll_url(poll_url)
+        if self._PROGRESS_TRACKER_KWARG in kwargs:
+            # An enclosing run() owns the display (or chose not to have one);
+            # it feeds, finishes and stops the tracker.
+            return super().sync_poll(poll_url, **kwargs)
+
+        # Standalone poll: own a display of our own, same shape as run().
+        tracker = self._start_progress_tracker(kwargs)
+        try:
+            result = super().sync_poll(poll_url, **kwargs, _progress_tracker=tracker)
+        except BaseException:
+            if tracker is not None:
+                tracker.stop()
+            raise
+        self._finish_progress_tracker(tracker, result)
+        return result
 
     def _validate_expected_output(self) -> None:
         if self.output_format == OutputFormat.JSON.value:
@@ -2633,7 +2616,7 @@ class Agent(
                 f"session '{session.id}'; cannot poll the agent run result."
             )
 
-        # Same progress-tracker plumbing as the direct path: sync_poll calls
+        # Same progress-display ownership as the direct path: sync_poll calls
         # self.on_poll(...) on every iteration, which forwards to the tracker.
         tracker = self._start_progress_tracker(kwargs)
         try:
@@ -2641,15 +2624,13 @@ class Agent(
                 user_msg.request_id,
                 timeout=kwargs.get("timeout", 300),
                 wait_time=kwargs.get("wait_time", 0.5),
+                _progress_tracker=tracker,
             )
-        except BaseException as e:
-            # BaseException, not Exception: a Ctrl-C in a notebook leaves the
-            # kernel -- and any leaked display thread -- alive (BUG-943). The
-            # tracker is passed explicitly so teardown cannot depend on the
-            # ContextVar still holding it.
-            self._finish_progress_tracker(e, tracker=tracker)
+        except BaseException:
+            if tracker is not None:
+                tracker.stop()
             raise
-        self._finish_progress_tracker(result, tracker=tracker)
+        self._finish_progress_tracker(tracker, result)
 
         # The /sdk/agents/{id}/result response doesn't always echo back
         # identifiers at the top level — back-fill from what we know locally so

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1,5 +1,6 @@
 """Agent module for aiXplain v2 SDK."""
 
+import contextvars
 import json
 import logging
 import re
@@ -40,6 +41,17 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+# One progress tracker per *run*, never per Agent. It used to live on
+# ``self._progress_tracker``, so two concurrent ``run()`` calls on one shared
+# Agent overwrote each other: A's tracker was replaced by B's, and A's
+# ``finish()`` then stopped B's display thread while A's spun at 20 Hz until
+# process exit (BUG-943). A ContextVar is per-thread *and* per-asyncio-task, so
+# the slot is run-local by construction rather than by discipline.
+_ACTIVE_PROGRESS_TRACKER: contextvars.ContextVar[Optional[Any]] = contextvars.ContextVar(
+    "aixplain_active_progress_tracker", default=None
+)
 
 
 # Type definitions for conversation history
@@ -707,14 +719,17 @@ class Agent(
         metadata=config(field_name="contextOverflowStrategy"),
     )
 
-    # Internal state for progress tracking (excluded from serialization)
-    _progress_tracker: Optional[Any] = field(
-        default=None,
-        repr=False,
-        compare=False,
-        metadata=config(exclude=lambda x: True),
-        init=False,
-    )
+    @property
+    def _progress_tracker(self) -> Optional[Any]:
+        """Deprecated read-only alias for the active run's progress tracker.
+
+        The tracker moved off the instance and into a run-local ContextVar
+        (BUG-943); a per-instance slot is precisely what let concurrent runs
+        stop each other's display threads. Kept as a property so any
+        out-of-tree reader still sees a sensible value. Assignment is no longer
+        supported.
+        """
+        return _ACTIVE_PROGRESS_TRACKER.get()
 
     def __post_init__(self) -> None:
         """Initialize agent after dataclass creation."""
@@ -965,12 +980,17 @@ class Agent(
             return {"id": tool.get("id"), "type": tool.get("type")}
         return {"id": getattr(tool, "id", None), "type": getattr(tool, "type", None)}
 
-    def _start_progress_tracker(self, kwargs: Dict[str, Any]) -> None:
-        """Initialize ``self._progress_tracker`` from progress kwargs (no-op if disabled)."""
+    def _start_progress_tracker(self, kwargs: Dict[str, Any]) -> Optional[Any]:
+        """Create, start and bind a run-local progress tracker.
+
+        Returns the tracker so callers with real control flow (the session
+        path) can hand it straight back to :meth:`_finish_progress_tracker`;
+        the hook path resolves it from the ContextVar instead. Returns ``None``
+        when progress display was not requested.
+        """
         progress_format = kwargs.get("progress_format")
         if progress_format is None:
-            self._progress_tracker = None
-            return
+            return None
 
         from .agent_progress import AgentProgressTracker, ProgressFormat
 
@@ -981,22 +1001,68 @@ class Agent(
         # ``poll_interval`` is deliberately not set: this tracker is driven by the
         # start/update/finish hooks off ``sync_poll``, which owns the interval.
         # It would only be slept on by ``stream_progress``, which is not used here.
-        self._progress_tracker = AgentProgressTracker(
+        tracker = AgentProgressTracker(
             poll_func=lambda url: self.poll(url),
             max_polls=None,
         )
-        self._progress_tracker.start(
+        tracker.start(
             format=fmt,
             verbosity=progress_verbosity,
             truncate=progress_truncate,
         )
+        # The reset token rides on the tracker: ``after_run`` receives the run's
+        # result but no run-scoped state of its own, and ``ContextVar.reset()``
+        # must be handed the token produced by the context that set it.
+        tracker._context_token = _ACTIVE_PROGRESS_TRACKER.set(tracker)
+        return tracker
 
-    def _finish_progress_tracker(self, result: Union[AgentRunResult, Exception]) -> None:
-        """Finalize the progress tracker; safe to call even if it was never started."""
-        if self._progress_tracker is not None:
-            if not isinstance(result, Exception):
-                self._progress_tracker.finish(result)
-            self._progress_tracker = None
+    def _unbind_progress_tracker(self, tracker: Any) -> None:
+        """Clear *tracker* out of the run-local slot."""
+        token = getattr(tracker, "_context_token", None)
+        tracker._context_token = None
+        if token is not None:
+            try:
+                _ACTIVE_PROGRESS_TRACKER.reset(token)
+                return
+            except ValueError:
+                # Token minted in a different context (teardown ran on another
+                # thread than the start). Clearing our own slot is the right
+                # fallback -- the originating context is already gone.
+                pass
+        if _ACTIVE_PROGRESS_TRACKER.get() is tracker:
+            _ACTIVE_PROGRESS_TRACKER.set(None)
+
+    def _finish_progress_tracker(
+        self,
+        result: Union[AgentRunResult, BaseException],
+        tracker: Optional[Any] = None,
+    ) -> None:
+        """Finalize the run-local tracker; safe to call twice, or never started.
+
+        The display thread is stopped for *every* outcome. Only a non-exception
+        result renders a completion summary: stopping the thread and printing
+        the summary used to be the same call, so an errored run skipped both and
+        leaked a thread printing to stdout 20 times a second (BUG-943).
+        """
+        tracker = tracker if tracker is not None else _ACTIVE_PROGRESS_TRACKER.get()
+        if tracker is None:
+            return
+        try:
+            if not isinstance(result, BaseException):
+                tracker.finish(result)
+        finally:
+            tracker.stop()
+            self._unbind_progress_tracker(tracker)
+
+    def _stop_progress_tracker(self, tracker: Optional[Any] = None) -> None:
+        """Stop the run-local tracker without rendering anything."""
+        tracker = tracker if tracker is not None else _ACTIVE_PROGRESS_TRACKER.get()
+        if tracker is None:
+            return
+        try:
+            tracker.stop()
+        finally:
+            self._unbind_progress_tracker(tracker)
 
     def before_run(self, *args: Any, **kwargs: Unpack[AgentRunParams]) -> Optional[AgentRunResult]:
         """Hook called before running the agent to validate and prepare state."""
@@ -1025,21 +1091,27 @@ class Agent(
         """
         # Always update progress tracker, including on final completed response
         # This ensures the last step's completion state is displayed before finish() is called
-        if self._progress_tracker is not None:
-            self._progress_tracker.update(response)
+        tracker = _ACTIVE_PROGRESS_TRACKER.get()
+        if tracker is not None:
+            tracker.update(response)
 
     def after_run(
         self,
-        result: Union[AgentRunResult, Exception],
+        result: Union[AgentRunResult, BaseException],
         *args: Any,
         **kwargs: Unpack[AgentRunParams],
     ) -> Optional[AgentRunResult]:
-        """Hook called after running the agent for result transformation."""
+        """Hook called after running the agent for result transformation.
+
+        Also reached on the failure path (``result`` is the raised exception),
+        so progress teardown always runs -- ``run()`` used to skip this hook
+        entirely when ``sync_poll`` raised (BUG-943).
+        """
         # Finish progress tracking if enabled
         self._finish_progress_tracker(result)
 
         # Set the context on the result for debug() method support
-        if not isinstance(result, Exception):
+        if not isinstance(result, BaseException):
             result._context = self.context
 
         return None  # Return original result
@@ -1191,7 +1263,14 @@ class Agent(
                 "session.add_message() + session.messages() directly."
             )
 
-        return super().run_async(**kwargs)
+        # ``before_run`` starts a progress tracker, but there is no poll loop
+        # here and therefore no ``after_run``: nothing would ever update the
+        # display and nothing would ever stop its thread (BUG-943). Stop it as
+        # soon as the submission returns; the run itself is unaffected.
+        try:
+            return super().run_async(**kwargs)
+        finally:
+            self._stop_progress_tracker()
 
     def _resolve_poll_url(self, poll_url: str) -> str:
         """Resolve a poll URL or bare execution ID to a full poll URL.
@@ -2556,17 +2635,21 @@ class Agent(
 
         # Same progress-tracker plumbing as the direct path: sync_poll calls
         # self.on_poll(...) on every iteration, which forwards to the tracker.
-        self._start_progress_tracker(kwargs)
+        tracker = self._start_progress_tracker(kwargs)
         try:
             result = self.sync_poll(
                 user_msg.request_id,
                 timeout=kwargs.get("timeout", 300),
                 wait_time=kwargs.get("wait_time", 0.5),
             )
-        except Exception as e:
-            self._finish_progress_tracker(e)
+        except BaseException as e:
+            # BaseException, not Exception: a Ctrl-C in a notebook leaves the
+            # kernel -- and any leaked display thread -- alive (BUG-943). The
+            # tracker is passed explicitly so teardown cannot depend on the
+            # ContextVar still holding it.
+            self._finish_progress_tracker(e, tracker=tracker)
             raise
-        self._finish_progress_tracker(result)
+        self._finish_progress_tracker(result, tracker=tracker)
 
         # The /sdk/agents/{id}/result response doesn't always echo back
         # identifiers at the top level — back-fill from what we know locally so

--- a/aixplain/v2/agent_progress.py
+++ b/aixplain/v2/agent_progress.py
@@ -29,10 +29,12 @@ logger = logging.getLogger(__name__)
 # Set to True to revert to the old behavior where centiseconds are always shown
 _USE_LEGACY_TIME_FORMAT = False
 
-# Opt-in override for callers who deliberately pipe progress output (a CI log,
-# ``tee``, a terminal wrapper with no PTY). The instance-scoped
-# ``force_display`` argument is preferred; this exists because run kwargs are
-# the only lever a caller of ``agent.run(progress_format=...)`` has.
+# Opt-in: run the animated repaint thread even when stdout is not a terminal
+# (a terminal wrapper with no PTY, say). Any other value, ``false`` and ``0``
+# included, expresses no opinion and leaves the auto-detection in charge. The
+# instance-scoped ``force_display`` argument is preferred; this exists because
+# run kwargs are the only lever a caller of ``agent.run(progress_format=...)``
+# has.
 _FORCE_DISPLAY_ENV = "AIXPLAIN_PROGRESS_FORCE_DISPLAY"
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -40,7 +42,7 @@ _TRUTHY = {"1", "true", "yes", "on"}
 def _stdout_is_tty() -> bool:
     """Return True when stdout is an interactive terminal.
 
-    The progress display is a human affordance: repainting a spinner 20 times a
+    The spinner animation is a human affordance: repainting it 20 times a
     second into a pipe produces nothing but carriage-return-terminated log
     garbage (BUG-943). Never raises -- a closed, detached or replaced
     ``sys.stdout`` (pytest capture, a ``StringIO``, a daemonized process)
@@ -149,9 +151,13 @@ class AgentProgressTracker:
                 (default: 0.5). Unused by the start/update/finish flow, where
                 the caller's own poll loop owns the interval.
             max_polls: Maximum number of polls before stopping (default: None)
-            force_display: Override the terminal auto-detection. ``None``
-                (default) renders only when stdout is a TTY or we are in a
-                notebook; ``True`` always renders, ``False`` never does.
+            force_display: Override the terminal auto-detection for the
+                animated repaint thread. ``None`` (default) animates only when
+                stdout is a TTY or we are in a notebook; ``True`` always
+                animates, ``False`` never does. The caller-thread output --
+                the ``logs`` step timeline and the completion summary -- is
+                written regardless, so a piped or captured run still gets a
+                full, newline-terminated record.
         """
         self.poll = poll_func
         self.poll_interval = poll_interval
@@ -160,15 +166,11 @@ class AgentProgressTracker:
         # Detect notebook environment once at init time
         self._is_notebook = _is_notebook_environment()
 
-        # Display gating. Re-resolved in ``start()`` because ``sys.stdout`` can
-        # be swapped between construction and the run (``redirect_stdout``,
-        # notebooks, tests).
+        # Gate for the background repaint thread only. Re-resolved in
+        # ``start()`` because ``sys.stdout`` can be swapped between construction
+        # and the run (``redirect_stdout``, notebooks, tests).
         self._force_display = force_display
-        self._display_enabled = self._resolve_display_enabled()
-
-        # Set by the run path when the tracker is bound to a ContextVar, so
-        # teardown can unbind it. Declared here so the attribute always exists.
-        self._context_token: Optional[Any] = None
+        self._animate = self._resolve_animate()
 
         # Tracking state
         self._seen_steps: Dict[str, Dict] = {}
@@ -195,26 +197,24 @@ class AgentProgressTracker:
         self._verbosity = 1
         self._truncate = True
 
-    def _resolve_display_enabled(self) -> bool:
-        """Decide whether this tracker may write to stdout at all.
+    def _resolve_animate(self) -> bool:
+        """Decide whether the 20 Hz repaint thread may run.
 
-        Precedence: explicit ``force_display`` argument, then the
-        ``AIXPLAIN_PROGRESS_FORCE_DISPLAY`` environment override, then
-        auto-detection. Notebooks are checked before ``isatty()`` because
-        ipykernel's ``OutStream`` is not a terminal but is a real display.
+        Only the animation is gated: the ``logs`` timeline and the completion
+        summary are newline-terminated caller-thread output and are always
+        written. Precedence: explicit ``force_display`` argument, then a truthy
+        ``AIXPLAIN_PROGRESS_FORCE_DISPLAY`` (an opt-in only -- ``false`` is no
+        opinion), then auto-detection. Notebooks are checked before ``isatty()``
+        because ipykernel's ``OutStream`` is not a terminal but is a real
+        display.
         """
         if self._force_display is not None:
             return self._force_display
-        env = os.environ.get(_FORCE_DISPLAY_ENV, "").strip().lower()
-        if env:
-            return env in _TRUTHY
+        if os.environ.get(_FORCE_DISPLAY_ENV, "").strip().lower() in _TRUTHY:
+            return True
         if self._is_notebook:
             return True
         return _stdout_is_tty()
-
-    def _should_render(self) -> bool:
-        """True when progress output is both requested and destined somewhere useful."""
-        return self._format != ProgressFormat.NONE and self._display_enabled
 
     def stop(self) -> None:
         """Stop the display thread and wait for it to exit.
@@ -552,7 +552,7 @@ class AgentProgressTracker:
         step_line += f" · {agent_action_part}"
         return step_line
 
-    def _display_refresh_loop(self) -> None:
+    def _display_refresh_loop(self, stop_event: threading.Event) -> None:
         """Background thread that refreshes display for smooth spinner animation.
 
         The lock is taken only to copy the shared snapshot, never across the
@@ -562,8 +562,11 @@ class AgentProgressTracker:
 
         Waiting on the stop event rather than sleeping means :meth:`stop`
         is observed immediately instead of up to ``DISPLAY_REFRESH_RATE`` later.
+        *stop_event* is this thread's own: a thread that outlived its join
+        (blocked in ``print()`` on a full pipe) must never be re-armed when the
+        next ``start()`` arms a new one.
         """
-        while not self._stop_display.is_set():
+        while not stop_event.is_set():
             with self._display_lock:
                 data = self._current_display_data.copy() if self._current_display_data else None
 
@@ -574,7 +577,7 @@ class AgentProgressTracker:
                 elif self._format == ProgressFormat.LOGS:
                     self._refresh_logs_display(steps)
 
-            if self._stop_display.wait(self.DISPLAY_REFRESH_RATE):
+            if stop_event.wait(self.DISPLAY_REFRESH_RATE):
                 break
 
     def _refresh_status_display(self, steps: List[Dict]) -> None:
@@ -790,8 +793,9 @@ class AgentProgressTracker:
             format: Display format (status, logs, none)
             verbosity: Detail level (1=minimal, 2=thoughts, 3=full I/O)
             truncate: Whether to truncate long text
-            force_display: Override the terminal auto-detection for this run.
-                ``None`` keeps whatever was passed to ``__init__``.
+            force_display: Override the terminal auto-detection for the
+                animated repaint thread on this run. ``None`` keeps whatever
+                was passed to ``__init__``.
         """
         # Tear down any thread a previous start() left running. Without this a
         # second start() -- which ``stream_progress`` performs on every call --
@@ -818,23 +822,27 @@ class AgentProgressTracker:
         self._verbosity = verbosity
         self._truncate = truncate
 
-        # Re-resolve the display gate: stdout may have been swapped since
+        # Re-resolve the animation gate: stdout may have been swapped since
         # __init__ (redirect_stdout, a notebook kernel, a test harness).
         if force_display is not None:
             self._force_display = force_display
-        self._display_enabled = self._resolve_display_enabled()
+        self._animate = self._resolve_animate()
 
-        # Reset threading state
-        self._stop_display.clear()
+        # A fresh stop event per start(). Clearing a shared one would re-arm a
+        # previous thread that outlived its join -- stuck in print() on a full
+        # pipe -- and put two painters on one fd with no way to join either.
+        stop_event = threading.Event()
+        self._stop_display = stop_event
         self._current_display_data = None
 
         # Start display refresh thread for smooth spinner animation.
         # Skipped in notebook environments (it causes display issues) and off a
         # terminal, where the thread would print log garbage 20 times a second
         # for the life of the run (BUG-943).
-        if self._should_render() and not self._is_notebook:
+        if self._format != ProgressFormat.NONE and self._animate and not self._is_notebook:
             self._display_thread = threading.Thread(
                 target=self._display_refresh_loop,
+                args=(stop_event,),
                 name=self.DISPLAY_THREAD_NAME,
                 daemon=True,
             )
@@ -969,12 +977,8 @@ class AgentProgressTracker:
         if not steps:
             return
 
-        # Update metrics. Bookkeeping is not display state: the counter and the
-        # totals stay unconditional even with rendering gated off (BUG-942).
+        # Update metrics
         self._update_metrics(steps)
-
-        if not self._should_render():
-            return
 
         # Update shared display data for background thread (terminal mode)
         with self._display_lock:
@@ -994,7 +998,7 @@ class AgentProgressTracker:
         """
         self.stop()
 
-        if not self._should_render():
+        if self._format == ProgressFormat.NONE:
             return
 
         # Get final status and steps
@@ -1073,30 +1077,29 @@ class AgentProgressTracker:
                 if steps:
                     self._update_metrics(steps)
 
-                    if self._should_render():
-                        # Update shared display data for background thread (terminal mode)
-                        with self._display_lock:
-                            self._current_display_data = {"steps": steps}
+                    # Update shared display data for background thread (terminal mode)
+                    with self._display_lock:
+                        self._current_display_data = {"steps": steps}
 
-                        # Handle display based on format
-                        if self._format == ProgressFormat.LOGS:
-                            self._display_logs_format(steps)
-                        elif self._format == ProgressFormat.STATUS and self._is_notebook:
-                            self._display_status_format_notebook(steps)
+                    # Handle display based on format
+                    if self._format == ProgressFormat.LOGS:
+                        self._display_logs_format(steps)
+                    elif self._format == ProgressFormat.STATUS and self._is_notebook:
+                        self._display_status_format_notebook(steps)
 
                 # Check termination conditions
                 if status_up == terminal_success:
-                    if self._should_render():
+                    if self._format != ProgressFormat.NONE:
                         self._print_completion_message(status_up, steps)
                     return resp
 
                 if status_up in terminal_failures:
-                    if self._should_render():
+                    if self._format != ProgressFormat.NONE:
                         self._print_completion_message(status_up, steps)
                     return resp
 
                 if self.max_polls is not None and self._poll_count >= self.max_polls:
-                    if self._should_render():
+                    if self._format != ProgressFormat.NONE:
                         self._print_completion_message("MAX_POLLS", steps)
                     return resp
 
@@ -1107,7 +1110,7 @@ class AgentProgressTracker:
                         timeout,
                         status_up or "UNKNOWN",
                     )
-                    if self._should_render():
+                    if self._format != ProgressFormat.NONE:
                         self._print_completion_message("TIMEOUT", steps)
                     raise TimeoutError(
                         f"Operation timed out after {timeout} seconds (last status: {status_up or 'UNKNOWN'})"

--- a/aixplain/v2/agent_progress.py
+++ b/aixplain/v2/agent_progress.py
@@ -13,6 +13,7 @@ Both modes use carriage return (\r) for in-place line updates.
 
 import json
 import logging
+import os
 import sys
 import time
 import threading
@@ -27,6 +28,29 @@ logger = logging.getLogger(__name__)
 # Internal flag to use legacy time format (MM:SS.cc always)
 # Set to True to revert to the old behavior where centiseconds are always shown
 _USE_LEGACY_TIME_FORMAT = False
+
+# Opt-in override for callers who deliberately pipe progress output (a CI log,
+# ``tee``, a terminal wrapper with no PTY). The instance-scoped
+# ``force_display`` argument is preferred; this exists because run kwargs are
+# the only lever a caller of ``agent.run(progress_format=...)`` has.
+_FORCE_DISPLAY_ENV = "AIXPLAIN_PROGRESS_FORCE_DISPLAY"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _stdout_is_tty() -> bool:
+    """Return True when stdout is an interactive terminal.
+
+    The progress display is a human affordance: repainting a spinner 20 times a
+    second into a pipe produces nothing but carriage-return-terminated log
+    garbage (BUG-943). Never raises -- a closed, detached or replaced
+    ``sys.stdout`` (pytest capture, a ``StringIO``, a daemonized process)
+    answers False.
+    """
+    stream = sys.stdout
+    try:
+        return bool(stream is not None and stream.isatty())
+    except (AttributeError, ValueError):
+        return False
 
 
 def _is_notebook_environment() -> bool:
@@ -100,11 +124,17 @@ class AgentProgressTracker:
     # Wall-clock budget for a ``stream_progress`` call, matching ``sync_poll``.
     DEFAULT_STREAM_TIMEOUT = 300.0
 
+    # Upper bound on how long teardown waits for the display thread. With
+    # ``Event.wait`` the loop exits in microseconds; the bound only exists so a
+    # wedged render can never block the caller's run from returning.
+    DISPLAY_JOIN_TIMEOUT = 1.0
+
     def __init__(
         self,
         poll_func: Callable[[str], Any],
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         max_polls: Optional[int] = None,
+        force_display: Optional[bool] = None,
     ):
         """Initialize the progress tracker.
 
@@ -115,6 +145,9 @@ class AgentProgressTracker:
                 (default: 0.5). Unused by the start/update/finish flow, where
                 the caller's own poll loop owns the interval.
             max_polls: Maximum number of polls before stopping (default: None)
+            force_display: Override the terminal auto-detection. ``None``
+                (default) renders only when stdout is a TTY or we are in a
+                notebook; ``True`` always renders, ``False`` never does.
         """
         self.poll = poll_func
         self.poll_interval = poll_interval
@@ -122,6 +155,16 @@ class AgentProgressTracker:
 
         # Detect notebook environment once at init time
         self._is_notebook = _is_notebook_environment()
+
+        # Display gating. Re-resolved in ``start()`` because ``sys.stdout`` can
+        # be swapped between construction and the run (``redirect_stdout``,
+        # notebooks, tests).
+        self._force_display = force_display
+        self._display_enabled = self._resolve_display_enabled()
+
+        # Set by the run path when the tracker is bound to a ContextVar, so
+        # teardown can unbind it. Declared here so the attribute always exists.
+        self._context_token: Optional[Any] = None
 
         # Tracking state
         self._seen_steps: Dict[str, Dict] = {}
@@ -147,6 +190,48 @@ class AgentProgressTracker:
         self._format = ProgressFormat.STATUS
         self._verbosity = 1
         self._truncate = True
+
+    def _resolve_display_enabled(self) -> bool:
+        """Decide whether this tracker may write to stdout at all.
+
+        Precedence: explicit ``force_display`` argument, then the
+        ``AIXPLAIN_PROGRESS_FORCE_DISPLAY`` environment override, then
+        auto-detection. Notebooks are checked before ``isatty()`` because
+        ipykernel's ``OutStream`` is not a terminal but is a real display.
+        """
+        if self._force_display is not None:
+            return self._force_display
+        env = os.environ.get(_FORCE_DISPLAY_ENV, "").strip().lower()
+        if env:
+            return env in _TRUTHY
+        if self._is_notebook:
+            return True
+        return _stdout_is_tty()
+
+    def _should_render(self) -> bool:
+        """True when progress output is both requested and destined somewhere useful."""
+        return self._format != ProgressFormat.NONE and self._display_enabled
+
+    def stop(self) -> None:
+        """Stop the display thread and wait for it to exit.
+
+        Idempotent, safe from any thread, and safe on a tracker that never
+        started a thread. Deliberately renders nothing: stopping the thread and
+        printing a completion summary used to be the same call (``finish()``),
+        so skipping the summary on an errored run skipped the stop too and
+        leaked a thread that printed 20 times a second forever (BUG-943).
+        """
+        self._stop_display.set()
+        thread, self._display_thread = self._display_thread, None
+        if thread is None or thread is threading.current_thread():
+            return
+        if thread.is_alive():
+            thread.join(timeout=self.DISPLAY_JOIN_TIMEOUT)
+            if thread.is_alive():
+                logger.warning(
+                    "Progress display thread did not exit within %ss",
+                    self.DISPLAY_JOIN_TIMEOUT,
+                )
 
     def _now(self) -> float:
         """Get current timestamp."""
@@ -464,25 +549,29 @@ class AgentProgressTracker:
         return step_line
 
     def _display_refresh_loop(self) -> None:
-        """Background thread that refreshes display for smooth spinner animation."""
+        """Background thread that refreshes display for smooth spinner animation.
+
+        The lock is taken only to copy the shared snapshot, never across the
+        render or the wait: ``update()`` takes the same lock, so a tracker that
+        sat in the no-data branch held it for the whole refresh interval and
+        throttled the live run polling alongside it (BUG-943).
+
+        Waiting on the stop event rather than sleeping means :meth:`stop`
+        is observed immediately instead of up to ``DISPLAY_REFRESH_RATE`` later.
+        """
         while not self._stop_display.is_set():
             with self._display_lock:
-                if self._current_display_data is None:
-                    time.sleep(self.DISPLAY_REFRESH_RATE)
-                    continue
-                data = self._current_display_data.copy()
+                data = self._current_display_data.copy() if self._current_display_data else None
 
-            steps = data.get("steps", [])
-            if not steps:
-                time.sleep(self.DISPLAY_REFRESH_RATE)
-                continue
+            steps = data.get("steps") if data else None
+            if steps:
+                if self._format == ProgressFormat.STATUS:
+                    self._refresh_status_display(steps)
+                elif self._format == ProgressFormat.LOGS:
+                    self._refresh_logs_display(steps)
 
-            if self._format == ProgressFormat.STATUS:
-                self._refresh_status_display(steps)
-            elif self._format == ProgressFormat.LOGS:
-                self._refresh_logs_display(steps)
-
-            time.sleep(self.DISPLAY_REFRESH_RATE)
+            if self._stop_display.wait(self.DISPLAY_REFRESH_RATE):
+                break
 
     def _refresh_status_display(self, steps: List[Dict]) -> None:
         """Refresh status mode display (single updating line)."""
@@ -689,6 +778,7 @@ class AgentProgressTracker:
         format: ProgressFormat = ProgressFormat.STATUS,
         verbosity: int = 1,
         truncate: bool = True,
+        force_display: Optional[bool] = None,
     ) -> None:
         """Start progress tracking (call from before_run hook).
 
@@ -696,6 +786,8 @@ class AgentProgressTracker:
             format: Display format (status, logs, none)
             verbosity: Detail level (1=minimal, 2=thoughts, 3=full I/O)
             truncate: Whether to truncate long text
+            force_display: Override the terminal auto-detection for this run.
+                ``None`` keeps whatever was passed to ``__init__``.
         """
         # Reset tracking state
         self._seen_steps = {}
@@ -714,13 +806,21 @@ class AgentProgressTracker:
         self._verbosity = verbosity
         self._truncate = truncate
 
+        # Re-resolve the display gate: stdout may have been swapped since
+        # __init__ (redirect_stdout, a notebook kernel, a test harness).
+        if force_display is not None:
+            self._force_display = force_display
+        self._display_enabled = self._resolve_display_enabled()
+
         # Reset threading state
         self._stop_display.clear()
         self._current_display_data = None
 
-        # Start display refresh thread for smooth spinner animation
-        # Skip threading in notebook environments - it causes display issues
-        if self._format != ProgressFormat.NONE and not self._is_notebook:
+        # Start display refresh thread for smooth spinner animation.
+        # Skipped in notebook environments (it causes display issues) and off a
+        # terminal, where the thread would print log garbage 20 times a second
+        # for the life of the run (BUG-943).
+        if self._should_render() and not self._is_notebook:
             self._display_thread = threading.Thread(target=self._display_refresh_loop, daemon=True)
             self._display_thread.start()
 
@@ -853,8 +953,12 @@ class AgentProgressTracker:
         if not steps:
             return
 
-        # Update metrics
+        # Update metrics. Bookkeeping is not display state: the counter and the
+        # totals stay unconditional even with rendering gated off (BUG-942).
         self._update_metrics(steps)
+
+        if not self._should_render():
+            return
 
         # Update shared display data for background thread (terminal mode)
         with self._display_lock:
@@ -872,12 +976,9 @@ class AgentProgressTracker:
         Args:
             response: Final response from agent execution
         """
-        # Stop display thread
-        self._stop_display.set()
-        if self._display_thread and self._display_thread.is_alive():
-            self._display_thread.join(timeout=1.0)
+        self.stop()
 
-        if self._format == ProgressFormat.NONE:
+        if not self._should_render():
             return
 
         # Get final status and steps
@@ -956,29 +1057,30 @@ class AgentProgressTracker:
                 if steps:
                     self._update_metrics(steps)
 
-                    # Update shared display data for background thread (terminal mode)
-                    with self._display_lock:
-                        self._current_display_data = {"steps": steps}
+                    if self._should_render():
+                        # Update shared display data for background thread (terminal mode)
+                        with self._display_lock:
+                            self._current_display_data = {"steps": steps}
 
-                    # Handle display based on format
-                    if self._format == ProgressFormat.LOGS:
-                        self._display_logs_format(steps)
-                    elif self._format == ProgressFormat.STATUS and self._is_notebook:
-                        self._display_status_format_notebook(steps)
+                        # Handle display based on format
+                        if self._format == ProgressFormat.LOGS:
+                            self._display_logs_format(steps)
+                        elif self._format == ProgressFormat.STATUS and self._is_notebook:
+                            self._display_status_format_notebook(steps)
 
                 # Check termination conditions
                 if status_up == terminal_success:
-                    if self._format != ProgressFormat.NONE:
+                    if self._should_render():
                         self._print_completion_message(status_up, steps)
                     return resp
 
                 if status_up in terminal_failures:
-                    if self._format != ProgressFormat.NONE:
+                    if self._should_render():
                         self._print_completion_message(status_up, steps)
                     return resp
 
                 if self.max_polls is not None and self._poll_count >= self.max_polls:
-                    if self._format != ProgressFormat.NONE:
+                    if self._should_render():
                         self._print_completion_message("MAX_POLLS", steps)
                     return resp
 
@@ -989,7 +1091,7 @@ class AgentProgressTracker:
                         timeout,
                         status_up or "UNKNOWN",
                     )
-                    if self._format != ProgressFormat.NONE:
+                    if self._should_render():
                         self._print_completion_message("TIMEOUT", steps)
                     raise TimeoutError(
                         f"Operation timed out after {timeout} seconds (last status: {status_up or 'UNKNOWN'})"
@@ -999,6 +1101,4 @@ class AgentProgressTracker:
                 interval = next_wait(interval)
 
         finally:
-            self._stop_display.set()
-            if self._display_thread and self._display_thread.is_alive():
-                self._display_thread.join(timeout=1.0)
+            self.stop()

--- a/aixplain/v2/agent_progress.py
+++ b/aixplain/v2/agent_progress.py
@@ -129,6 +129,10 @@ class AgentProgressTracker:
     # wedged render can never block the caller's run from returning.
     DISPLAY_JOIN_TIMEOUT = 1.0
 
+    # Named so a survivor is identifiable in a thread dump instead of being one
+    # more anonymous ``Thread-N``.
+    DISPLAY_THREAD_NAME = "aixplain-progress-display"
+
     def __init__(
         self,
         poll_func: Callable[[str], Any],
@@ -789,6 +793,14 @@ class AgentProgressTracker:
             force_display: Override the terminal auto-detection for this run.
                 ``None`` keeps whatever was passed to ``__init__``.
         """
+        # Tear down any thread a previous start() left running. Without this a
+        # second start() -- which ``stream_progress`` performs on every call --
+        # cleared the stop event and overwrote ``_display_thread``, dropping the
+        # only reference to the first thread while it kept printing: two
+        # spinners interleaving on one fd, and the same lost-reference shape as
+        # the original leak (BUG-943).
+        self.stop()
+
         # Reset tracking state
         self._seen_steps = {}
         self._first_seen = {}
@@ -821,7 +833,11 @@ class AgentProgressTracker:
         # terminal, where the thread would print log garbage 20 times a second
         # for the life of the run (BUG-943).
         if self._should_render() and not self._is_notebook:
-            self._display_thread = threading.Thread(target=self._display_refresh_loop, daemon=True)
+            self._display_thread = threading.Thread(
+                target=self._display_refresh_loop,
+                name=self.DISPLAY_THREAD_NAME,
+                daemon=True,
+            )
             self._display_thread.start()
 
     def _update_metrics(self, steps: List[Dict]) -> None:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -1703,9 +1703,11 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
     # (BUG-1091).
     #
     # The ``progress_*`` trio configures the client-side progress display (the
-    # ``show_progress`` toggle already lived here). ``before_run`` / ``after_run``
-    # still receive the *unfiltered* kwargs, so the tracker keeps seeing them —
-    # only the payload/URL builders are filtered.
+    # ``show_progress`` toggle already lived here) and ``_progress_tracker`` is
+    # the live display object an owning ``run()`` hands down to ``on_poll``.
+    # ``before_run`` / ``after_run`` / ``on_poll`` still receive the
+    # *unfiltered* kwargs, so the tracker keeps seeing them — only the
+    # payload/URL builders are filtered.
     _RUN_CONTROL_KEYS: frozenset[str] = (
         frozenset(
             {
@@ -1717,6 +1719,7 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                 "progress_format",
                 "progress_verbosity",
                 "progress_truncate",
+                "_progress_tracker",
                 "session_id",
                 "agent_name",
             }
@@ -1978,7 +1981,7 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
 
     def after_run(
         self,
-        result: Union[ResultT, Exception],
+        result: Union[ResultT, BaseException],
         *args: Any,
         **kwargs: Unpack[RunParamsT],
     ) -> Optional[ResultT]:
@@ -1987,15 +1990,19 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         Override this method to add custom logic after running.
 
         Args:
-            result: The result from the run operation (ResultT on success,
-                   Exception on failure)
+            result: The result from the run operation: ``ResultT`` on success,
+                   or the raised ``BaseException`` on failure. This includes
+                   ``KeyboardInterrupt`` and ``SystemExit``, so a hook must test
+                   ``isinstance(result, BaseException)`` rather than
+                   ``Exception`` before treating *result* as a result.
             *args: Positional arguments that were passed to the run operation
             **kwargs: Keyword arguments that were passed to the run operation
 
         Returns:
             Optional[ResultT]: If not None, this result will be returned instead
                              of the original result. If None, the original result
-                             will be returned.
+                             will be returned. On the failure path the return
+                             value is ignored and the exception propagates.
         """
         return None
 

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -2016,10 +2016,13 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
             watching an already-running job raises instead of starting — and
             billing — a second execution.
 
-            ``after_run`` runs exactly once per ``run()`` call on *every* exit
-            path, including submission and polling failures, so whatever
-            ``before_run`` started is always torn down. On the failure path its
-            return value is ignored and the original exception propagates.
+            ``after_run`` runs exactly once per ``run()`` call on every exit
+            path from the run itself -- success, submission failure, polling
+            failure -- so whatever ``before_run`` started is always torn down.
+            On the failure path its return value is ignored and the original
+            exception propagates. The one path it does not cover is
+            ``before_run`` raising: nothing has been set up yet, so a hook must
+            not leave a resource live behind a raise of its own.
         """
         early = self._begin_run(**kwargs)
         if early is not None:

--- a/aixplain/v2/resource.py
+++ b/aixplain/v2/resource.py
@@ -1850,6 +1850,27 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
                 return custom_result
         return result
 
+    def _apply_after_run_failure(self, error: BaseException, **kwargs: Unpack[RunParamsT]) -> None:
+        """Invoke ``after_run`` with a failure, discarding its return value.
+
+        ``run()`` had no exception handling at all, so ``sync_poll``'s
+        ``TimeoutError`` and terminal ``APIError``s bypassed ``after_run`` and
+        any teardown it owns -- notably the agent progress display thread, which
+        then printed to stdout 20 times a second for the life of the process
+        (BUG-943).
+
+        The hook's return value is deliberately ignored: a hook may not turn a
+        raised run into a returned result. A hook that itself raises is logged
+        and swallowed so it can never mask the caller's original exception.
+        """
+        after_method = getattr(self, "after_run", None)
+        if after_method is None:
+            return
+        try:
+            after_method(error, **kwargs)
+        except Exception:
+            logger.warning("after_run hook raised while handling %r", error, exc_info=True)
+
     def build_run_payload(self, **kwargs: Unpack[RunParamsT]) -> dict:
         """Build the payload for the run action.
 
@@ -1994,17 +2015,28 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
             polling happens outside the retry boundary, so a failure while
             watching an already-running job raises instead of starting — and
             billing — a second execution.
+
+            ``after_run`` runs exactly once per ``run()`` call on *every* exit
+            path, including submission and polling failures, so whatever
+            ``before_run`` started is always torn down. On the failure path its
+            return value is ignored and the original exception propagates.
         """
         early = self._begin_run(**kwargs)
         if early is not None:
             return self._apply_after_run(early, **kwargs)
 
-        result = self._submit_with_retries(**kwargs)
-        if result.url and not result.completed:
-            request_id = getattr(result, "request_id", None)
-            result = self.sync_poll(result.url, **kwargs)
-            if request_id is not None and hasattr(result, "request_id") and not result.request_id:
-                result.request_id = request_id
+        try:
+            result = self._submit_with_retries(**kwargs)
+            if result.url and not result.completed:
+                request_id = getattr(result, "request_id", None)
+                result = self.sync_poll(result.url, **kwargs)
+                if request_id is not None and hasattr(result, "request_id") and not result.request_id:
+                    result.request_id = request_id
+        except BaseException as exc:
+            # BaseException, not Exception: a Ctrl-C in a notebook leaves the
+            # kernel alive, and with it anything before_run started (BUG-943).
+            self._apply_after_run_failure(exc, **kwargs)
+            raise
         return self._apply_after_run(result, **kwargs)
 
     def run_async(self, **kwargs: Unpack[RunParamsT]) -> ResultT:
@@ -2023,7 +2055,11 @@ class RunnableResourceMixin(BaseMixin, Generic[RunParamsT, ResultT]):
         if early is not None:
             return early
 
-        return self._submit_with_retries(**kwargs)
+        try:
+            return self._submit_with_retries(**kwargs)
+        except BaseException as exc:
+            self._apply_after_run_failure(exc, **kwargs)
+            raise
 
     def poll(self, poll_url: str, timeout: Optional[float] = None) -> ResultT:
         """Poll for the result of an asynchronous operation.

--- a/docs/api-reference/python/aixplain/v2/agent.md
+++ b/docs/api-reference/python/aixplain/v2/agent.md
@@ -385,7 +385,7 @@ Hook called after each poll to update progress display.
 #### after\_run
 
 ```python
-def after_run(result: Union[AgentRunResult, Exception], *args: Any,
+def after_run(result: Union[AgentRunResult, BaseException], *args: Any,
               **kwargs: Unpack[AgentRunParams]) -> Optional[AgentRunResult]
 ```
 

--- a/docs/api-reference/python/aixplain/v2/resource.md
+++ b/docs/api-reference/python/aixplain/v2/resource.md
@@ -895,7 +895,7 @@ Override this method to add custom logic before running.
 #### after\_run
 
 ```python
-def after_run(result: Union[ResultT, Exception], *args: Any,
+def after_run(result: Union[ResultT, BaseException], *args: Any,
               **kwargs: Unpack[RunParamsT]) -> Optional[ResultT]
 ```
 
@@ -907,8 +907,11 @@ Override this method to add custom logic after running.
 
 **Arguments**:
 
-- `result` - The result from the run operation (ResultT on success,
-  Exception on failure)
+- `result` - The result from the run operation: `ResultT` on success,
+  or the raised `BaseException` on failure. This includes
+  `KeyboardInterrupt` and `SystemExit`, so a hook must test
+  `isinstance(result, BaseException)` rather than `Exception`
+  before treating *result* as a result.
 - `*args` - Positional arguments that were passed to the run operation
 - `**kwargs` - Keyword arguments that were passed to the run operation
   
@@ -917,7 +920,8 @@ Override this method to add custom logic after running.
 
 - `Optional[ResultT]` - If not None, this result will be returned instead
   of the original result. If None, the original result
-  will be returned.
+  will be returned. On the failure path the return
+  value is ignored and the exception propagates.
 
 #### run
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -862,7 +862,7 @@ Hook called after each poll to update progress display.
 #### after_run
 
 ```python
-def after_run(result: Union[AgentRunResult, Exception], *args: Any,
+def after_run(result: Union[AgentRunResult, BaseException], *args: Any,
               **kwargs: Unpack[AgentRunParams]) -> Optional[AgentRunResult]
 ```
 
@@ -4693,7 +4693,7 @@ Override this method to add custom logic before running.
 #### after_run
 
 ```python
-def after_run(result: Union[ResultT, Exception], *args: Any,
+def after_run(result: Union[ResultT, BaseException], *args: Any,
               **kwargs: Unpack[RunParamsT]) -> Optional[ResultT]
 ```
 
@@ -4705,8 +4705,11 @@ Override this method to add custom logic after running.
 
 **Arguments**:
 
-- `result` - The result from the run operation (ResultT on success,
-  Exception on failure)
+- `result` - The result from the run operation: `ResultT` on success,
+  or the raised `BaseException` on failure. This includes
+  `KeyboardInterrupt` and `SystemExit`, so a hook must test
+  `isinstance(result, BaseException)` rather than `Exception`
+  before treating *result* as a result.
 - `*args` - Positional arguments that were passed to the run operation
 - `**kwargs` - Keyword arguments that were passed to the run operation
   
@@ -4715,7 +4718,8 @@ Override this method to add custom logic after running.
 
 - `Optional[ResultT]` - If not None, this result will be returned instead
   of the original result. If None, the original result
-  will be returned.
+  will be returned. On the failure path the return
+  value is ignored and the exception propagates.
 
 #### run
 

--- a/tests/unit/v2/test_progress_thread_lifecycle.py
+++ b/tests/unit/v2/test_progress_thread_lifecycle.py
@@ -92,11 +92,25 @@ def assert_all_stopped(created, timeout: float = JOIN_TIMEOUT) -> None:
     assert not leaked, f"leaked progress display threads: {leaked}"
 
 
+def live_display_threads() -> list:
+    """Every progress display thread currently alive, anywhere in the process."""
+    name = AgentProgressTracker.DISPLAY_THREAD_NAME
+    return [t for t in threading.enumerate() if t.name == name and t.is_alive()]
+
+
 def assert_thread_count_restored(before: int, timeout: float = JOIN_TIMEOUT) -> None:
-    """Wait (bounded) for the interpreter's thread count to drop back."""
+    """Wait (bounded) for the interpreter's thread count to drop back.
+
+    Checks the named display threads first: they are the ones this module is
+    about, and naming the survivor is far more useful than reporting a count.
+    The count assertion then catches anything the module started that the name
+    check would miss.
+    """
     deadline = time.monotonic() + timeout
-    while threading.active_count() > before and time.monotonic() < deadline:
+    while (live_display_threads() or threading.active_count() > before) and time.monotonic() < deadline:
         time.sleep(0.01)
+    survivors = live_display_threads()
+    assert not survivors, f"leaked progress display threads: {[t.name for t in survivors]}"
     assert threading.active_count() == before, (
         f"thread count did not return to {before} (now {threading.active_count()}); "
         f"alive: {[t.name for t in threading.enumerate()]}"
@@ -215,6 +229,44 @@ class TestDirectPathFailuresStopTheThread:
 
         assert_all_stopped(trackers)
         assert_thread_count_restored(before)
+
+    def test_failed_run_async_stops_the_thread(self, fake_tty, trackers):
+        """``run_async`` had no teardown on the submit-failure path either."""
+        agent = _runnable_agent()
+        agent._submit_with_retries = MagicMock(side_effect=RuntimeError("POST failed"))
+        before = threading.active_count()
+
+        with pytest.raises(RuntimeError, match="POST failed"):
+            agent.run_async(query="hi", **PROGRESS_KWARGS)
+
+        assert trackers, "the run never built a progress tracker"
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_the_run_local_tracker_still_receives_poll_updates(self, fake_tty, trackers, capsys):
+        """Moving the tracker off ``self`` must not unhook ``on_poll``.
+
+        ``on_poll`` is the only thing that feeds the display, and it now
+        resolves the tracker from the run-local slot rather than the instance.
+        Without this, every other assertion in the module would still pass
+        against a tracker that was simply never fed.
+        """
+        agent = _runnable_agent()
+        steps = [{"agent": {"name": "Responder"}, "api_calls": 1}]
+        agent.poll = MagicMock(
+            side_effect=[
+                _FakeResult(completed=False, status="IN_PROGRESS", steps=steps),
+                _FakeResult(completed=True, status="SUCCESS", steps=steps),
+            ]
+        )
+
+        agent.run(query="hi", wait_time=0.2, **PROGRESS_KWARGS)
+
+        assert len(trackers) == 1
+        tracker = trackers[0]
+        assert tracker._poll_count == 2, "on_poll never reached the run-local tracker"
+        assert tracker._total_api_calls == 1
+        assert capsys.readouterr().out != "", "a TTY run rendered nothing at all"
 
 
 # ---------------------------------------------------------------------------
@@ -484,6 +536,31 @@ class TestRefreshLoop:
 
         assert thread is not None and not thread.is_alive()
         assert capsys.readouterr().out != ""
+
+    def test_a_second_start_does_not_orphan_the_first_thread(self, fake_tty):
+        """``stream_progress`` calls ``start()``; a tracker may already have one.
+
+        The second ``start()`` used to clear the shared stop event and overwrite
+        ``_display_thread``, dropping the only reference to a thread that kept
+        printing -- two spinners interleaving on one fd.
+        """
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
+        tracker.start(format=ProgressFormat.STATUS)
+        first = tracker._display_thread
+        assert first is not None
+
+        tracker.start(format=ProgressFormat.STATUS)
+        second = tracker._display_thread
+        try:
+            assert second is not None and second is not first
+            first.join(timeout=JOIN_TIMEOUT)
+            assert not first.is_alive(), "the first display thread outlived the second start()"
+            assert second.is_alive(), "the second start() must leave a live thread"
+        finally:
+            tracker.stop()
+
+        assert not second.is_alive()
+        assert live_display_threads() == []
 
     def test_stop_is_idempotent_and_safe_when_never_started(self):
         never_started = AgentProgressTracker(poll_func=lambda _: None)

--- a/tests/unit/v2/test_progress_thread_lifecycle.py
+++ b/tests/unit/v2/test_progress_thread_lifecycle.py
@@ -18,11 +18,18 @@ Each leaked thread then printed to stdout 20 times a second for the life of the
 process -- including in non-TTY server containers, where it is pure log garbage
 (hole 4: there was no ``isatty()`` check anywhere in the module).
 
+The fix gives ``Agent.run`` / ``Agent.sync_poll`` sole ownership of the
+tracker for the duration of the call, threads it down to ``on_poll`` as the
+``_progress_tracker`` run kwarg, and gates only the 20 Hz repaint thread on
+``isatty()`` -- the ``logs`` timeline and the completion summary are ordinary
+newline-terminated output and are still written off a terminal.
+
 Every assertion here is bounded: threads are joined with a timeout and the test
 fails loudly naming the survivors, rather than sleeping and hoping.
 """
 
 import io
+import logging
 import sys
 import threading
 import time
@@ -33,6 +40,7 @@ import pytest
 from aixplain.v2 import agent_progress
 from aixplain.v2.agent import Agent
 from aixplain.v2.agent_progress import AgentProgressTracker, ProgressFormat
+from aixplain.v2.exceptions import TimeoutError as AixplainTimeoutError
 from aixplain.v2.session import Session, SessionMessage
 
 JOIN_TIMEOUT = 2.0
@@ -220,18 +228,26 @@ class TestDirectPathFailuresStopTheThread:
         assert_all_stopped(trackers)
         assert_thread_count_restored(before)
 
-    def test_run_async_stops_the_thread(self, fake_tty, trackers):
-        """``run_async`` starts a tracker and never polls -- nobody else stops it."""
+    def test_run_async_starts_no_tracker_and_warns(self, fake_tty, trackers, caplog):
+        """``run_async`` returns at submission: it cannot drive a display.
+
+        It used to start a tracker in ``before_run`` that nothing ever fed or
+        stopped. Now it starts none and says so, pointing at ``sync_poll``.
+        """
         agent = _runnable_agent(submit_result=_FakeResult(url="http://poll/1", completed=False))
         before = threading.active_count()
 
-        agent.run_async(query="hi", **PROGRESS_KWARGS)
+        with caplog.at_level(logging.WARNING, logger="aixplain.v2.agent"):
+            result = agent.run_async(query="hi", **PROGRESS_KWARGS)
 
-        assert_all_stopped(trackers)
-        assert_thread_count_restored(before)
+        assert result.url == "http://poll/1"
+        assert trackers == [], "run_async must not build a tracker it cannot drive"
+        assert threading.active_count() == before
+        assert any("sync_poll" in record.getMessage() for record in caplog.records), (
+            "run_async accepted progress_format silently"
+        )
 
-    def test_failed_run_async_stops_the_thread(self, fake_tty, trackers):
-        """``run_async`` had no teardown on the submit-failure path either."""
+    def test_failed_run_async_leaves_no_thread(self, fake_tty, trackers):
         agent = _runnable_agent()
         agent._submit_with_retries = MagicMock(side_effect=RuntimeError("POST failed"))
         before = threading.active_count()
@@ -239,15 +255,106 @@ class TestDirectPathFailuresStopTheThread:
         with pytest.raises(RuntimeError, match="POST failed"):
             agent.run_async(query="hi", **PROGRESS_KWARGS)
 
-        assert trackers, "the run never built a progress tracker"
+        assert trackers == []
+        assert threading.active_count() == before
+
+    def test_run_async_then_sync_poll_with_progress_renders_and_stops(self, fake_tty, trackers, capsys):
+        """The documented pairing: submit with ``run_async``, watch with ``sync_poll``.
+
+        ``sync_poll`` owns a tracker of its own when handed the progress kwargs
+        and no enclosing ``run()`` is driving it.
+        """
+        agent = _runnable_agent(submit_result=_FakeResult(url="http://poll/1", completed=False))
+        steps = [{"agent": {"name": "Responder"}, "api_calls": 1}]
+        agent.poll = MagicMock(
+            side_effect=[
+                _FakeResult(completed=False, status="IN_PROGRESS", steps=steps),
+                _FakeResult(completed=True, status="SUCCESS", steps=steps),
+            ]
+        )
+        before = threading.active_count()
+
+        submitted = agent.run_async(query="hi")
+        result = agent.sync_poll(submitted.url, wait_time=0.2, **PROGRESS_KWARGS)
+
+        assert result.completed
+        assert len(trackers) == 1, "sync_poll should own exactly one tracker"
+        assert trackers[0]._poll_count == 2, "on_poll never reached sync_poll's tracker"
+        assert trackers[0].started_threads, "a TTY poll should have animated"
+        assert "✓ Completed" in capsys.readouterr().out
         assert_all_stopped(trackers)
         assert_thread_count_restored(before)
 
-    def test_the_run_local_tracker_still_receives_poll_updates(self, fake_tty, trackers, capsys):
+    def test_a_failing_standalone_sync_poll_stops_the_thread(self, fake_tty, trackers):
+        agent = _runnable_agent()
+        before = threading.active_count()
+
+        with pytest.raises(AixplainTimeoutError):
+            agent.sync_poll("http://poll/1", timeout=0, **PROGRESS_KWARGS)
+
+        assert trackers, "sync_poll never built a progress tracker"
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_sync_poll_inside_run_does_not_start_a_second_tracker(self, fake_tty, trackers):
+        """``run()`` calls ``sync_poll`` with the progress kwargs still present."""
+        agent = _runnable_agent()
+        agent.poll = MagicMock(return_value=_FakeResult(completed=True))
+
+        agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert len(trackers) == 1, "the enclosing run() owns the display; sync_poll must not add one"
+        assert_all_stopped(trackers)
+
+    def test_an_after_run_override_that_skips_super_cannot_leak(self, fake_tty, trackers):
+        """Teardown belongs to ``run()``, not to a hook a subclass may replace."""
+        agent = _runnable_agent()
+        agent.after_run = lambda result, *args, **kwargs: None
+        agent.sync_poll = MagicMock(side_effect=[_FakeResult(completed=True), RuntimeError("second run fails")])
+        before = threading.active_count()
+
+        agent.run(query="hi", **PROGRESS_KWARGS)
+        with pytest.raises(RuntimeError):
+            agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert len(trackers) == 2
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_a_nested_progress_less_run_cannot_touch_the_outer_display(self, fake_tty, trackers):
+        """Nothing is shared between runs, so a hook that starts another run is harmless.
+
+        With a context-wide slot, a nested ``run_async()`` without progress
+        adopted and stopped the *outer* run's tracker on its way out.
+        """
+        outer = _runnable_agent()
+        inner = _runnable_agent(submit_result=_FakeResult(url="http://poll/2", completed=False))
+        steps = [{"agent": {"name": "Responder"}, "api_calls": 1}]
+        seen_alive = []
+
+        def poll(url, timeout=None):
+            if not seen_alive:
+                inner.run_async(query="nested")
+                seen_alive.append(trackers[0].started_threads[0].is_alive())
+                return _FakeResult(completed=False, status="IN_PROGRESS", steps=steps)
+            return _FakeResult(completed=True, status="SUCCESS", steps=steps)
+
+        outer.poll = poll
+        before = threading.active_count()
+
+        outer.run(query="hi", wait_time=0.2, **PROGRESS_KWARGS)
+
+        assert len(trackers) == 1, "the nested progress-less run must not build a tracker"
+        assert seen_alive == [True], "the nested run stopped the outer display"
+        assert trackers[0]._poll_count == 2
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_the_run_owned_tracker_still_receives_poll_updates(self, fake_tty, trackers, capsys):
         """Moving the tracker off ``self`` must not unhook ``on_poll``.
 
         ``on_poll`` is the only thing that feeds the display, and it now
-        resolves the tracker from the run-local slot rather than the instance.
+        receives the tracker as a run kwarg rather than reading the instance.
         Without this, every other assertion in the module would still pass
         against a tracker that was simply never fed.
         """
@@ -264,7 +371,7 @@ class TestDirectPathFailuresStopTheThread:
 
         assert len(trackers) == 1
         tracker = trackers[0]
-        assert tracker._poll_count == 2, "on_poll never reached the run-local tracker"
+        assert tracker._poll_count == 2, "on_poll never reached the run's tracker"
         assert tracker._total_api_calls == 1
         assert capsys.readouterr().out != "", "a TTY run rendered nothing at all"
 
@@ -363,21 +470,53 @@ def test_concurrent_runs_on_one_agent_leave_no_thread(fake_tty, trackers):
 
 
 class TestTtyGate:
-    """A pipe is not a human: off a terminal, print nothing and start nothing."""
+    """A pipe is not a human: off a terminal, no repaint thread.
 
-    def test_non_tty_run_emits_nothing_and_starts_no_thread(self, trackers, capsys):
+    Only the 20 Hz carriage-return animation is gated. The ``logs`` timeline and the
+    completion summary are written from the caller's thread with ordinary
+    newlines, and a CI log or a ``tee`` must still get them in full.
+    """
+
+    def test_non_tty_run_starts_no_thread_but_still_prints_the_summary(self, trackers, capsys):
+        assert not agent_progress._stdout_is_tty(), "capsys should not look like a terminal"
         agent = _runnable_agent()
-        agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
+        agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True, steps=[{"agent": {"name": "A"}}]))
         before = threading.active_count()
 
         agent.run(query="hi", **PROGRESS_KWARGS)
 
         assert trackers, "the run never built a progress tracker"
         assert all(tracker.started_threads == [] for tracker in trackers)
-        assert capsys.readouterr().out == ""
+        out = capsys.readouterr().out
+        assert "✓ Completed 1 steps" in out
+        assert out.endswith("\n")
         assert threading.active_count() == before
 
-    def test_non_tty_tracker_prints_nothing_across_its_whole_lifecycle(self, capsys):
+    def test_logs_format_under_a_pipe_prints_the_full_timeline(self, trackers, capsys):
+        """A run piped through ``tee`` or into a CI log keeps its step timeline."""
+        assert not agent_progress._stdout_is_tty()
+        agent = _runnable_agent()
+        running = [{"agent": {"name": "Researcher"}, "api_calls": 1}]
+        done = [{"agent": {"name": "Researcher"}, "api_calls": 1, "output": "found it", "used_credits": 0.5}]
+        agent.poll = MagicMock(
+            side_effect=[
+                _FakeResult(completed=False, status="IN_PROGRESS", steps=running),
+                _FakeResult(completed=True, status="SUCCESS", steps=done),
+            ]
+        )
+        before = threading.active_count()
+
+        agent.run(query="hi", wait_time=0.2, progress_format="logs")
+
+        assert all(tracker.started_threads == [] for tracker in trackers)
+        out = capsys.readouterr().out
+        assert "Researcher" in out, "the logs timeline was suppressed off a terminal"
+        assert "✓ Completed 1 steps" in out
+        assert "$0.5" in out, "the credits summary was suppressed off a terminal"
+        assert threading.active_count() == before
+
+    def test_non_tty_logs_tracker_prints_the_timeline_and_summary_without_a_thread(self, capsys):
+        assert not agent_progress._stdout_is_tty()
         tracker = AgentProgressTracker(poll_func=lambda _: None)
         response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
 
@@ -386,47 +525,87 @@ class TestTtyGate:
         tracker.finish(response)
 
         assert tracker._display_thread is None
-        assert capsys.readouterr().out == ""
+        out = capsys.readouterr().out
+        assert "A" in out
+        assert "✓ Completed 1 steps" in out
+        assert out.endswith("\n")
 
-    def test_bookkeeping_still_runs_with_the_display_off(self, capsys):
-        """The poll counter and metrics are not display state (BUG-942)."""
+    def test_non_tty_status_tracker_prints_only_the_summary(self, capsys):
+        """Status mode paints from the thread; with no thread only the summary is left."""
+        assert not agent_progress._stdout_is_tty()
         tracker = AgentProgressTracker(poll_func=lambda _: None)
+        response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
+
+        tracker.start(format=ProgressFormat.STATUS)
+        tracker.update(response)
+        assert capsys.readouterr().out == "", "status mode must not paint from the caller thread"
+        tracker.finish(response)
+
+        assert tracker._display_thread is None
+        out = capsys.readouterr().out
+        assert out.startswith("\n✓ Completed 1 steps")
+        assert out.endswith("\n")
+
+    def test_bookkeeping_still_runs_with_the_animation_off(self, fake_tty):
+        """The poll counter and metrics are not display state (BUG-942)."""
+        tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=False)
         response = _FakeResult(steps=[{"agent": {"name": "A"}, "api_calls": 2}])
 
         tracker.start(format=ProgressFormat.LOGS)
         tracker.update(response)
         tracker.update(response)
 
+        assert tracker._display_thread is None
         assert tracker._poll_count == 2
         assert tracker._total_api_calls == 2
-        assert capsys.readouterr().out == ""
 
-    def test_force_display_kwarg_overrides_a_non_tty_stdout(self, capsys):
+    def test_force_display_kwarg_animates_a_non_tty_stdout(self, capsys):
         tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=True)
         response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
 
         tracker.start(format=ProgressFormat.LOGS)
         try:
+            assert tracker._display_thread is not None and tracker._display_thread.is_alive()
             tracker.update(response)
         finally:
             tracker.stop()
 
         assert capsys.readouterr().out != ""
 
-    def test_force_display_env_var_overrides_a_non_tty_stdout(self, monkeypatch, capsys):
-        monkeypatch.setenv("AIXPLAIN_PROGRESS_FORCE_DISPLAY", "1")
+    @pytest.mark.parametrize("value", ["1", "true", "YES", " on "])
+    def test_a_truthy_force_display_env_var_animates_a_non_tty_stdout(self, monkeypatch, value):
+        monkeypatch.setenv("AIXPLAIN_PROGRESS_FORCE_DISPLAY", value)
         tracker = AgentProgressTracker(poll_func=lambda _: None)
-        response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
 
-        tracker.start(format=ProgressFormat.LOGS)
+        tracker.start(format=ProgressFormat.STATUS)
         try:
-            tracker.update(response)
+            assert tracker._display_thread is not None, f"{value!r} should opt in to the animation"
         finally:
             tracker.stop()
 
-        assert capsys.readouterr().out != ""
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "", "maybe"])
+    def test_a_non_truthy_force_display_env_var_leaves_a_real_tty_animated(self, monkeypatch, fake_tty, value):
+        """The variable is an opt-in only: ``false`` is no opinion, not a veto."""
+        monkeypatch.setenv("AIXPLAIN_PROGRESS_FORCE_DISPLAY", value)
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
 
-    def test_force_display_false_silences_a_real_tty(self, fake_tty, capsys):
+        tracker.start(format=ProgressFormat.STATUS)
+        try:
+            assert tracker._display_thread is not None, f"{value!r} disabled the animation on a real TTY"
+        finally:
+            tracker.stop()
+
+    @pytest.mark.parametrize("value", ["false", "0"])
+    def test_a_non_truthy_force_display_env_var_does_not_animate_a_pipe(self, monkeypatch, value):
+        monkeypatch.setenv("AIXPLAIN_PROGRESS_FORCE_DISPLAY", value)
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
+
+        tracker.start(format=ProgressFormat.STATUS)
+        tracker.stop()
+
+        assert tracker._display_thread is None
+
+    def test_force_display_false_stops_the_animation_on_a_real_tty(self, fake_tty, capsys):
         tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=False)
 
         tracker.start(format=ProgressFormat.STATUS)
@@ -562,6 +741,51 @@ class TestRefreshLoop:
         assert not second.is_alive()
         assert live_display_threads() == []
 
+    def test_a_thread_that_outlives_its_join_is_not_re_armed_by_the_next_start(self, caplog):
+        """A painter blocked in ``print()`` (full pipe, paused pager) survives ``stop()``.
+
+        ``start()`` used to ``clear()`` the one shared stop event, which
+        re-armed that survivor alongside the new thread: two painters on one
+        fd and no reference left to join the first. Each ``start()`` now binds
+        a fresh event, so the survivor's own event stays set and it exits the
+        moment ``print()`` returns.
+        """
+        tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=True)
+        tracker.DISPLAY_JOIN_TIMEOUT = 0.05
+        entered = threading.Event()
+        release = threading.Event()
+
+        def stuck_render(steps):
+            entered.set()
+            assert release.wait(timeout=JOIN_TIMEOUT), "test never released the stuck painter"
+
+        tracker._refresh_status_display = stuck_render
+        tracker.start(format=ProgressFormat.STATUS)
+        first = tracker._display_thread
+        assert first is not None
+        tracker.update(_FakeResult(steps=[{"agent": {"name": "A"}}]))
+        assert entered.wait(timeout=JOIN_TIMEOUT), "the painter never reached the render"
+
+        with caplog.at_level(logging.WARNING, logger="aixplain.v2.agent_progress"):
+            tracker.stop()
+        assert first.is_alive(), "precondition: the painter must survive the bounded join"
+        assert any("did not exit" in record.getMessage() for record in caplog.records)
+
+        tracker.start(format=ProgressFormat.STATUS)
+        second = tracker._display_thread
+        assert second is not None and second is not first
+        try:
+            release.set()
+            first.join(timeout=JOIN_TIMEOUT)
+            assert not first.is_alive(), "the surviving painter was re-armed by the next start()"
+            assert second.is_alive()
+        finally:
+            tracker.stop()
+
+        second.join(timeout=JOIN_TIMEOUT)
+        assert not second.is_alive()
+        assert live_display_threads() == []
+
     def test_stop_is_idempotent_and_safe_when_never_started(self):
         never_started = AgentProgressTracker(poll_func=lambda _: None)
         never_started.stop()
@@ -644,13 +868,29 @@ class TestStreamProgressDisplayGate:
 
         assert "progress stream timed out" in capsys.readouterr().out
 
-    @pytest.mark.parametrize("status", ["SUCCESS", "FAILED"])
-    def test_nothing_is_printed_off_a_terminal(self, capsys, status):
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [("SUCCESS", "✓ Completed"), ("FAILED", "✗ Agent failed")],
+        ids=["success", "failure"],
+    )
+    def test_off_a_terminal_the_timeline_and_summary_print_without_a_thread(self, capsys, status, expected):
+        assert not agent_progress._stdout_is_tty()
         tracker = _stream_tracker([_StreamResponse(status, self.STEPS)])
+        started = []
+        real_start = tracker.start
+
+        def spy_start(*args, **kwargs):
+            real_start(*args, **kwargs)
+            started.append(tracker._display_thread)
+
+        tracker.start = spy_start
 
         tracker.stream_progress("http://poll", format=ProgressFormat.LOGS)
 
-        assert capsys.readouterr().out == ""
+        assert started == [None], "stream_progress started a repaint thread off a terminal"
+        out = capsys.readouterr().out
+        assert "A" in out
+        assert expected in out
 
     def test_the_display_thread_is_stopped_even_when_the_loop_raises(self, fake_tty):
         tracker = _stream_tracker([_StreamResponse(steps=self.STEPS)])
@@ -713,6 +953,30 @@ class TestRunSemanticsArePreserved:
         with pytest.raises(RuntimeError, match="original"):
             agent.run(query="hi")
 
+    def test_a_render_error_in_finish_does_not_discard_the_result(self, fake_tty, trackers, monkeypatch, caplog):
+        """The run is complete and billed; a console that cannot print ``✓`` must not lose it.
+
+        ``finish`` here raises *before* stopping the thread, so the test also
+        pins that the owner's teardown still runs after a failed render.
+        """
+        agent = _runnable_agent()
+        expected = _FakeResult(completed=True)
+        agent.sync_poll = MagicMock(return_value=expected)
+
+        def exploding_finish(self, response):
+            raise UnicodeEncodeError("ascii", "✓", 0, 1, "ordinal not in range(128)")
+
+        monkeypatch.setattr(AgentProgressTracker, "finish", exploding_finish)
+        before = threading.active_count()
+
+        with caplog.at_level(logging.WARNING, logger="aixplain.v2.agent"):
+            result = agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert result is expected
+        assert any("completion summary" in record.getMessage() for record in caplog.records)
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
     def test_keyboard_interrupt_also_stops_the_thread(self, fake_tty, trackers):
         """A Ctrl-C in a notebook leaves the kernel -- and the leak -- alive."""
         agent = _runnable_agent()
@@ -731,11 +995,10 @@ class TestRunSemanticsArePreserved:
 # ---------------------------------------------------------------------------
 
 
-def test_progress_tracker_attribute_is_a_read_only_alias(fake_tty):
-    """Kept for out-of-tree readers; a per-instance slot is what caused hole 3."""
+def test_the_agent_holds_no_progress_tracker_state():
+    """A per-instance slot is what caused hole 3; the tracker now lives in the run's kwargs only."""
     agent = _runnable_agent()
-    agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
 
-    assert agent._progress_tracker is None
-    with pytest.raises(AttributeError):
-        agent._progress_tracker = object()
+    assert not hasattr(agent, "_progress_tracker")
+    assert "_progress_tracker" in Agent._RUN_CONTROL_KEYS
+    assert "_progress_tracker" not in agent.build_run_payload(query="hi", _progress_tracker=object())

--- a/tests/unit/v2/test_progress_thread_lifecycle.py
+++ b/tests/unit/v2/test_progress_thread_lifecycle.py
@@ -1,0 +1,664 @@
+"""Thread-lifecycle guarantees for the v2 agent progress display (BUG-943).
+
+``AgentProgressTracker`` starts a daemon thread that repaints a spinner at
+20 FPS, and the only thing that ever stopped it was ``finish()``. Three
+independent holes meant ``finish()`` was routinely never called:
+
+1. ``Agent._finish_progress_tracker`` skipped ``finish()`` when the result was
+   an exception -- *and* then dropped the only reference to the tracker, so
+   nothing could ever stop the thread afterwards.
+2. ``RunnableResourceMixin.run`` had no exception handling at all, so
+   ``sync_poll``'s ``TimeoutError`` and terminal ``APIError``s never reached
+   ``after_run`` in the first place.
+3. The tracker lived on the ``Agent`` instance, so two concurrent ``run()``
+   calls overwrote each other: A's ``finish()`` stopped B's thread and A's span
+   until process exit.
+
+Each leaked thread then printed to stdout 20 times a second for the life of the
+process -- including in non-TTY server containers, where it is pure log garbage
+(hole 4: there was no ``isatty()`` check anywhere in the module).
+
+Every assertion here is bounded: threads are joined with a timeout and the test
+fails loudly naming the survivors, rather than sleeping and hoping.
+"""
+
+import io
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from aixplain.v2 import agent_progress
+from aixplain.v2.agent import Agent
+from aixplain.v2.agent_progress import AgentProgressTracker, ProgressFormat
+from aixplain.v2.session import Session, SessionMessage
+
+JOIN_TIMEOUT = 2.0
+PROGRESS_KWARGS = {"progress_format": "status"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_tty(monkeypatch):
+    """Make the TTY gate answer True so the display thread actually starts.
+
+    The predicate is patched rather than ``sys.stdout`` itself: pytest
+    re-assigns ``sys.stdout`` when it resumes global capture for the call
+    phase, so a monkeypatched stream would be silently replaced and every leak
+    assertion below would pass vacuously against a thread that never started.
+    """
+    monkeypatch.setattr(agent_progress, "_stdout_is_tty", lambda: True)
+
+
+@pytest.fixture
+def trackers(monkeypatch):
+    """Capture every tracker the run path builds, plus the threads it starts.
+
+    The thread has to be recorded at ``start()`` time: teardown nulls
+    ``_display_thread``, so reading it afterwards would hide a leak.
+    """
+    created = []
+    real = agent_progress.AgentProgressTracker
+
+    class _SpyTracker(real):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.started_threads = []
+            created.append(self)
+
+        def start(self, *args, **kwargs):
+            super().start(*args, **kwargs)
+            if self._display_thread is not None:
+                self.started_threads.append(self._display_thread)
+
+    monkeypatch.setattr(agent_progress, "AgentProgressTracker", _SpyTracker)
+    return created
+
+
+def assert_all_stopped(created, timeout: float = JOIN_TIMEOUT) -> None:
+    """Join every display thread the run started; fail naming any survivor."""
+    leaked = []
+    for tracker in created:
+        for thread in tracker.started_threads:
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                leaked.append(thread.name)
+    assert not leaked, f"leaked progress display threads: {leaked}"
+
+
+def assert_thread_count_restored(before: int, timeout: float = JOIN_TIMEOUT) -> None:
+    """Wait (bounded) for the interpreter's thread count to drop back."""
+    deadline = time.monotonic() + timeout
+    while threading.active_count() > before and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert threading.active_count() == before, (
+        f"thread count did not return to {before} (now {threading.active_count()}); "
+        f"alive: {[t.name for t in threading.enumerate()]}"
+    )
+
+
+class _FakeResult:
+    """A poll/submit result shaped enough for the tracker and the run path."""
+
+    def __init__(self, url=None, completed=True, status="SUCCESS", steps=None):
+        self.url = url
+        self.completed = completed
+        self.status = status
+        self.request_id = "req_1"
+        self.session_id = "sess_1"
+        self.data = None
+        self._raw_data = {"data": {"steps": steps or []}}
+        self._context = None
+
+
+def _runnable_agent(submit_result=None):
+    """An Agent whose POST is mocked out, ready for ``run(...)``."""
+    agent = Agent.from_dict({"id": "a1", "name": "t"})
+    agent.context = MagicMock()
+    agent.status = None
+    result = submit_result if submit_result is not None else _FakeResult(url="http://poll/1", completed=False)
+    agent.handle_run_response = lambda response, **kwargs: result
+    return agent
+
+
+def _make_session_agent():
+    """An Agent plus a Session whose ``add_message`` returns a request_id."""
+    ctx = MagicMock(backend_url="https://platform-api.aixplain.com", api_key="k")
+
+    class BoundAgent(Agent):
+        context = ctx
+
+    agent = BoundAgent(id="agent_99", name="A")
+    agent._update_saved_state()
+
+    session = Session(agent_id="agent_99", name="thread")
+    session.id = "sess_1"
+    session.context = ctx
+    session.add_message = MagicMock(
+        return_value=SessionMessage(
+            id="msg_1",
+            session_id="sess_1",
+            user_id="u1",
+            agent_id="agent_99",
+            role="user",
+            content="hi",
+            sequence=1,
+            request_id="req_abc",
+            created_at="2025-06-01T10:01:00Z",
+        )
+    )
+    return agent, session
+
+
+# ---------------------------------------------------------------------------
+# 1. The direct run path stops the thread on every failure mode
+# ---------------------------------------------------------------------------
+
+
+class TestDirectPathFailuresStopTheThread:
+    """``run()`` had no ``try/finally``, so teardown was simply never reached."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RuntimeError("backend blew up"),
+            TimeoutError("Operation timed out after 300 seconds"),
+        ],
+        ids=["raise", "timeout"],
+    )
+    def test_failed_run_leaves_no_display_thread(self, fake_tty, trackers, error):
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(side_effect=error)
+        before = threading.active_count()
+
+        with pytest.raises(type(error)):
+            agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert trackers, "the run never built a progress tracker"
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_failure_before_polling_leaves_no_display_thread(self, fake_tty, trackers):
+        """The submit can fail too -- the tracker is already running by then."""
+        agent = _runnable_agent()
+        agent._submit_with_retries = MagicMock(side_effect=RuntimeError("POST failed"))
+        before = threading.active_count()
+
+        with pytest.raises(RuntimeError):
+            agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_successful_run_still_stops_the_thread(self, fake_tty, trackers):
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
+        before = threading.active_count()
+
+        agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_run_async_stops_the_thread(self, fake_tty, trackers):
+        """``run_async`` starts a tracker and never polls -- nobody else stops it."""
+        agent = _runnable_agent(submit_result=_FakeResult(url="http://poll/1", completed=False))
+        before = threading.active_count()
+
+        agent.run_async(query="hi", **PROGRESS_KWARGS)
+
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+
+# ---------------------------------------------------------------------------
+# 2. The session run path
+# ---------------------------------------------------------------------------
+
+
+class TestSessionPathFailuresStopTheThread:
+    """The session path already had an ``except``; it leaked anyway (hole 1)."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RuntimeError("backend blew up"),
+            TimeoutError("Operation timed out after 300 seconds"),
+        ],
+        ids=["raise", "timeout"],
+    )
+    def test_failed_session_run_leaves_no_display_thread(self, fake_tty, trackers, error):
+        agent, session = _make_session_agent()
+        agent.sync_poll = MagicMock(side_effect=error)
+        before = threading.active_count()
+
+        with pytest.raises(type(error)):
+            agent.run("hi", session=session, **PROGRESS_KWARGS)
+
+        assert trackers, "the session run never built a progress tracker"
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+    def test_successful_session_run_leaves_no_display_thread(self, fake_tty, trackers):
+        agent, session = _make_session_agent()
+        agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
+        before = threading.active_count()
+
+        agent.run("hi", session=session, **PROGRESS_KWARGS)
+
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+
+# ---------------------------------------------------------------------------
+# 3. Concurrency: one Agent, two runs
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_runs_on_one_agent_leave_no_thread(fake_tty, trackers):
+    """Two runs must own two independent trackers and stop both.
+
+    With the tracker on ``self``, B overwrote A; A's ``finish()`` then stopped
+    B's thread while A's spun forever. The barrier guarantees both trackers are
+    live simultaneously, which is exactly the overwrite window.
+    """
+    agent = _runnable_agent()
+    barrier = threading.Barrier(2, timeout=JOIN_TIMEOUT)
+    outcomes = {}
+
+    def sync_poll(url, **kwargs):
+        barrier.wait()
+        if threading.current_thread().name == "run-fails":
+            raise RuntimeError("this one fails")
+        return _FakeResult(completed=True)
+
+    agent.sync_poll = sync_poll
+
+    def worker(name):
+        try:
+            agent.run(query="hi", **PROGRESS_KWARGS)
+            outcomes[name] = "ok"
+        except RuntimeError:
+            outcomes[name] = "raised"
+
+    before = threading.active_count()
+    workers = [
+        threading.Thread(target=worker, args=("run-ok",), name="run-ok"),
+        threading.Thread(target=worker, args=("run-fails",), name="run-fails"),
+    ]
+    for thread in workers:
+        thread.start()
+    for thread in workers:
+        thread.join(timeout=JOIN_TIMEOUT * 2)
+        assert not thread.is_alive(), f"{thread.name} never finished"
+
+    assert outcomes == {"run-ok": "ok", "run-fails": "raised"}
+    assert len(trackers) == 2, f"expected one tracker per run, got {len(trackers)}"
+    assert trackers[0] is not trackers[1]
+    assert_all_stopped(trackers)
+    assert_thread_count_restored(before)
+
+
+# ---------------------------------------------------------------------------
+# 4. The TTY gate
+# ---------------------------------------------------------------------------
+
+
+class TestTtyGate:
+    """A pipe is not a human: off a terminal, print nothing and start nothing."""
+
+    def test_non_tty_run_emits_nothing_and_starts_no_thread(self, trackers, capsys):
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
+        before = threading.active_count()
+
+        agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert trackers, "the run never built a progress tracker"
+        assert all(tracker.started_threads == [] for tracker in trackers)
+        assert capsys.readouterr().out == ""
+        assert threading.active_count() == before
+
+    def test_non_tty_tracker_prints_nothing_across_its_whole_lifecycle(self, capsys):
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
+        response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
+
+        tracker.start(format=ProgressFormat.LOGS)
+        tracker.update(response)
+        tracker.finish(response)
+
+        assert tracker._display_thread is None
+        assert capsys.readouterr().out == ""
+
+    def test_bookkeeping_still_runs_with_the_display_off(self, capsys):
+        """The poll counter and metrics are not display state (BUG-942)."""
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
+        response = _FakeResult(steps=[{"agent": {"name": "A"}, "api_calls": 2}])
+
+        tracker.start(format=ProgressFormat.LOGS)
+        tracker.update(response)
+        tracker.update(response)
+
+        assert tracker._poll_count == 2
+        assert tracker._total_api_calls == 2
+        assert capsys.readouterr().out == ""
+
+    def test_force_display_kwarg_overrides_a_non_tty_stdout(self, capsys):
+        tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=True)
+        response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
+
+        tracker.start(format=ProgressFormat.LOGS)
+        try:
+            tracker.update(response)
+        finally:
+            tracker.stop()
+
+        assert capsys.readouterr().out != ""
+
+    def test_force_display_env_var_overrides_a_non_tty_stdout(self, monkeypatch, capsys):
+        monkeypatch.setenv("AIXPLAIN_PROGRESS_FORCE_DISPLAY", "1")
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
+        response = _FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}])
+
+        tracker.start(format=ProgressFormat.LOGS)
+        try:
+            tracker.update(response)
+        finally:
+            tracker.stop()
+
+        assert capsys.readouterr().out != ""
+
+    def test_force_display_false_silences_a_real_tty(self, fake_tty, capsys):
+        tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=False)
+
+        tracker.start(format=ProgressFormat.STATUS)
+        tracker.update(_FakeResult(steps=[{"agent": {"name": "A"}, "output": "done"}]))
+
+        assert tracker._display_thread is None
+        assert capsys.readouterr().out == ""
+
+    def test_notebook_path_still_renders_without_a_tty(self, monkeypatch, capsys):
+        """ipykernel's stdout is not a tty but is very much a display."""
+        monkeypatch.setattr(agent_progress, "_is_notebook_environment", lambda: True)
+        tracker = AgentProgressTracker(poll_func=lambda _: None)
+        assert tracker._is_notebook
+
+        tracker.start(format=ProgressFormat.STATUS)
+        tracker.update(_FakeResult(steps=[{"agent": {"name": "A"}}]))
+
+        # Notebooks never used the background thread; they repaint synchronously.
+        assert tracker._display_thread is None
+        assert capsys.readouterr().out != ""
+
+    def test_a_closed_stdout_is_not_a_tty(self, monkeypatch):
+        """A detached or replaced stream must answer False, never raise."""
+        stream = io.StringIO()
+        stream.close()
+        monkeypatch.setattr(sys, "stdout", stream)
+
+        assert agent_progress._stdout_is_tty() is False
+
+        monkeypatch.setattr(sys, "stdout", None)
+        assert agent_progress._stdout_is_tty() is False
+
+
+# ---------------------------------------------------------------------------
+# 5. The refresh loop: lock released before waiting, immediate shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshLoop:
+    """``update()`` takes ``_display_lock`` too -- holding it across the sleep
+    made every leaked tracker throttle the live run that followed it."""
+
+    @staticmethod
+    def _slow_tracker():
+        """A started tracker whose refresh interval is far longer than any bound."""
+        tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=True)
+        tracker.DISPLAY_REFRESH_RATE = 5.0
+        tracker.start(format=ProgressFormat.STATUS)
+        return tracker
+
+    def test_display_lock_is_free_during_a_refresh_cycle(self):
+        tracker = self._slow_tracker()
+        try:
+            # Repeated so the check cannot slip through the microsecond gap
+            # between two iterations of a lock-holding loop.
+            for attempt in range(5):
+                acquired = tracker._display_lock.acquire(timeout=0.5)
+                assert acquired, f"_display_lock was held across the refresh interval (attempt {attempt})"
+                tracker._display_lock.release()
+        finally:
+            tracker.stop()
+
+    def test_stop_returns_immediately_at_a_long_refresh_rate(self):
+        tracker = self._slow_tracker()
+        thread = tracker._display_thread
+        assert thread is not None
+
+        started = time.monotonic()
+        tracker.stop()
+        elapsed = time.monotonic() - started
+
+        assert not thread.is_alive(), "the display thread outlived stop()"
+        assert elapsed < 1.0, f"stop() waited {elapsed:.2f}s; Event.wait should be immediate"
+
+    @pytest.mark.parametrize("fmt", [ProgressFormat.STATUS, ProgressFormat.LOGS], ids=["status", "logs"])
+    def test_the_thread_renders_a_frame_and_still_exits_promptly(self, fake_tty, capsys, fmt):
+        """The rewritten loop must keep repainting -- and keep the lock free.
+
+        This is the 20 Hz printer itself: with data present it renders outside
+        the lock, so ``update()`` and ``stop()`` are never blocked by a frame.
+        """
+        painted = threading.Event()
+        tracker = AgentProgressTracker(poll_func=lambda _: None, force_display=True)
+        real_status = tracker._refresh_status_display
+        real_logs = tracker._refresh_logs_display
+
+        def spy_status(steps):
+            real_status(steps)
+            painted.set()
+
+        def spy_logs(steps):
+            real_logs(steps)
+            painted.set()
+
+        tracker._refresh_status_display = spy_status
+        tracker._refresh_logs_display = spy_logs
+
+        tracker.start(format=fmt)
+        try:
+            tracker.update(_FakeResult(steps=[{"agent": {"name": "Responder"}, "api_calls": 1}]))
+            assert painted.wait(timeout=JOIN_TIMEOUT), "the display thread never rendered a frame"
+            assert tracker._display_lock.acquire(timeout=0.5), "_display_lock was held across a render"
+            tracker._display_lock.release()
+        finally:
+            thread = tracker._display_thread
+            tracker.stop()
+
+        assert thread is not None and not thread.is_alive()
+        assert capsys.readouterr().out != ""
+
+    def test_stop_is_idempotent_and_safe_when_never_started(self):
+        never_started = AgentProgressTracker(poll_func=lambda _: None)
+        never_started.stop()
+        never_started.stop()
+
+        disabled = AgentProgressTracker(poll_func=lambda _: None, force_display=True)
+        disabled.start(format=ProgressFormat.NONE)
+        disabled.stop()
+        disabled.stop()
+
+        assert disabled._display_thread is None
+
+    def test_finish_after_an_error_renders_nothing_but_still_stops(self, fake_tty, capsys):
+        """An errored run stops cleanly; it does not print a completion summary."""
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(side_effect=RuntimeError("nope"))
+
+        with pytest.raises(RuntimeError):
+            agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert "Completed" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# 6. stream_progress: the standalone loop is gated and torn down the same way
+# ---------------------------------------------------------------------------
+
+
+class _StreamResponse:
+    """A poll response for ``stream_progress``: a status and optional steps."""
+
+    def __init__(self, status="IN_PROGRESS", steps=None):
+        self.status = status
+        self._raw_data = {"data": {"steps": steps or []}}
+
+
+def _stream_tracker(responses, **kwargs):
+    """A tracker whose poll returns *responses* in order, then repeats the last."""
+    calls = []
+
+    def poll(url):
+        calls.append(url)
+        return responses[min(len(calls) - 1, len(responses) - 1)]
+
+    tracker = AgentProgressTracker(poll_func=poll, poll_interval=0.0, **kwargs)
+    return tracker
+
+
+class TestStreamProgressDisplayGate:
+    """``stream_progress`` owns its own loop; it must obey the same gate."""
+
+    STEPS = [{"agent": {"name": "A"}, "output": "done", "api_calls": 1}]
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [("SUCCESS", "✓ Completed"), ("FAILED", "✗ Agent failed")],
+        ids=["success", "failure"],
+    )
+    def test_terminal_status_prints_a_summary_when_display_is_on(self, capsys, status, expected):
+        tracker = _stream_tracker([_StreamResponse(status, self.STEPS)], force_display=True)
+
+        tracker.stream_progress("http://poll", format=ProgressFormat.LOGS)
+
+        assert expected in capsys.readouterr().out
+        assert tracker._display_thread is None
+
+    def test_max_polls_prints_a_summary_when_display_is_on(self, capsys):
+        tracker = _stream_tracker([_StreamResponse(steps=self.STEPS)], max_polls=2, force_display=True)
+
+        tracker.stream_progress("http://poll", format=ProgressFormat.LOGS)
+
+        assert "reached max polling limit" in capsys.readouterr().out
+        assert tracker._poll_count == 2
+
+    def test_timeout_prints_a_summary_and_still_raises(self, capsys):
+        tracker = _stream_tracker([_StreamResponse(steps=self.STEPS)], force_display=True)
+
+        with pytest.raises(TimeoutError):
+            tracker.stream_progress("http://poll", format=ProgressFormat.LOGS, timeout=0.0)
+
+        assert "progress stream timed out" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("status", ["SUCCESS", "FAILED"])
+    def test_nothing_is_printed_off_a_terminal(self, capsys, status):
+        tracker = _stream_tracker([_StreamResponse(status, self.STEPS)])
+
+        tracker.stream_progress("http://poll", format=ProgressFormat.LOGS)
+
+        assert capsys.readouterr().out == ""
+
+    def test_the_display_thread_is_stopped_even_when_the_loop_raises(self, fake_tty):
+        tracker = _stream_tracker([_StreamResponse(steps=self.STEPS)])
+        tracker.start(format=ProgressFormat.STATUS)
+        thread = tracker._display_thread
+        assert thread is not None, "the tty gate should have started a display thread"
+
+        def exploding_poll(url):
+            raise RuntimeError("poll died")
+
+        tracker.poll = exploding_poll
+        with pytest.raises(RuntimeError, match="poll died"):
+            tracker.stream_progress("http://poll", format=ProgressFormat.STATUS)
+
+        thread.join(timeout=JOIN_TIMEOUT)
+        assert not thread.is_alive()
+        assert tracker._display_thread is None
+
+
+# ---------------------------------------------------------------------------
+# 7. The run() teardown must not change what run() returns or raises
+# ---------------------------------------------------------------------------
+
+
+class TestRunSemanticsArePreserved:
+    """Teardown is additive: it may not swallow, substitute, or reorder."""
+
+    def test_run_returns_the_after_run_result_unchanged(self):
+        agent = _runnable_agent()
+        expected = _FakeResult(completed=True)
+        agent.sync_poll = MagicMock(return_value=expected)
+
+        assert agent.run(query="hi") is expected
+
+    def test_after_run_may_still_substitute_the_result_on_success(self):
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
+        substitute = _FakeResult(completed=True)
+        agent.after_run = lambda result, *args, **kwargs: substitute
+
+        assert agent.run(query="hi") is substitute
+
+    def test_after_run_cannot_turn_a_raise_into_a_return(self):
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(side_effect=RuntimeError("boom"))
+        agent.after_run = lambda result, *args, **kwargs: _FakeResult(completed=True)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            agent.run(query="hi")
+
+    def test_a_raising_after_run_hook_cannot_mask_the_original_exception(self):
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(side_effect=RuntimeError("original"))
+
+        def exploding_after_run(result, *args, **kwargs):
+            raise ValueError("teardown blew up")
+
+        agent.after_run = exploding_after_run
+
+        with pytest.raises(RuntimeError, match="original"):
+            agent.run(query="hi")
+
+    def test_keyboard_interrupt_also_stops_the_thread(self, fake_tty, trackers):
+        """A Ctrl-C in a notebook leaves the kernel -- and the leak -- alive."""
+        agent = _runnable_agent()
+        agent.sync_poll = MagicMock(side_effect=KeyboardInterrupt())
+        before = threading.active_count()
+
+        with pytest.raises(KeyboardInterrupt):
+            agent.run(query="hi", **PROGRESS_KWARGS)
+
+        assert_all_stopped(trackers)
+        assert_thread_count_restored(before)
+
+
+# ---------------------------------------------------------------------------
+# 8. Structural guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_progress_tracker_attribute_is_a_read_only_alias(fake_tty):
+    """Kept for out-of-tree readers; a per-instance slot is what caused hole 3."""
+    agent = _runnable_agent()
+    agent.sync_poll = MagicMock(return_value=_FakeResult(completed=True))
+
+    assert agent._progress_tracker is None
+    with pytest.raises(AttributeError):
+        agent._progress_tracker = object()


### PR DESCRIPTION
## Summary

The v2 agent progress display starts a daemon thread that repaints stdout at 20 Hz, and the only thing that ever stopped it was `AgentProgressTracker.finish()`. Four independent holes meant that call was routinely never made, so every failed, timed-out or concurrent agent run with `progress_format` set leaked a thread that kept printing `\r`-terminated lines for the life of the process — interleaving with and corrupting every other line on the same fd, including in non-TTY server containers where the output is pure log garbage.

All four holes were re-located and confirmed on this branch before any change, and none of the merged BUG-942 `stream_progress` work (deadline, `TimeoutError` on expiry, unconditional `_poll_count`) is undone.

## Design

**One frame owns the tracker.** `Agent.run`, `Agent.sync_poll` (standalone) and the session path each start the tracker, run the poll inside a single `try/except BaseException: tracker.stop(); raise`, and render the completion summary on success. The tracker reaches `on_poll` as the `_progress_tracker` run kwarg, a `_RUN_CONTROL_KEYS` entry that `_payload_kwargs_for_run` / `build_run_payload` strip before anything is posted. `run()` calls `sync_poll` with the key present, which tells `sync_poll` that an enclosing owner is driving the display and not to start a second one.

Consequences:

- `before_run` no longer starts anything and `after_run` no longer tears anything down, so an `after_run` override that skips `super()` cannot leak the thread.
- Nothing is shared between runs, on the instance or in a context, so a nested progress-less `run_async()` fired from a hook cannot adopt, stop or print the outer run's display. Two concurrent `run()` calls on one `Agent` get two independent trackers.
- There is no ContextVar, no reset token on the tracker, no `_unbind`/`_stop` helper pair and no `_progress_tracker` property. The dataclass field is deleted outright: `grep -rn _progress_tracker` finds no reader outside `agent.py`.
- `Agent.run` calls `super().run` directly, so the shared `build_run_payload` warning `stacklevel` still resolves to the caller's line on both `run()` and `run_async()`.

**`run_async` + `sync_poll`.** `run_async` returns as soon as the run is submitted; it cannot drive a display, so it starts none. It still accepts `progress_format` (nothing breaks) but logs a warning saying so and pointing at the replacement: pass the progress kwargs to the poll, `agent.sync_poll(r.url, progress_format="status")`, which owns its own tracker for the duration of the poll. This is a documented change from base, where `run_async(progress_format=...)` bound a tracker to the instance that the user's later `sync_poll` fed and nothing ever stopped. The `run_async` and `sync_poll` docstrings describe the new pairing.

**TTY gate on the animation only.** `isatty()` (or a notebook, or an explicit override) decides whether the 20 Hz repaint thread starts. The `logs` step timeline and the newline-terminated completion summary are ordinary caller-thread output and are written regardless, so `progress_format="logs"` under CI or `tee` still yields the full timeline and credits summary; `status` mode off a terminal yields just the summary line. Overrides: `AgentProgressTracker(force_display=…)` and `AIXPLAIN_PROGRESS_FORCE_DISPLAY`, the latter a pure opt-in — only `1`/`true`/`yes`/`on` count, `false` or `0` leave auto-detection in charge.

**Fresh stop event per `start()`.** A painter blocked in `print()` (full pipe, paused pager) can outlive the bounded join in `stop()`. `start()` used to `clear()` the one shared event, re-arming that survivor next to the new thread. Each `start()` now hands its thread its own `Event`; the survivor's stays set and it exits the moment `print()` returns.

**Render failures never discard a result.** A `UnicodeEncodeError` printing `✓` on an ascii console or a `BrokenPipeError` in the summary line is logged at WARNING and the completed, billed result is returned; the thread is still stopped.

**Widened hook contract.** `after_run` is reached on the failure path with the raised exception, which can be a `KeyboardInterrupt` or `SystemExit`. `RunnableResourceMixin.after_run`, its docstring and `docs/api-reference/python/aixplain/v2/resource.md` / `agent.md` / `llms-full.txt` now promise `Union[ResultT, BaseException]`, matching `Agent.after_run`, and say the return value is ignored on the failure path.

## Per-item status

| # | Suggested fix | Status | Where |
| - | ------------- | ------ | ----- |
| 1 | `_finish_progress_tracker` must always stop and join the thread | Fixed | `AgentProgressTracker.stop()` is the single unconditional exit. The owner calls it on any exception and `finish()` (which calls it first) on success. An errored run stops cleanly and prints no completion summary. |
| 2 | `RunnableResourceMixin.run` needs `try/finally` | Fixed | `run()` / `run_async()` wrap their body in `except BaseException → _apply_after_run_failure(exc) → raise`, so `after_run` sees every outcome. The hook's return value is ignored on the failure path and a raising hook cannot mask the original error. The progress display no longer depends on this: `Agent.run` owns it directly. |
| 3 | Make the tracker run-local | Fixed | Owned by the calling frame and passed as a run kwarg; no instance or context state at all. |
| 4 | Gate the display thread on `sys.stdout.isatty()` | Fixed | Thread start only. Caller-thread `logs` timeline and completion summary still print off a terminal. |
| 5 | Don't hold `_display_lock` across the sleep; use `Event.wait` | Fixed | The loop copies the snapshot under the lock, renders and waits outside it, parked on its own per-start `Event`. `stop()` is observed in microseconds. |
| — | `run_async` starts a tracker nothing ever stops | Fixed | It starts none; see the `run_async` + `sync_poll` section. |
| — | A second `start()` orphaned the first thread | Fixed | `start()` calls `stop()` first and binds a fresh `Event`, so neither a stopped nor a stuck predecessor is ever re-armed. |

## Behaviour changes (intentional)

- **`run_async(progress_format=...)` no longer produces a display.** It logs a warning; pass the progress kwargs to `sync_poll(result.url, ...)` instead. At base this pairing rendered a spinner and then leaked the thread.
- **Off a terminal, the spinner animation is suppressed; the `logs` timeline and the completion summary are not.** Opt the animation back in with `AIXPLAIN_PROGRESS_FORCE_DISPLAY=1` or `AgentProgressTracker(..., force_display=True)`.
- A run that raises no longer prints a completion summary. It never printed a correct one — `finish()` was skipped entirely; now the thread also stops.
- `RunnableResourceMixin.after_run` may receive any `BaseException`, not only `Exception`; hooks written to the old contract that test `isinstance(result, Exception)` should test `BaseException`.
- No public signature is broken. `force_display` is a new trailing optional parameter on `__init__`/`start`; `stop()` is new; `_progress_tracker` is a new private run kwarg; the `Agent._progress_tracker` field (private, `init=False`, excluded from serialization, no reader outside `agent.py`) is removed.

## Test evidence

`tests/unit/v2/test_progress_thread_lifecycle.py`, **59 tests**. Every thread assertion is bounded — joins with a timeout and fails naming the survivors, never sleep-and-hope. The TTY fixture patches the gate predicate rather than `sys.stdout`, because pytest re-assigns `sys.stdout` when it resumes global capture for the call phase.

- Raising run, timing-out run, submission failure and `KeyboardInterrupt` leave no display thread and restore `threading.active_count()`, on both the direct and the session path.
- `run_async(progress_format=...)` builds no tracker and logs the warning; `run_async` then `sync_poll(url, progress_format=...)` renders, is fed on every poll and stops; a failing standalone `sync_poll` stops; `sync_poll` inside `run()` starts no second tracker.
- An `after_run` override that skips `super()` cannot leak, on success or failure. A nested progress-less `run_async()` from inside the outer run's poll leaves the outer display alive, fed and stopped on time.
- Two concurrent `run()` calls on one `Agent` build two distinct trackers and leave neither thread alive.
- Off a terminal: `run(progress_format="logs")` prints the step timeline, the `✓ Completed` line and the credits, and starts no thread; `status` mode prints only the summary; `stream_progress` prints the timeline and summary with no thread. `force_display=True` and every truthy env value start the thread off a terminal; `false`, `0`, `no`, `off`, empty and junk neither disable a real TTY nor enable a pipe.
- A painter that survives a timed-out join is not re-armed by the next `start()`; the second `start()` still gets a live thread and both are dead after `stop()`.
- A `finish()` that raises `UnicodeEncodeError` before stopping its thread: the run returns the result, logs the warning and the thread is still stopped.
- `run()` cannot swallow the exception, substitute a result on failure, or let a raising `after_run` mask the original error; `after_run` may still substitute on success.
- Structural: `Agent` has no `_progress_tracker` attribute; `_progress_tracker` is in `_RUN_CONTROL_KEYS` and never appears in `build_run_payload` output.

```
$ python -m pytest tests/unit -q
2743 passed, 152 warnings in 35.16s

$ ruff check aixplain/v2 && ruff format --check aixplain/v2
All checks passed!
30 files already formatted

$ coverage report --include="aixplain/v2/agent_progress.py"
before (development): 565 stmts, 344 miss, 39%
after:                592 stmts, 221 miss, 63%
```

The remaining uncovered lines are verbosity-2/3 text formatting (`_get_label`, `_truncate_text`, `_print_step_details`, `_print_token_usage`, the `_format_step_line` branches), display formatting this PR does not touch.

## Follow-ups, not in this PR

- Should the display thread exist at all on the TTY path? Notebooks already repaint synchronously from `update()`, and the poll cadence is now ≥0.5 s after BUG-942. Deleting the thread would remove this bug class permanently at the cost of spinner smoothness.
- A suite-wide autouse leak guard asserting `threading.active_count()` is restored after every `tests/unit` test would catch the next such regression anywhere in the SDK, but risks flaking on unrelated tests that spawn threads.

Jira: https://aixplain.atlassian.net/browse/BUG-943
