### PR TITLE
fix(cache): stop persisting the API key and harden the asset cache (BUG-940)

### DIFF
--- a/aixplain/utils/asset_cache.py
+++ b/aixplain/utils/asset_cache.py
@@ -3,20 +3,37 @@
 This module provides a generic caching system for aiXplain assets (Models, Pipelines,
 Agents, etc.) with file-based persistence, automatic serialization, expiration,
 and thread-safe operations.
+
+Security notes (BUG-940):
+    * The cache lives under the per-user cache directory (``$XDG_CACHE_HOME`` /
+      ``~/.cache/aixplain``), never the current working directory. A cache in
+      ``$CWD`` leaks into shared CI workspaces and Docker image layers.
+    * Cached entries are built from an explicit field allowlist and are additionally
+      scrubbed of credential-shaped keys, so the account API key is never written
+      to disk. :meth:`AssetCache.get` returns objects whose credential is taken from
+      the live configuration instead.
+    * Files are written atomically through a private temporary file
+      (``0600``) inside a ``0700`` directory, so there is no window in which a
+      world-readable or partially written cache file exists.
 """
 
-import os
-import logging
+import copy
 import json
+import logging
+import os
+import sys
+import tempfile
+import threading
 import time
-from typing import Any, Dict, Optional
+from collections import OrderedDict
 from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar
+
 from filelock import FileLock
 
 logging.getLogger("filelock").setLevel(logging.INFO)
-
-from typing import TypeVar, Generic, Type
-from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +41,142 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 # Constants
-CACHE_FOLDER = ".cache"
 CACHE_DURATION = 86400
+#: Upper bound on entries kept in a single cache file. Evicted least-recently-used
+#: first, so a long-lived process cannot grow the file without limit.
+CACHE_MAX_ENTRIES = 1000
+
+#: Permissions for the cache directory and the cache files inside it. The cache
+#: holds account-scoped metadata, so it is owner-only.
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
+
+#: Keys that must never reach the cache file, at any nesting depth. This is a
+#: backstop behind the per-class field allowlist, not a replacement for it.
+SENSITIVE_FIELDS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "team_api_key",
+        "aixplain_api_key",
+        "access_token",
+        "refresh_token",
+        "token",
+        "password",
+        "secret",
+        "client_secret",
+        "authorization",
+    }
+)
+
+#: Attributes that describe the current environment rather than the asset. Caching
+#: them would pin a stale backend URL into a later session.
+_ENVIRONMENT_FIELDS = frozenset({"url", "backend_url"})
+
+
+def default_cache_folder() -> str:
+    """Return the directory holding aiXplain cache files.
+
+    Resolution order:
+        1. ``AIXPLAIN_CACHE_FOLDER``, when set (used by tests and by callers that
+           want an explicit location).
+        2. ``%LOCALAPPDATA%\\aixplain\\cache`` on Windows.
+        3. ``$XDG_CACHE_HOME/aixplain``, when ``XDG_CACHE_HOME`` is set.
+        4. ``~/.cache/aixplain``.
+
+    Returns:
+        str: Absolute path to the cache directory. The directory is not created.
+
+    Note:
+        The current working directory is deliberately never used: a cache in
+        ``$CWD`` is readable by anything sharing the checkout (CI runners,
+        Docker build contexts, co-tenant processes).
+    """
+    override = os.getenv("AIXPLAIN_CACHE_FOLDER")
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+
+    if sys.platform == "win32":
+        root = os.getenv("LOCALAPPDATA") or os.path.join(os.path.expanduser("~"), "AppData", "Local")
+        return os.path.join(root, "aixplain", "cache")
+
+    xdg = os.getenv("XDG_CACHE_HOME")
+    if xdg:
+        return os.path.join(xdg, "aixplain")
+
+    return os.path.join(os.path.expanduser("~"), ".cache", "aixplain")
+
+
+def ensure_cache_folder(folder: str) -> None:
+    """Create ``folder`` and restrict it to its owner.
+
+    Args:
+        folder (str): Directory to create.
+
+    Note:
+        The mode is applied with an explicit ``chmod`` because ``makedirs``
+        masks its ``mode`` through the process umask, and because the directory
+        may already exist with looser permissions from an earlier SDK version.
+    """
+    os.makedirs(folder, exist_ok=True)
+    try:
+        os.chmod(folder, _DIR_MODE)
+    except OSError as e:
+        # Windows and some network/overlay filesystems ignore POSIX modes.
+        logger.debug(f"Could not set permissions on {folder}: {e}")
+
+
+def atomic_write_private(path: str, blob: str) -> None:
+    """Write ``blob`` to ``path`` atomically, readable only by its owner.
+
+    The content goes to a private temporary file in the destination directory
+    and is then moved into place with :func:`os.replace`. Consequently readers
+    never see a truncated file, and the file is never world-readable -- not even
+    for the instant between ``open`` and ``chmod`` that a plain write would leave
+    (BUG-940).
+
+    Args:
+        path (str): Destination file path.
+        blob (str): Content to write.
+    """
+    folder = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=folder, prefix=".tmp-", suffix=".json")
+    try:
+        # mkstemp already creates the file 0600; make it explicit so the
+        # guarantee does not rest on the platform's mkstemp semantics.
+        try:
+            os.fchmod(fd, _FILE_MODE)
+        except OSError as e:
+            logger.debug(f"Could not set permissions on {tmp_path}: {e}")
+
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = -1  # ownership transferred to the file object
+            f.write(blob)
+            f.flush()
+            os.fsync(f.fileno())
+
+        # Rename preserves the temporary file's 0600 mode, so the published file
+        # is never world-readable.
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if tmp_path is not None and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+
+def _max_entries() -> int:
+    """Return the configured maximum number of cached entries."""
+    try:
+        value = int(os.getenv("CACHE_MAX_ENTRIES", CACHE_MAX_ENTRIES))
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid CACHE_MAX_ENTRIES, falling back to {CACHE_MAX_ENTRIES}")
+        return CACHE_MAX_ENTRIES
+    return value if value > 0 else CACHE_MAX_ENTRIES
 
 
 @dataclass
@@ -51,50 +202,113 @@ class AssetCache(Generic[T]):
     (Models, Pipelines, Agents, etc.) with automatic serialization, expiration,
     and thread-safe file persistence.
 
-    The cache uses JSON files for storage and implements file locking to ensure
-    thread safety. It also supports automatic cache invalidation based on
-    expiration time.
+    Instances are cheap to reuse and expensive to rebuild -- constructing one reads
+    and deserializes the whole cache file -- so callers should obtain them through
+    :meth:`shared` rather than instantiating per operation.
 
     Attributes:
         cls (Type[T]): The class type of assets to be cached.
+        cache_folder (str): Directory holding the cache and lock files.
         cache_file (str): Path to the JSON file storing the cached data.
-        lock_file (str): Path to the lock file for thread-safe operations.
+        lock_file (str): Path to the lock file for cross-process exclusion.
         store (Store[T]): The in-memory store containing cached data and expiry.
 
     Note:
-        The cached assets must be serializable to JSON and should implement
-        either a to_dict() method or have a standard __dict__ attribute.
+        Cached assets are persisted through an explicit field allowlist
+        (``__cache_fields__`` on the asset class, falling back to ``to_dict()``)
+        and are rebuilt with ``cls.from_dict()``. Credential-shaped fields are
+        never written.
     """
 
     def __init__(
         self,
         cls: Type[T],
         cache_filename: Optional[str] = None,
+        cache_folder: Optional[str] = None,
     ) -> None:
         """Initialize a new AssetCache instance.
 
         Args:
-            cls (Type[T]): The class type of assets to be cached. Must be
-                serializable to JSON.
+            cls (Type[T]): The class type of assets to be cached. Must expose a
+                ``from_dict`` classmethod.
             cache_filename (Optional[str], optional): Base name for the cache file.
                 If None, uses lowercase class name. Defaults to None.
+            cache_folder (Optional[str], optional): Directory for the cache file.
+                Defaults to :func:`default_cache_folder`.
+
+        Note:
+            Constructing a cache never writes to disk; the file appears on the
+            first :meth:`add`/:meth:`add_list`/:meth:`save`. This is what lets
+            callers that opted out of caching avoid touching the filesystem.
         """
         self.cls = cls
         if cache_filename is None:
             cache_filename = self.cls.__name__.lower()
 
-        # create cache file and lock file name
-        self.cache_file = os.path.join(CACHE_FOLDER, f"{cache_filename}.json")
-        self.lock_file = os.path.join(CACHE_FOLDER, f"{cache_filename}.lock")
+        self.cache_folder = cache_folder or default_cache_folder()
+        self.cache_file = os.path.join(self.cache_folder, f"{cache_filename}.json")
+        self.lock_file = os.path.join(self.cache_folder, f"{cache_filename}.lock")
 
         logger.info(f"Initializing AssetCache for {self.cls.__name__} with cache file: {self.cache_file}")
 
-        self.store = Store(data={}, expiry=self.compute_expiry())
+        # Guards ``store`` and ``_serialized`` against the SDK's own thread pools
+        # (e.g. the agent tool-build pool), which share one instance.
+        self._lock = threading.RLock()
+        # asset_id -> already-serialized payload, so save() never re-walks an
+        # object graph it has already converted.
+        self._serialized: Dict[str, Any] = {}
+        self.store = Store(data=OrderedDict(), expiry=self.compute_expiry())
         self.load()
 
-        if not os.path.exists(self.cache_file):
-            logger.info(f"Cache file doesn't exist, creating new one: {self.cache_file}")
-            self.save()
+    # ------------------------------------------------------------------
+    # Shared instances
+    # ------------------------------------------------------------------
+
+    _instances: Dict[Tuple[Any, ...], "AssetCache"] = {}
+    _instances_lock = threading.Lock()
+
+    @classmethod
+    def shared(
+        cls,
+        asset_cls: Type[T],
+        cache_filename: Optional[str] = None,
+        cache_folder: Optional[str] = None,
+    ) -> "AssetCache":
+        """Return a process-wide cache instance for ``asset_cls``.
+
+        Building an ``AssetCache`` loads and deserializes the entire cache file, so
+        constructing one per lookup makes every read O(cache size). Callers share a
+        single instance instead.
+
+        Args:
+            asset_cls (Type[T]): The class type of assets to be cached.
+            cache_filename (Optional[str], optional): Base name for the cache file.
+            cache_folder (Optional[str], optional): Directory for the cache file.
+
+        Returns:
+            AssetCache: A shared instance, created on first use.
+        """
+        key = (asset_cls, cache_filename, cache_folder or default_cache_folder())
+        with cls._instances_lock:
+            instance = cls._instances.get(key)
+            if instance is None:
+                instance = cls(asset_cls, cache_filename, cache_folder)
+                cls._instances[key] = instance
+            return instance
+
+    @classmethod
+    def reset_shared(cls) -> None:
+        """Drop all shared instances.
+
+        Intended for tests and for callers that change ``AIXPLAIN_CACHE_FOLDER``
+        at runtime.
+        """
+        with cls._instances_lock:
+            cls._instances.clear()
+
+    # ------------------------------------------------------------------
+    # Expiry
+    # ------------------------------------------------------------------
 
     def compute_expiry(self) -> int:
         """Calculate the expiration timestamp for cached data.
@@ -115,127 +329,203 @@ class AssetCache(Generic[T]):
         except Exception as e:
             logger.warning(f"Failed to parse CACHE_EXPIRY_TIME: {e}, fallback to default value {CACHE_DURATION}")
             # remove the CACHE_EXPIRY_TIME from the environment variables
-            del os.environ["CACHE_EXPIRY_TIME"]
+            os.environ.pop("CACHE_EXPIRY_TIME", None)
             expiry = CACHE_DURATION
 
         return time.time() + int(expiry)
 
-    def invalidate(self) -> None:
-        """Clear the cache and remove cache files.
+    def invalidate(self, delete_file: bool = True) -> None:
+        """Clear the cache and, by default, remove the cache file.
 
-        This method:
-        1. Resets the in-memory store with empty data and new expiry
-        2. Deletes the cache file if it exists
-        3. Deletes the lock file if it exists
+        Args:
+            delete_file (bool, optional): Whether to unlink the cache file as well
+                as clearing memory. Defaults to True.
+
+        Note:
+            The lock file is deliberately left in place. Unlinking it while the
+            lock is held drops mutual exclusion: a second process recreates the
+            path and takes ``flock`` on a different inode, so both processes enter
+            the critical section and one write is lost (BUG-940).
         """
         logger.info(f"Invalidating cache for {self.cls.__name__}")
-        self.store = Store(data={}, expiry=self.compute_expiry())
-        # delete cache file and lock file
-        if os.path.exists(self.cache_file):
-            os.remove(self.cache_file)
-            logger.info(f"Removed cache file: {self.cache_file}")
-        if os.path.exists(self.lock_file):
-            os.remove(self.lock_file)
-            logger.info(f"Removed lock file: {self.lock_file}")
+        with self._lock:
+            self.store = Store(data=OrderedDict(), expiry=self.compute_expiry())
+            self._serialized = {}
+
+        if delete_file and os.path.exists(self.cache_file):
+            try:
+                os.remove(self.cache_file)
+                logger.info(f"Removed cache file: {self.cache_file}")
+            except OSError as e:
+                logger.warning(f"Could not remove cache file {self.cache_file}: {e}")
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
 
     def load(self) -> None:
         """Load cached data from the cache file.
 
-        This method reads the cache file (if it exists) and loads the data into
-        the in-memory store. It performs the following:
-        1. Checks if cache file exists, if not, invalidates cache
-        2. Uses file locking to ensure thread-safe reading
-        3. Deserializes JSON data and converts to appropriate asset instances
-        4. Checks expiration time and invalidates if expired
-        5. Handles any errors by invalidating the cache
+        Reads the cache file (if present) and populates the in-memory store:
+
+        1. Returns early when the file does not exist.
+        2. Reads the file under the cross-process lock, then releases it.
+        3. Checks expiry *before* deserializing, so an expired cache costs one
+           read instead of a full rebuild of every entry.
+        4. Rebuilds entries with ``cls.from_dict``, skipping individual
+           unreadable entries rather than discarding the whole cache.
 
         Note:
-            If any errors occur during loading (file not found, invalid JSON,
-            deserialization errors), the cache will be invalidated.
+            A malformed file (bad JSON, missing keys) clears the in-memory store
+            and leaves the file to be overwritten by the next save.
         """
         logger.info(f"Loading cache for {self.cls.__name__} from {self.cache_file}")
 
         if not os.path.exists(self.cache_file):
             logger.info(f"Cache file doesn't exist: {self.cache_file}")
-            self.invalidate()
+            self.invalidate(delete_file=False)
             return
 
         try:
+            # Hold the lock only for the read itself; deserialization happens
+            # outside so a slow rebuild does not block other processes.
             with FileLock(self.lock_file):
                 logger.info(f"Acquired file lock for loading: {self.lock_file}")
-                with open(self.cache_file, "r") as f:
+                with open(self.cache_file, "r", encoding="utf-8") as f:
                     cache_data = json.load(f)
-                    expiry = cache_data["expiry"]
-                    raw_data = cache_data["data"]
-
-                    logger.info(f"Found {len(raw_data)} cached items for {self.cls.__name__}")
-
-                    parsed_data = {k: self.cls.from_dict(v) for k, v in raw_data.items()}
-
-                    self.store = Store(data=parsed_data, expiry=expiry)
-
-                    if self.store.expiry < time.time():
-                        logger.warning(
-                            f"Cache expired for {self.cls.__name__} (expiry: {self.store.expiry}, current: {time.time()})"
-                        )
-                        self.invalidate()
-                    else:
-                        logger.info(f"Successfully loaded {len(parsed_data)} cached items for {self.cls.__name__}")
-
         except Exception as e:
-            logger.error(f"Failed to load cache data for {self.cls.__name__}: {e}")
-            self.invalidate()
-
-    def save(self) -> None:
-        """Save the current cache state to the cache file.
-
-        This method serializes the current cache state to JSON and writes it
-        to the cache file. It performs the following:
-        1. Creates the cache directory if it doesn't exist
-        2. Uses file locking to ensure thread-safe writing
-        3. Serializes each cached asset to a JSON-compatible format
-        4. Writes the serialized data and expiry time to the cache file
-
-        Note:
-            If serialization fails for any asset, that asset will be skipped
-            and an error will be logged, but the save operation will continue
-            for other assets.
-        """
-        logger.info(f"Saving cache for {self.cls.__name__} with {len(self.store.data)} items")
+            logger.error(f"Failed to read cache data for {self.cls.__name__}: {e}")
+            self.invalidate(delete_file=False)
+            return
 
         try:
-            os.makedirs(CACHE_FOLDER, exist_ok=True)
-            logger.info(f"Cache directory created/verified: {CACHE_FOLDER}")
+            expiry = cache_data["expiry"]
+            raw_data = cache_data["data"]
+        except (TypeError, KeyError) as e:
+            logger.error(f"Malformed cache file for {self.cls.__name__}: {e}")
+            self.invalidate(delete_file=False)
+            return
 
+        # Expiry is checked before any deserialization work.
+        if expiry < time.time():
+            logger.warning(f"Cache expired for {self.cls.__name__} (expiry: {expiry}, current: {time.time()})")
+            self.invalidate(delete_file=False)
+            return
+
+        logger.info(f"Found {len(raw_data)} cached items for {self.cls.__name__}")
+
+        parsed_data: "OrderedDict[str, T]" = OrderedDict()
+        serialized: Dict[str, Any] = {}
+        skipped = 0
+        # Keep the most recently written entries when the file exceeds the cap.
+        for key, value in list(raw_data.items())[-_max_entries() :]:
+            try:
+                parsed_data[key] = self.cls.from_dict(value)
+                serialized[key] = value
+            except Exception as e:
+                skipped += 1
+                logger.warning(f"Skipping unreadable cache entry {key} for {self.cls.__name__}: {e}")
+
+        with self._lock:
+            self.store = Store(data=parsed_data, expiry=expiry)
+            self._serialized = serialized
+
+        if skipped:
+            logger.warning(f"Loaded {len(parsed_data)} cached items for {self.cls.__name__}, skipped {skipped}")
+        else:
+            logger.info(f"Successfully loaded {len(parsed_data)} cached items for {self.cls.__name__}")
+
+    def save(self, merge: bool = True) -> None:
+        """Persist the current cache state to the cache file.
+
+        The payload is serialized to a string *before* the file is touched, then
+        written to a private temporary file (``0600``) in the cache directory and
+        moved into place with :func:`os.replace`. Consequently:
+
+        * readers never observe a truncated or partially written cache;
+        * the file is never world-readable, not even briefly;
+        * a serialization failure leaves the previous cache intact.
+
+        Note:
+            Failures are logged, not raised -- a cache is best-effort.
+
+        Args:
+            merge (bool, optional): Fold in entries other processes added since
+                this instance loaded, instead of overwriting them. Defaults to
+                True. :meth:`add_list` passes False, since replacing the cache
+                wholesale is exactly what it promises.
+        """
+        with self._lock:
+            data = {
+                asset_id: self._serialized[asset_id]
+                for asset_id in self.store.data
+                if asset_id in self._serialized
+            }
+            expiry = self.store.expiry
+
+        logger.info(f"Saving cache for {self.cls.__name__} with {len(data)} items")
+
+        try:
+            ensure_cache_folder(self.cache_folder)
             with FileLock(self.lock_file):
                 logger.info(f"Acquired file lock for saving: {self.lock_file}")
-                with open(self.cache_file, "w") as f:
-                    data_dict = {}
-                    serialization_errors = 0
-
-                    for asset_id, asset in self.store.data.items():
-                        try:
-                            data_dict[asset_id] = serialize(asset)
-                        except Exception as e:
-                            logger.error(f"Error serializing {asset_id}: {e}")
-                            serialization_errors += 1
-
-                    serializable_store = {
-                        "expiry": self.store.expiry,
-                        "data": data_dict,
-                    }
-
-                    json.dump(serializable_store, f, indent=4)
-
-                    if serialization_errors > 0:
-                        logger.warning(
-                            f"Saved cache for {self.cls.__name__} with {serialization_errors} serialization errors"
-                        )
-                    else:
-                        logger.info(f"Successfully saved cache for {self.cls.__name__} with {len(data_dict)} items")
-
+                # Read-modify-write, entirely inside the lock.
+                merged, merged_expiry = self._merge_with_disk(data, expiry) if merge else (data, expiry)
+                # Serialize fully before the file is touched, so a failure here
+                # cannot leave a partial file behind.
+                blob = json.dumps({"expiry": merged_expiry, "data": merged}, separators=(",", ":"))
+                atomic_write_private(self.cache_file, blob)
+            logger.info(f"Successfully saved cache for {self.cls.__name__} with {len(merged)} items")
         except Exception as e:
             logger.error(f"Failed to save cache for {self.cls.__name__}: {e}")
+
+    def _merge_with_disk(self, data: Dict[str, Any], expiry: float) -> Tuple[Dict[str, Any], float]:
+        """Fold entries added by other processes into ``data``.
+
+        Overwriting the file outright drops every entry another process added
+        since this one last loaded. Because this runs under the same lock as the
+        write, the read-modify-write is atomic with respect to other SDK
+        processes.
+
+        Args:
+            data (Dict[str, Any]): This instance's serialized entries.
+            expiry (float): This instance's expiry timestamp.
+
+        Returns:
+            Tuple[Dict[str, Any], float]: Merged entries (this instance's
+                winning on conflict) and the *earlier* of the two expiries.
+
+        Note:
+            The earlier expiry is kept deliberately. The merged set contains
+            entries from both writers, and taking the later deadline would keep
+            serving the older writer's entries past the point it declared them
+            stale. Erring early only costs a refetch.
+        """
+        try:
+            with open(self.cache_file, "r", encoding="utf-8") as f:
+                on_disk = json.load(f)
+            other, other_expiry = on_disk["data"], on_disk["expiry"]
+        except (OSError, ValueError, KeyError, TypeError):
+            # No readable cache on disk: nothing to merge.
+            return data, expiry
+
+        if other_expiry < time.time():
+            # Their cache is stale; do not resurrect it.
+            return data, expiry
+
+        # Our entries go last so that trimming to the cap drops theirs first.
+        merged = {key: value for key, value in other.items() if key not in data}
+        merged.update(data)
+
+        limit = _max_entries()
+        if len(merged) > limit:
+            merged = dict(list(merged.items())[-limit:])
+
+        return merged, min(expiry, other_expiry)
+
+    # ------------------------------------------------------------------
+    # Reads and writes
+    # ------------------------------------------------------------------
 
     def get(self, asset_id: str) -> Optional[T]:
         """Retrieve a cached asset by its ID.
@@ -244,46 +534,164 @@ class AssetCache(Generic[T]):
             asset_id (str): The unique identifier of the asset to retrieve.
 
         Returns:
-            Optional[T]: The cached asset instance if found, None otherwise.
-        """
-        result = self.store.data.get(asset_id)
-        if result:
-            logger.info(f"Cache hit for {self.cls.__name__} asset: {asset_id}")
-        else:
-            logger.info(f"Cache miss for {self.cls.__name__} asset: {asset_id}")
-        return result
+            Optional[T]: A deep copy of the cached asset if present, None
+                otherwise.
 
-    def add(self, asset: T) -> None:
+        Note:
+            The copy is deep because the instance is shared process-wide. A
+            shallow copy would still alias mutable attributes, letting a caller
+            that mutates one in place (``additional_info``, say) corrupt what
+            every later reader sees. The cost is a fixed ~45us per hit and does
+            not grow with the cache.
+        """
+        with self._lock:
+            self._expire_if_needed()
+            result = self.store.data.get(asset_id)
+            if result is None:
+                logger.info(f"Cache miss for {self.cls.__name__} asset: {asset_id}")
+                return None
+            # Track recency for LRU eviction.
+            self._ensure_ordered()
+            self.store.data.move_to_end(asset_id)
+
+        logger.info(f"Cache hit for {self.cls.__name__} asset: {asset_id}")
+        try:
+            return copy.deepcopy(result)
+        except Exception as e:
+            # Some assets hold non-copyable handles; a shallow copy still keeps
+            # the caller from rebinding attributes on the shared instance.
+            logger.debug(f"Deep copy failed for {asset_id}, falling back to a shallow copy: {e}")
+            return copy.copy(result)
+
+    def _expire_if_needed(self) -> bool:
+        """Drop the in-memory entries when the store has passed its expiry.
+
+        The instance is memoized process-wide, so :meth:`load` -- which is where
+        expiry used to be enforced -- no longer runs on every lookup. Without
+        this check a long-lived process would keep serving entries forever.
+
+        The cache file is left alone: another process may have refreshed it, and
+        the next miss repopulates from it anyway.
+
+        Must be called with ``self._lock`` held.
+
+        Returns:
+            bool: True when entries were expired and cleared.
+        """
+        if self.store.data and self.store.expiry < time.time():
+            logger.info(f"Cache expired for {self.cls.__name__}; clearing {len(self.store.data)} in-memory entries")
+            self.store = Store(data=OrderedDict(), expiry=self.compute_expiry())
+            self._serialized = {}
+            return True
+        return False
+
+    def _ensure_ordered(self) -> None:
+        """Normalize the store's mapping to an ``OrderedDict``.
+
+        ``store`` is a public attribute, so a caller may assign a plain dict.
+        LRU tracking needs ``move_to_end``/``popitem(last=False)``, which a
+        plain dict does not provide.
+
+        Must be called with ``self._lock`` held.
+        """
+        if not isinstance(self.store.data, OrderedDict):
+            self.store.data = OrderedDict(self.store.data)
+
+    def __contains__(self, asset_id: str) -> bool:
+        """Return whether ``asset_id`` is cached, without copying the entry.
+
+        Args:
+            asset_id (str): The unique identifier to look for.
+
+        Returns:
+            bool: True if the asset is present in the cache.
+        """
+        with self._lock:
+            self._expire_if_needed()
+            return asset_id in self.store.data
+
+    def add(self, asset: T, save: bool = True) -> None:
         """Add a single asset to the cache.
 
         Args:
-            asset (T): The asset instance to cache. Must have an 'id' attribute
-                and be serializable to JSON.
+            asset (T): The asset instance to cache. Must have an ``id`` attribute.
+            save (bool, optional): Whether to persist the cache afterwards.
+                Defaults to True.
 
         Note:
-            This method automatically saves the updated cache to disk after
-            adding the asset.
+            The asset object is stored as-is, so in-process readers get back the
+            concrete type they put in. The persisted form is the allowlisted,
+            credential-free projection produced by :func:`serialize_asset`.
         """
         logger.info(f"Adding {self.cls.__name__} asset to cache: {asset.id}")
-        self.store.data[asset.id] = asset.__dict__
-        self.save()
+        with self._lock:
+            self._put(asset)
+        if save:
+            self.save()
 
-    def add_list(self, assets: List[T]) -> None:
-        """Add multiple assets to the cache at once.
+    def add_many(self, assets: List[T], save: bool = True) -> None:
+        """Add several assets to the cache, keeping existing entries.
 
-        This method replaces all existing cached assets with the new list.
+        Args:
+            assets (List[T]): Asset instances to cache.
+            save (bool, optional): Whether to persist the cache afterwards.
+                Defaults to True.
+
+        Note:
+            Unlike :meth:`add_list`, existing entries are preserved. One save
+            covers the whole batch.
+        """
+        logger.info(f"Adding {len(assets)} {self.cls.__name__} assets to cache")
+        with self._lock:
+            for asset in assets:
+                self._put(asset)
+        if save:
+            self.save()
+
+    def add_list(self, assets: List[T], save: bool = True) -> None:
+        """Replace all cached assets with the given list.
 
         Args:
             assets (List[T]): List of asset instances to cache. Each asset must
-                have an 'id' attribute and be serializable to JSON.
-
-        Note:
-            This method automatically saves the updated cache to disk after
-            adding the assets.
+                have an ``id`` attribute.
+            save (bool, optional): Whether to persist the cache afterwards.
+                Defaults to True.
         """
         logger.info(f"Adding {len(assets)} {self.cls.__name__} assets to cache (replacing existing)")
-        self.store.data = {asset.id: asset.__dict__ for asset in assets}
-        self.save()
+        with self._lock:
+            self.store.data = OrderedDict()
+            self._serialized = {}
+            for asset in assets:
+                self._put(asset)
+        if save:
+            # Replacing, not merging: this call defines the whole cache.
+            self.save(merge=False)
+
+    def _put(self, asset: T) -> None:
+        """Insert one asset and evict least-recently-used entries past the cap.
+
+        Must be called with ``self._lock`` held.
+
+        Args:
+            asset (T): The asset instance to cache.
+        """
+        self._ensure_ordered()
+        asset_id = asset.id
+        try:
+            self._serialized[asset_id] = serialize_asset(asset)
+        except Exception as e:
+            # Keep it in memory; it just will not survive this process.
+            logger.error(f"Error serializing {asset_id}: {e}")
+            self._serialized.pop(asset_id, None)
+
+        self.store.data[asset_id] = asset
+        self.store.data.move_to_end(asset_id)
+
+        limit = _max_entries()
+        while len(self.store.data) > limit:
+            evicted, _ = self.store.data.popitem(last=False)
+            self._serialized.pop(evicted, None)
+            logger.info(f"Evicted {self.cls.__name__} cache entry {evicted} (cap {limit})")
 
     def get_all(self) -> List[T]:
         """Retrieve all cached assets.
@@ -292,7 +700,8 @@ class AssetCache(Generic[T]):
             List[T]: List of all cached asset instances. Returns an empty list
                 if the cache is empty.
         """
-        return list(self.store.data.values())
+        with self._lock:
+            return list(self.store.data.values())
 
     def has_valid_cache(self) -> bool:
         """Check if the cache is valid and not expired.
@@ -301,11 +710,44 @@ class AssetCache(Generic[T]):
             bool: True if the cache has not expired and contains data,
                 False otherwise.
         """
-        is_valid = self.store.expiry >= time.time() and bool(self.store.data)
+        with self._lock:
+            self._expire_if_needed()
+            is_valid = self.store.expiry >= time.time() and bool(self.store.data)
+            count = len(self.store.data)
+            expiry = self.store.expiry
         logger.info(
-            f"Cache validity check for {self.cls.__name__}: {is_valid} (expiry: {self.store.expiry}, current: {time.time()}, data count: {len(self.store.data)})"
+            f"Cache validity check for {self.cls.__name__}: {is_valid} "
+            f"(expiry: {expiry}, current: {time.time()}, data count: {count})"
         )
         return is_valid
+
+
+def serialize_asset(asset: Any) -> Any:
+    """Project an asset onto its cacheable, credential-free fields.
+
+    Fields are chosen from the asset class's ``__cache_fields__`` allowlist when
+    present, falling back to ``to_dict()`` and finally to the instance
+    ``__dict__``. The result is then scrubbed of credential-shaped keys.
+
+    Args:
+        asset (Any): The asset to project.
+
+    Returns:
+        Any: A JSON-serializable dictionary safe to write to disk.
+
+    Note:
+        The allowlist is what keeps the account API key -- held as a plain
+        instance attribute -- out of the cache file (BUG-940).
+    """
+    fields = getattr(type(asset), "__cache_fields__", None)
+    if fields:
+        raw = {name: getattr(asset, name, None) for name in fields}
+    elif hasattr(asset, "to_dict"):
+        raw = asset.to_dict()
+    else:
+        raw = vars(asset)
+
+    return serialize(raw)
 
 
 def serialize(obj: Any) -> Any:
@@ -314,10 +756,15 @@ def serialize(obj: Any) -> Any:
     This function handles various Python types and converts them to formats
     that can be serialized to JSON. It supports:
     - Basic types (str, int, float, bool, None)
+    - Enums (converted to their value)
+    - Dates and datetimes (ISO 8601 strings)
     - Collections (list, tuple, set, dict)
     - Objects with to_dict() method
     - Objects with __dict__ attribute
     - Other objects (converted to string)
+
+    Keys named after credentials (see :data:`SENSITIVE_FIELDS`) and environment
+    fields are dropped at every nesting depth.
 
     Args:
         obj (Any): The Python object to serialize.
@@ -325,15 +772,37 @@ def serialize(obj: Any) -> Any:
     Returns:
         Any: A JSON-serializable version of the input object.
     """
-    if isinstance(obj, (str, int, float, bool, type(None))):
+    # Enums first: a member is often also a str, and recursing into its
+    # ``__dict__`` would drag in ``__objclass__`` -- i.e. every other member of
+    # the enum, which is how a single Model used to serialize to ~20 KB.
+    if isinstance(obj, Enum):
+        return serialize(obj.value)
+    elif isinstance(obj, (str, int, float, bool, type(None))):
         return obj
+    elif isinstance(obj, (datetime, date)):
+        return obj.isoformat()
     elif isinstance(obj, (list, tuple, set)):
         return [serialize(o) for o in obj]
     elif isinstance(obj, dict):
-        return {str(k): serialize(v) for k, v in obj.items()}
+        return {str(k): serialize(v) for k, v in obj.items() if not _is_redacted(k)}
     elif hasattr(obj, "to_dict"):
         return serialize(obj.to_dict())
     elif hasattr(obj, "__dict__"):
-        return serialize(vars(obj))
+        return serialize({k: v for k, v in vars(obj).items() if not _is_redacted(k)})
     else:
         return str(obj)
+
+
+def _is_redacted(key: Any) -> bool:
+    """Return True when ``key`` names a credential or environment field.
+
+    Args:
+        key (Any): Candidate mapping key or attribute name.
+
+    Returns:
+        bool: True if the key must not be persisted.
+    """
+    if not isinstance(key, str):
+        return False
+    normalized = key.strip().lower().lstrip("_").replace("-", "_")
+    return normalized in SENSITIVE_FIELDS or normalized in _ENVIRONMENT_FIELDS

--- a/aixplain/utils/asset_cache.py
+++ b/aixplain/utils/asset_cache.py
@@ -144,9 +144,21 @@ def atomic_write_private(path: str, blob: str) -> None:
     try:
         # mkstemp already creates the file 0600; make it explicit so the
         # guarantee does not rest on the platform's mkstemp semantics.
+        #
+        # os.fchmod is Unix-only, and an absent attribute raises AttributeError
+        # rather than OSError -- which would escape this handler and abort the
+        # whole write, so every cache save failed on Windows.
         try:
-            os.fchmod(fd, _FILE_MODE)
-        except OSError as e:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, _FILE_MODE)
+            else:
+                os.chmod(tmp_path, _FILE_MODE)
+        except (OSError, AttributeError, NotImplementedError) as e:
+            # Windows honours only the read-only bit, and some network and
+            # overlay filesystems ignore modes entirely. Not fatal: the
+            # enclosing directory is already owner-only. AttributeError is
+            # caught as well as guarded for, so tightening permissions can
+            # never be what stops the cache from being written.
             logger.debug(f"Could not set permissions on {tmp_path}: {e}")
 
         with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -167,6 +179,36 @@ def atomic_write_private(path: str, blob: str) -> None:
                 os.remove(tmp_path)
             except OSError:
                 pass
+
+
+def _isolate(asset: Any, asset_id: str = "") -> Any:
+    """Return a copy of ``asset`` sharing no mutable state with the original.
+
+    The cache is a process-wide singleton, so an entry and the object a caller
+    holds must never be the same object, and must not share mutable attributes
+    (``model_params``, ``additional_info``, ...). Otherwise one consumer's
+    in-place edit silently rewrites what every later consumer reads.
+
+    Args:
+        asset (Any): The asset to copy.
+        asset_id (str, optional): Identifier, for log context only.
+
+    Returns:
+        Any: A deep copy, or a shallow copy if the asset cannot be deep-copied.
+
+    Note:
+        The shallow fallback is logged at warning, not debug: it does *not*
+        deliver isolation, and a silent fallback here is exactly what hid the
+        aliasing this function exists to prevent (BUG-940).
+    """
+    try:
+        return copy.deepcopy(asset)
+    except Exception as e:
+        logger.warning(
+            f"Could not deep-copy cached asset {asset_id or type(asset).__name__} ({e}); "
+            "falling back to a shallow copy, which leaves mutable attributes shared"
+        )
+        return copy.copy(asset)
 
 
 def _max_entries() -> int:
@@ -376,8 +418,12 @@ class AssetCache(Generic[T]):
            unreadable entries rather than discarding the whole cache.
 
         Note:
-            A malformed file (bad JSON, missing keys) clears the in-memory store
-            and leaves the file to be overwritten by the next save.
+            Any malformed file -- bad JSON, missing keys, a null expiry, a
+            ``data`` that is not a mapping -- clears the in-memory store and
+            leaves the file to be overwritten by the next save. Nothing here
+            propagates: this runs from ``__init__``, so an exception would make
+            every ``AssetCache(...)``/:meth:`shared` call fail until the user
+            deleted the file by hand (BUG-940).
         """
         logger.info(f"Loading cache for {self.cls.__name__} from {self.cache_file}")
 
@@ -393,47 +439,45 @@ class AssetCache(Generic[T]):
                 logger.info(f"Acquired file lock for loading: {self.lock_file}")
                 with open(self.cache_file, "r", encoding="utf-8") as f:
                     cache_data = json.load(f)
-        except Exception as e:
-            logger.error(f"Failed to read cache data for {self.cls.__name__}: {e}")
-            self.invalidate(delete_file=False)
-            return
 
-        try:
             expiry = cache_data["expiry"]
             raw_data = cache_data["data"]
-        except (TypeError, KeyError) as e:
-            logger.error(f"Malformed cache file for {self.cls.__name__}: {e}")
+
+            # Expiry is checked before any deserialization work.
+            if not isinstance(expiry, (int, float)) or expiry < time.time():
+                logger.warning(f"Cache expired or unusable for {self.cls.__name__} (expiry: {expiry!r})")
+                self.invalidate(delete_file=False)
+                return
+
+            if not isinstance(raw_data, dict):
+                raise TypeError(f"'data' must be a mapping, got {type(raw_data).__name__}")
+
+            logger.info(f"Found {len(raw_data)} cached items for {self.cls.__name__}")
+
+            parsed_data: "OrderedDict[str, T]" = OrderedDict()
+            serialized: Dict[str, Any] = {}
+            skipped = 0
+            # Keep the most recently written entries when the file exceeds the cap.
+            for key, value in list(raw_data.items())[-_max_entries() :]:
+                try:
+                    parsed_data[key] = self.cls.from_dict(value)
+                    serialized[key] = value
+                except Exception as e:
+                    skipped += 1
+                    logger.warning(f"Skipping unreadable cache entry {key} for {self.cls.__name__}: {e}")
+
+            with self._lock:
+                self.store = Store(data=parsed_data, expiry=expiry)
+                self._serialized = serialized
+
+            if skipped:
+                logger.warning(f"Loaded {len(parsed_data)} cached items for {self.cls.__name__}, skipped {skipped}")
+            else:
+                logger.info(f"Successfully loaded {len(parsed_data)} cached items for {self.cls.__name__}")
+
+        except Exception as e:
+            logger.error(f"Failed to load cache data for {self.cls.__name__}: {e}")
             self.invalidate(delete_file=False)
-            return
-
-        # Expiry is checked before any deserialization work.
-        if expiry < time.time():
-            logger.warning(f"Cache expired for {self.cls.__name__} (expiry: {expiry}, current: {time.time()})")
-            self.invalidate(delete_file=False)
-            return
-
-        logger.info(f"Found {len(raw_data)} cached items for {self.cls.__name__}")
-
-        parsed_data: "OrderedDict[str, T]" = OrderedDict()
-        serialized: Dict[str, Any] = {}
-        skipped = 0
-        # Keep the most recently written entries when the file exceeds the cap.
-        for key, value in list(raw_data.items())[-_max_entries() :]:
-            try:
-                parsed_data[key] = self.cls.from_dict(value)
-                serialized[key] = value
-            except Exception as e:
-                skipped += 1
-                logger.warning(f"Skipping unreadable cache entry {key} for {self.cls.__name__}: {e}")
-
-        with self._lock:
-            self.store = Store(data=parsed_data, expiry=expiry)
-            self._serialized = serialized
-
-        if skipped:
-            logger.warning(f"Loaded {len(parsed_data)} cached items for {self.cls.__name__}, skipped {skipped}")
-        else:
-            logger.info(f"Successfully loaded {len(parsed_data)} cached items for {self.cls.__name__}")
 
     def save(self, merge: bool = True) -> None:
         """Persist the current cache state to the cache file.
@@ -555,13 +599,7 @@ class AssetCache(Generic[T]):
             self.store.data.move_to_end(asset_id)
 
         logger.info(f"Cache hit for {self.cls.__name__} asset: {asset_id}")
-        try:
-            return copy.deepcopy(result)
-        except Exception as e:
-            # Some assets hold non-copyable handles; a shallow copy still keeps
-            # the caller from rebinding attributes on the shared instance.
-            logger.debug(f"Deep copy failed for {asset_id}, falling back to a shallow copy: {e}")
-            return copy.copy(result)
+        return _isolate(result, asset_id)
 
     def _expire_if_needed(self) -> bool:
         """Drop the in-memory entries when the store has passed its expiry.
@@ -684,7 +722,11 @@ class AssetCache(Generic[T]):
             logger.error(f"Error serializing {asset_id}: {e}")
             self._serialized.pop(asset_id, None)
 
-        self.store.data[asset_id] = asset
+        # Store an isolated copy. The instance is shared process-wide, so
+        # keeping the caller's object would let whatever the caller does to it
+        # next -- ``build_llm`` assigning a temperature, say -- rewrite the
+        # entry every later reader sees (BUG-940).
+        self.store.data[asset_id] = _isolate(asset, asset_id)
         self.store.data.move_to_end(asset_id)
 
         limit = _max_entries()
@@ -727,7 +769,7 @@ def serialize_asset(asset: Any) -> Any:
 
     Fields are chosen from the asset class's ``__cache_fields__`` allowlist when
     present, falling back to ``to_dict()`` and finally to the instance
-    ``__dict__``. The result is then scrubbed of credential-shaped keys.
+    ``__dict__``.
 
     Args:
         asset (Any): The asset to project.
@@ -738,14 +780,24 @@ def serialize_asset(asset: Any) -> Any:
     Note:
         The allowlist is what keeps the account API key -- held as a plain
         instance attribute -- out of the cache file (BUG-940).
+
+        Redaction is applied to this mapping's own keys and nowhere deeper,
+        because these are *attribute* names while everything below is data. In
+        particular ``input_params``, ``output_params``, ``model_params`` and
+        ``additional_info["parameters"]`` are keyed by user-defined parameter
+        name, so a tool that legitimately takes a ``url`` or ``token``
+        parameter would otherwise have it silently dropped -- and then fail
+        validation on the next process, which is worse than the leak this was
+        meant to guard against. The credential is a single attribute; excluding
+        it by name here is the whole job.
     """
     fields = getattr(type(asset), "__cache_fields__", None)
     if fields:
-        raw = {name: getattr(asset, name, None) for name in fields}
+        raw = {name: getattr(asset, name, None) for name in fields if not _is_redacted(name)}
     elif hasattr(asset, "to_dict"):
-        raw = asset.to_dict()
+        raw = {key: value for key, value in asset.to_dict().items() if not _is_redacted(key)}
     else:
-        raw = vars(asset)
+        raw = {key: value for key, value in vars(asset).items() if not _is_redacted(key)}
 
     return serialize(raw)
 
@@ -763,14 +815,18 @@ def serialize(obj: Any) -> Any:
     - Objects with __dict__ attribute
     - Other objects (converted to string)
 
-    Keys named after credentials (see :data:`SENSITIVE_FIELDS`) and environment
-    fields are dropped at every nesting depth.
-
     Args:
         obj (Any): The Python object to serialize.
 
     Returns:
         Any: A JSON-serializable version of the input object.
+
+    Note:
+        This is a faithful conversion and drops nothing. Choosing what may be
+        persisted belongs to :func:`serialize_asset`, which decides it from the
+        asset's own attribute names. Filtering by key name during the recursion
+        instead cannot tell an attribute from a parameter that merely shares its
+        name (BUG-940).
     """
     # Enums first: a member is often also a str, and recursing into its
     # ``__dict__`` would drag in ``__objclass__`` -- i.e. every other member of
@@ -784,11 +840,11 @@ def serialize(obj: Any) -> Any:
     elif isinstance(obj, (list, tuple, set)):
         return [serialize(o) for o in obj]
     elif isinstance(obj, dict):
-        return {str(k): serialize(v) for k, v in obj.items() if not _is_redacted(k)}
+        return {str(k): serialize(v) for k, v in obj.items()}
     elif hasattr(obj, "to_dict"):
         return serialize(obj.to_dict())
     elif hasattr(obj, "__dict__"):
-        return serialize({k: v for k, v in vars(obj).items() if not _is_redacted(k)})
+        return serialize(vars(obj))
     else:
         return str(obj)
 

--- a/aixplain/utils/asset_cache.py
+++ b/aixplain/utils/asset_cache.py
@@ -78,8 +78,7 @@ def default_cache_folder() -> str:
     """Return the directory holding aiXplain cache files.
 
     Resolution order:
-        1. ``AIXPLAIN_CACHE_FOLDER``, when set (used by tests and by callers that
-           want an explicit location).
+        1. ``$AIXPLAIN_CACHE_FOLDER/aixplain``, when the variable is set.
         2. ``%LOCALAPPDATA%\\aixplain\\cache`` on Windows.
         3. ``$XDG_CACHE_HOME/aixplain``, when ``XDG_CACHE_HOME`` is set.
         4. ``~/.cache/aixplain``.
@@ -91,10 +90,17 @@ def default_cache_folder() -> str:
         The current working directory is deliberately never used: a cache in
         ``$CWD`` is readable by anything sharing the checkout (CI runners,
         Docker build contexts, co-tenant processes).
+
+        Every branch ends in a directory belonging to the SDK, including the
+        override, which gets its own ``aixplain`` subdirectory. That matters
+        because :func:`ensure_cache_folder` restricts this directory to its
+        owner on every save: pointed straight at ``$HOME``, ``.`` or a shared
+        volume, it would strip the group and other bits off a directory the
+        user never meant to hand over (BUG-940).
     """
     override = os.getenv("AIXPLAIN_CACHE_FOLDER")
     if override:
-        return os.path.abspath(os.path.expanduser(override))
+        return os.path.join(os.path.abspath(os.path.expanduser(override)), "aixplain")
 
     if sys.platform == "win32":
         root = os.getenv("LOCALAPPDATA") or os.path.join(os.path.expanduser("~"), "AppData", "Local")
@@ -105,6 +111,64 @@ def default_cache_folder() -> str:
         return os.path.join(xdg, "aixplain")
 
     return os.path.join(os.path.expanduser("~"), ".cache", "aixplain")
+
+
+#: Where releases before this fix wrote the cache: relative to the working
+#: directory, world-readable, credential included.
+LEGACY_CACHE_FOLDER = ".cache"
+
+
+def purge_legacy_cwd_cache(cache_filename: str) -> bool:
+    """Delete a pre-fix cache file left in the working directory.
+
+    Moving the cache out of ``$CWD`` stops new leaks but does nothing about the
+    cleartext credential an earlier release already wrote there, which would
+    otherwise sit in the checkout indefinitely. Removing it is part of the fix.
+
+    Args:
+        cache_filename (str): Base name of the cache file, e.g. ``"model"``.
+
+    Returns:
+        bool: True if a legacy cache file was removed.
+
+    Note:
+        Deliberately narrow. It removes only ``.cache/<cache_filename>.json``,
+        only after confirming the contents are this cache's own structure, and
+        it leaves the ``.cache`` directory itself in place -- other tools use
+        that name, and none of their files are ours to delete.
+    """
+    legacy = os.path.join(LEGACY_CACHE_FOLDER, f"{cache_filename}.json")
+    if not os.path.isfile(legacy):
+        return False
+
+    try:
+        with open(legacy, "r", encoding="utf-8") as f:
+            content = json.load(f)
+        if not (isinstance(content, dict) and "expiry" in content and "data" in content):
+            logger.debug(f"Leaving {legacy} alone: not an aiXplain asset cache")
+            return False
+    except Exception as e:
+        logger.debug(f"Leaving {legacy} alone: could not be read as an asset cache ({e})")
+        return False
+
+    try:
+        os.remove(legacy)
+        logger.warning(
+            f"Removed legacy cache {legacy}, which earlier versions wrote to the working "
+            "directory with the account API key in cleartext. If it was committed or copied "
+            "into an image, rotate the key."
+        )
+    except OSError as e:
+        logger.warning(f"Could not remove legacy cache {legacy}: {e}")
+        return False
+
+    legacy_lock = os.path.join(LEGACY_CACHE_FOLDER, f"{cache_filename}.lock")
+    if os.path.isfile(legacy_lock):
+        try:
+            os.remove(legacy_lock)
+        except OSError:
+            pass
+    return True
 
 
 def ensure_cache_folder(folder: str) -> None:
@@ -300,6 +364,14 @@ class AssetCache(Generic[T]):
         # object graph it has already converted.
         self._serialized: Dict[str, Any] = {}
         self.store = Store(data=OrderedDict(), expiry=self.compute_expiry())
+
+        # Clean up after releases that cached into the working directory with
+        # the credential in cleartext. Best effort, and never fatal.
+        try:
+            purge_legacy_cwd_cache(cache_filename)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"Legacy cache cleanup skipped: {e}")
+
         self.load()
 
     # ------------------------------------------------------------------
@@ -602,24 +674,30 @@ class AssetCache(Generic[T]):
         return _isolate(result, asset_id)
 
     def _expire_if_needed(self) -> bool:
-        """Drop the in-memory entries when the store has passed its expiry.
+        """Refresh the store from disk once it has passed its expiry.
 
         The instance is memoized process-wide, so :meth:`load` -- which is where
         expiry used to be enforced -- no longer runs on every lookup. Without
         this check a long-lived process would keep serving entries forever.
 
-        The cache file is left alone: another process may have refreshed it, and
-        the next miss repopulates from it anyway.
+        Expiry then *reloads* rather than only clearing memory. Another process
+        has very likely refreshed the file in the meantime, and simply emptying
+        the store sent the next lookup down the cold path, which repopulates
+        from one page of the account's models and overwrote everything those
+        other processes had just written (BUG-940).
 
         Must be called with ``self._lock`` held.
 
         Returns:
-            bool: True when entries were expired and cleared.
+            bool: True when the store had expired and was refreshed.
         """
         if self.store.data and self.store.expiry < time.time():
-            logger.info(f"Cache expired for {self.cls.__name__}; clearing {len(self.store.data)} in-memory entries")
+            logger.info(f"Cache expired for {self.cls.__name__}; reloading {self.cache_file}")
             self.store = Store(data=OrderedDict(), expiry=self.compute_expiry())
             self._serialized = {}
+            # Safe to re-enter: ``_lock`` is an RLock and ``load`` takes the
+            # cross-process lock afresh, never nested inside another.
+            self.load()
             return True
         return False
 
@@ -648,22 +726,27 @@ class AssetCache(Generic[T]):
             self._expire_if_needed()
             return asset_id in self.store.data
 
-    def add(self, asset: T, save: bool = True) -> None:
+    def add(self, asset: T, save: bool = True, key: Optional[str] = None) -> None:
         """Add a single asset to the cache.
 
         Args:
             asset (T): The asset instance to cache. Must have an ``id`` attribute.
             save (bool, optional): Whether to persist the cache afterwards.
                 Defaults to True.
+            key (Optional[str], optional): Cache key to store under. Defaults to
+                ``asset.id``. Pass the identifier the caller looked the asset up
+                by when that can differ from the asset's own id -- a request by
+                slug may be answered with a canonical id, and the next lookup
+                will use the slug again.
 
         Note:
-            The asset object is stored as-is, so in-process readers get back the
-            concrete type they put in. The persisted form is the allowlisted,
+            An isolated copy is stored, so the caller keeps sole ownership of
+            the object it passed in. The persisted form is the allowlisted,
             credential-free projection produced by :func:`serialize_asset`.
         """
-        logger.info(f"Adding {self.cls.__name__} asset to cache: {asset.id}")
+        logger.info(f"Adding {self.cls.__name__} asset to cache: {key or asset.id}")
         with self._lock:
-            self._put(asset)
+            self._put(asset, key=key)
         if save:
             self.save()
 
@@ -699,22 +782,28 @@ class AssetCache(Generic[T]):
         with self._lock:
             self.store.data = OrderedDict()
             self._serialized = {}
+            # A full replacement restarts the TTL. Without this the new file
+            # inherits whatever expiry the store happened to hold, which for an
+            # already-expired store means writing a file that is dead on
+            # arrival (BUG-940).
+            self.store.expiry = self.compute_expiry()
             for asset in assets:
                 self._put(asset)
         if save:
             # Replacing, not merging: this call defines the whole cache.
             self.save(merge=False)
 
-    def _put(self, asset: T) -> None:
+    def _put(self, asset: T, key: Optional[str] = None) -> None:
         """Insert one asset and evict least-recently-used entries past the cap.
 
         Must be called with ``self._lock`` held.
 
         Args:
             asset (T): The asset instance to cache.
+            key (Optional[str], optional): Cache key. Defaults to ``asset.id``.
         """
         self._ensure_ordered()
-        asset_id = asset.id
+        asset_id = key or asset.id
         try:
             self._serialized[asset_id] = serialize_asset(asset)
         except Exception as e:

--- a/aixplain/utils/cache_utils.py
+++ b/aixplain/utils/cache_utils.py
@@ -1,15 +1,22 @@
-import os
 import json
-import time
 import logging
+import os
+import time
+
 from filelock import FileLock
+
+from aixplain.utils.asset_cache import atomic_write_private, default_cache_folder, ensure_cache_folder
 
 logging.getLogger("filelock").setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
 
-CACHE_FOLDER = ".cache"
-CACHE_FILE = f"{CACHE_FOLDER}/cache.json"
+#: Cache location. Resolved under the per-user cache directory rather than the
+#: current working directory, which would expose the contents to anything sharing
+#: the checkout -- CI runners, Docker build contexts, co-tenant processes
+#: (BUG-940).
+CACHE_FOLDER = default_cache_folder()
+CACHE_FILE = os.path.join(CACHE_FOLDER, "cache.json")
 LOCK_FILE = f"{CACHE_FILE}.lock"
 CACHE_DURATION = 86400
 
@@ -38,19 +45,27 @@ def save_to_cache(cache_file: str, data: dict, lock_file: str) -> None:
         lock_file (str): Path to the lock file used for thread safety.
 
     Note:
-        - Creates the cache directory if it doesn't exist
+        - Creates the cache directory (owner-only) if it doesn't exist
+        - Writes atomically through a private temporary file, so the file is
+          never world-readable and never observed half-written
         - Logs an error if saving fails but doesn't raise an exception
         - The data is saved with a timestamp for expiration checking
     """
     logger.info(f"Attempting to save cache to {cache_file}")
     try:
-        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
-        logger.info(f"Cache directory created/verified: {os.path.dirname(cache_file)}")
+        blob = json.dumps({"timestamp": time.time(), "data": data})
+    except Exception as e:
+        logger.error(f"Failed to serialize cache for {cache_file}: {e}")
+        return
+
+    try:
+        folder = os.path.dirname(cache_file) or "."
+        ensure_cache_folder(folder)
+        logger.info(f"Cache directory created/verified: {folder}")
 
         with FileLock(lock_file):
             logger.info(f"Acquired file lock: {lock_file}")
-            with open(cache_file, "w") as f:
-                json.dump({"timestamp": time.time(), "data": data}, f)
+            atomic_write_private(cache_file, blob)
             logger.info(f"Successfully saved cache to {cache_file}")
     except Exception as e:
         logger.error(f"Failed to save cache to {cache_file}: {e}")

--- a/aixplain/v1/base/parameters.py
+++ b/aixplain/v1/base/parameters.py
@@ -165,7 +165,17 @@ class BaseParameters:
 
         Raises:
             AttributeError: If attempting to access a parameter that hasn't been defined.
+
+        Note:
+            The lookup goes through ``__dict__`` rather than ``self.parameters``.
+            ``__getattr__`` runs whenever normal attribute lookup fails, and that
+            includes the attribute-less instance ``copy`` and ``pickle`` create
+            before restoring state: there ``self.parameters`` also misses,
+            re-enters ``__getattr__``, and recurses until ``RecursionError``.
+            That made ``copy.deepcopy`` of any Model carrying parameters fail
+            (BUG-940).
         """
-        if name in self.parameters:
-            return self.parameters[name].value
+        parameters = self.__dict__.get("parameters")
+        if parameters is not None and name in parameters:
+            return parameters[name].value
         raise AttributeError(f"Parameter '{name}' is not defined")

--- a/aixplain/v1/factories/agent_factory/utils.py
+++ b/aixplain/v1/factories/agent_factory/utils.py
@@ -137,6 +137,62 @@ def build_tool(tool: Dict):
     return tool
 
 
+def prefetch_tool_models(tools_dict: List[Dict], payload: Dict, api_key: Text = config.TEAM_API_KEY) -> None:
+    """Resolve every model-backed tool of an agent in a single backend request.
+
+    Building a tool goes ``build_tool`` -> ``ModelTool.validate`` ->
+    ``ModelFactory.get``, which issues its own HTTP request. Loading an agent with
+    N model tools therefore cost N round trips even though the backend already
+    resolves a batch through ``sdk/models?ids=a,b,c``. Issuing that one request
+    up front and warming the shared cache turns the per-tool lookups into cache
+    hits (BUG-940).
+
+    Args:
+        tools_dict (List[Dict]): Raw tool payloads from the agent response.
+        payload (Dict): The agent payload, read for ``llmId`` so the agent's main
+            LLM joins the same batch.
+        api_key (Text, optional): API key for authentication. Defaults to
+            config.TEAM_API_KEY.
+
+    Note:
+        Best effort. A failed batch is logged and leaves each tool to fetch
+        itself, which is the behaviour this function optimizes away.
+    """
+    from aixplain.factories.model_factory.utils import get_model_from_ids
+    from aixplain.utils.asset_cache import AssetCache
+
+    wanted = []
+    for tool in tools_dict:
+        if (tool.get("type") or "").lower() != "model":
+            continue
+        asset_id = tool.get("assetId")
+        if isinstance(asset_id, str) and asset_id:
+            wanted.append(asset_id)
+
+    llm_id = payload.get("llmId")
+    if isinstance(llm_id, str) and llm_id:
+        wanted.append(llm_id)
+
+    cache = AssetCache.shared(Model)
+
+    missing, seen = [], set()
+    for asset_id in wanted:
+        if asset_id in seen or asset_id in cache:
+            continue
+        seen.add(asset_id)
+        missing.append(asset_id)
+
+    if len(missing) < 2:
+        # One id is no cheaper as a batch than as the direct fetch that follows.
+        return
+
+    logging.info(f"Resolving {len(missing)} agent tool models in a single request")
+    try:
+        cache.add_many(get_model_from_ids(missing, api_key))
+    except Exception as e:
+        logging.warning(f"Batch model resolution failed, falling back to per-tool fetch: {e}")
+
+
 def build_llm(payload: Dict, api_key: Text = config.TEAM_API_KEY) -> LLM:
     """Build a Large Language Model (LLM) instance from a dictionary configuration.
 
@@ -236,6 +292,10 @@ def build_agent(payload: Dict, tools: List[Tool] = None, api_key: Text = config.
 
         # Build all tools in parallel (only if there are tools to build)
         if len(tools_dict) > 0:
+            # Resolve the tools' models in one request first. Without this the
+            # workers below each issue their own, and the pool wins nothing
+            # because they queue behind the cache's exclusive file lock.
+            prefetch_tool_models(tools_dict, payload, api_key)
             with ThreadPoolExecutor(max_workers=min(len(tools_dict), 10)) as executor:
                 # Submit all tool build tasks
                 future_to_tool = {executor.submit(build_tool_safe, tool): tool for tool in tools_dict}

--- a/aixplain/v1/factories/model_factory/mixins/model_getter.py
+++ b/aixplain/v1/factories/model_factory/mixins/model_getter.py
@@ -11,7 +11,7 @@ from aixplain.modules.model import Model
 from aixplain.utils import config
 from aixplain.utils.request_utils import _request_with_retry
 from aixplain.utils.asset_cache import AssetCache
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 from typing import Optional, Text
 
 
@@ -60,8 +60,11 @@ class ModelGetterMixin:
         if name:
             return cls._fetch_model_by_name(name, api_key)
 
-        # Continue with existing ID-based logic
-        model_id = model_id.replace("/", "%2F")
+        # Continue with existing ID-based logic. The id is used verbatim as the
+        # cache key -- percent-escaping is a URL concern and is applied where
+        # the request is built. Escaping here keyed lookups on
+        # "a%2Fb%2Fc" while every write keyed on the raw id, so slug ids
+        # ("openai/gpt-4o-mini/openai") never hit the cache (BUG-940).
         if api_key is None:
             api_key = config.TEAM_API_KEY
 
@@ -81,17 +84,32 @@ class ModelGetterMixin:
                 if not cache.has_valid_cache():
                     model_list_resp = cls.list(model_ids=None, api_key=api_key)
                     models = model_list_resp["results"]
-                    cache.add_list(models)
+                    # Additive: this is one page of the account's models, not
+                    # the authoritative cache contents, so it must not discard
+                    # entries this process never saw.
+                    cache.add_many(models)
                     for model in models:
                         if model.id == model_id:
                             return model
 
                 logging.info("Model not found in valid cache, fetching individually...")
                 model = cls._fetch_model_by_id(model_id, api_key)
-                cache.add(model)
+                # Key on the requested id: the backend may answer a slug with a
+                # canonical id, and the next lookup will use the slug again.
+                cache.add(model, key=model_id)
                 return model
             except Exception as e:
                 logging.warning(f"Cache lookup failed, falling back to direct fetch: {e}")
+
+            # The cache was unusable, but the result is still worth keeping:
+            # otherwise a failing bulk listing is re-attempted, with retries,
+            # on every single call.
+            model = cls._fetch_model_by_id(model_id, api_key)
+            try:
+                cache.add(model, key=model_id)
+            except Exception as e:
+                logging.warning(f"Could not cache directly fetched model: {e}")
+            return model
 
         logging.info("Fetching model directly without cache...")
         return cls._fetch_model_by_id(model_id, api_key)
@@ -168,7 +186,10 @@ class ModelGetterMixin:
         """
         resp = None
         try:
-            url = urljoin(cls.backend_url, f"sdk/models/{model_id}")
+            # Escape here rather than at the caller: a slug id must not be read
+            # as extra path segments, but the unescaped id is what identifies
+            # the model everywhere else, the cache included.
+            url = urljoin(cls.backend_url, f"sdk/models/{quote(model_id, safe='')}")
             headers = {
                 "Authorization": f"Token {api_key or config.TEAM_API_KEY}",
                 "Content-Type": "application/json",

--- a/aixplain/v1/factories/model_factory/mixins/model_getter.py
+++ b/aixplain/v1/factories/model_factory/mixins/model_getter.py
@@ -40,8 +40,10 @@ class ModelGetterMixin:
             name (Optional[Text], optional): Name of the model to retrieve.
             api_key (Optional[Text], optional): API key for authentication.
                 Defaults to None, using the configured TEAM_API_KEY.
-            use_cache (bool, optional): Whether to attempt retrieving from cache.
-                Defaults to False.
+            use_cache (bool, optional): Whether to use the on-disk model cache.
+                Defaults to False. When False, the cache is neither read nor
+                written -- opting out of caching also opts out of persisting
+                anything about the model (BUG-940).
 
         Returns:
             Model: Retrieved model instance.
@@ -60,34 +62,39 @@ class ModelGetterMixin:
 
         # Continue with existing ID-based logic
         model_id = model_id.replace("/", "%2F")
-        cache = AssetCache(Model)
         if api_key is None:
             api_key = config.TEAM_API_KEY
 
         if use_cache:
+            # Shared instance: building one reads and deserializes the whole
+            # cache file, so a per-call instance made every get() O(cache size).
+            cache = AssetCache.shared(Model)
             try:
-                if cache.has_valid_cache():
-                    cached_model = cache.store.data.get(model_id)
-                    if cached_model:
-                        return cached_model
-                    logging.info("Model not found in valid cache, fetching individually...")
-                    model = cls._fetch_model_by_id(model_id, api_key)
-                    cache.add(model)
-                    return model
-                else:
+                cached_model = cache.get(model_id)
+                if cached_model is not None:
+                    # The cache never stores a credential, so stamp the one this
+                    # call is authorized with rather than leaking another
+                    # caller's key or a stale configured one.
+                    cached_model.api_key = api_key
+                    return cached_model
+
+                if not cache.has_valid_cache():
                     model_list_resp = cls.list(model_ids=None, api_key=api_key)
                     models = model_list_resp["results"]
                     cache.add_list(models)
                     for model in models:
                         if model.id == model_id:
                             return model
+
+                logging.info("Model not found in valid cache, fetching individually...")
+                model = cls._fetch_model_by_id(model_id, api_key)
+                cache.add(model)
+                return model
             except Exception as e:
                 logging.warning(f"Cache lookup failed, falling back to direct fetch: {e}")
 
         logging.info("Fetching model directly without cache...")
-        model = cls._fetch_model_by_id(model_id, api_key)
-        cache.add(model)
-        return model
+        return cls._fetch_model_by_id(model_id, api_key)
 
     @classmethod
     def _fetch_model_by_name(cls, name: Text, api_key: Optional[Text] = None) -> Model:

--- a/aixplain/v1/factories/model_factory/utils.py
+++ b/aixplain/v1/factories/model_factory/utils.py
@@ -332,7 +332,10 @@ def get_model_from_ids(model_ids: List[str], api_key: Optional[str] = None) -> L
             total_items = resp.get("total", 0)
             process_items(page_items)
 
-            while True:
+            # Only ask for further pages when the first one did not cover the
+            # batch. The exit condition used to be checked after the request, so
+            # every batch paid for one extra round trip even when complete.
+            while total_fetched < total_items:
                 # Make request for current page
                 paginated_url = urljoin(
                     config.BACKEND_URL, f"sdk/models?ids={','.join(model_ids)}&pageNumber={page_number}"
@@ -353,10 +356,6 @@ def get_model_from_ids(model_ids: List[str], api_key: Optional[str] = None) -> L
 
                 process_items(page_items)
                 total_fetched += len(page_items)
-
-                if total_fetched >= total_items:
-                    break
-
                 page_number += 1
         else:
             # Handle non-paginated response (original logic)

--- a/aixplain/v1/modules/model/__init__.py
+++ b/aixplain/v1/modules/model/__init__.py
@@ -72,6 +72,30 @@ class Model(Asset):
         additional_info (dict): Additional model metadata.
     """
 
+    #: Fields persisted by :class:`~aixplain.utils.asset_cache.AssetCache`.
+    #:
+    #: This is an allowlist, and deliberately so: ``api_key`` is held as a plain
+    #: instance attribute, so serializing ``__dict__`` wrote the account
+    #: credential into the cache file in cleartext (BUG-940). Anything not named
+    #: here never reaches disk. The set mirrors what :meth:`from_dict` reads, so
+    #: cached entries round-trip.
+    __cache_fields__ = (
+        "id",
+        "name",
+        "description",
+        "supplier",
+        "version",
+        "function",
+        "is_subscribed",
+        "cost",
+        "created_at",
+        "input_params",
+        "output_params",
+        "model_params",
+        "status",
+        "additional_info",
+    )
+
     def __init__(
         self,
         id: Text,
@@ -612,10 +636,18 @@ class Model(Asset):
                 - input_params: Input parameter configuration
                 - output_params: Output parameter configuration
                 - model_params: Model behavior parameters
+                - status: Current model status
                 - additional_info: Extra metadata
 
         Returns:
             Model: A new Model instance populated with the dictionary data.
+
+        Note:
+            ``api_key`` is optional and falls back to the configured
+            ``TEAM_API_KEY``. Cached payloads never carry it (see
+            ``__cache_fields__``), so a model rebuilt from cache authenticates
+            with the credential of the current session rather than a stale one
+            recovered from disk.
         """
         return cls(
             id=data.get("id", ""),
@@ -631,5 +663,6 @@ class Model(Asset):
             input_params=data.get("input_params"),
             output_params=data.get("output_params"),
             model_params=data.get("model_params"),
+            status=data.get("status", AssetStatus.ONBOARDED),
             **data.get("additional_info", {}),
         )

--- a/tests/functional/model/run_model_test.py
+++ b/tests/functional/model/run_model_test.py
@@ -16,7 +16,12 @@ from aixplain.factories.index_factory.utils import (
 import time
 import os
 import json
+import stat
 
+from aixplain.utils import config
+
+#: Location the cache must never use. Kept as a literal so the assertions below
+#: still fail if the default moves back into the working directory (BUG-940).
 CACHE_FOLDER = ".cache"
 
 
@@ -246,20 +251,30 @@ def test_llm_run_with_file():
     assert "🤖" in response["data"], "Robot emoji should be present in the response"
 
 
-def test_aixplain_model_cache_creation():
-    """Ensure AssetCache is triggered and cache is created."""
+MODEL_ID_FOR_CACHE = "6239efa4822d7a13b8e20454"  # Translate from Punjabi to Portuguese (Brazil)
 
-    cache_file = os.path.join(CACHE_FOLDER, "model.json")
 
-    # Clean up cache before the test
-    if os.path.exists(cache_file):
-        os.remove(cache_file)
+@pytest.fixture
+def model_cache():
+    """Yield a clean model AssetCache, and leave nothing behind."""
+    from aixplain.modules.model import Model
+    from aixplain.utils.asset_cache import AssetCache
 
-    # Instantiate the Model (replace this with a real model ID from your env)
-    model_id = "6239efa4822d7a13b8e20454"  # Translate from Punjabi to Portuguese (Brazil)
-    _ = ModelFactory.get(model_id)
+    AssetCache.reset_shared()
+    cache = AssetCache(Model)
+    cache.invalidate()
+    try:
+        yield cache
+    finally:
+        cache.invalidate()
+        AssetCache.reset_shared()
 
-    # Assert the cache file was created
+
+def test_aixplain_model_cache_creation(model_cache):
+    """Ensure AssetCache is triggered and cache is created when caching is requested."""
+    _ = ModelFactory.get(MODEL_ID_FOR_CACHE, use_cache=True)
+
+    cache_file = model_cache.cache_file
     assert os.path.exists(cache_file), "Expected cache file was not created."
 
     with open(cache_file, "r", encoding="utf-8") as f:
@@ -268,7 +283,49 @@ def test_aixplain_model_cache_creation():
     assert "data" in cache_data, "Cache file structure invalid - missing 'data' key."
     # Cache structure is: {"expiry": ..., "data": {"model_id": {...}}}
     # So we check if the model_id exists as a key in cache_data["data"]
-    assert model_id in cache_data["data"], "Instantiated model not found in cache."
+    assert MODEL_ID_FOR_CACHE in cache_data["data"], "Instantiated model not found in cache."
+
+
+def test_aixplain_model_cache_never_persists_the_api_key(model_cache):
+    """The account credential must not reach the cache file (BUG-940).
+
+    ``Model`` holds ``api_key`` as a plain instance attribute, so serializing
+    ``__dict__`` wrote the team key to disk in cleartext.
+    """
+    _ = ModelFactory.get(MODEL_ID_FOR_CACHE, use_cache=True)
+
+    raw = Path(model_cache.cache_file).read_text(encoding="utf-8")
+    assert "api_key" not in raw, "Cache file must not contain an api_key field."
+    assert config.TEAM_API_KEY not in raw, "Cache file must not contain the account credential."
+
+
+def test_aixplain_model_cache_is_private_and_outside_the_cwd(model_cache):
+    """The cache must be owner-only, and must not be written into $CWD (BUG-940).
+
+    A cache in the working directory is readable by anything sharing it: another
+    job on a CI runner, a Docker build layer, any local process.
+    """
+    _ = ModelFactory.get(MODEL_ID_FOR_CACHE, use_cache=True)
+
+    cache_file = Path(model_cache.cache_file)
+    assert not Path(CACHE_FOLDER).exists(), f"Cache must not be created in $CWD ({CACHE_FOLDER})."
+    assert Path.cwd() not in cache_file.parents, f"Cache must live outside $CWD, got {cache_file}."
+
+    if os.name != "nt":  # POSIX modes are not meaningful on Windows
+        assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600, "Cache file must be mode 0600."
+        assert stat.S_IMODE(cache_file.parent.stat().st_mode) == 0o700, "Cache directory must be mode 0700."
+
+
+def test_model_get_without_cache_writes_nothing(model_cache):
+    """``use_cache=False`` must not write the cache (BUG-940).
+
+    Opting out of caching has to also opt out of persisting the model -- and so
+    the credential it used to carry.
+    """
+    _ = ModelFactory.get(MODEL_ID_FOR_CACHE)  # use_cache defaults to False
+
+    assert not os.path.exists(model_cache.cache_file), "use_cache=False must not write the cache file."
+    assert not Path(CACHE_FOLDER).exists(), f"use_cache=False must not create {CACHE_FOLDER}."
 
 
 @pytest.mark.skip(reason="Flaky on test env: sample image asset returns 404 during document parsing")

--- a/tests/functional/model/run_model_test.py
+++ b/tests/functional/model/run_model_test.py
@@ -22,7 +22,12 @@ from aixplain.utils import config
 
 #: Location the cache must never use. Kept as a literal so the assertions below
 #: still fail if the default moves back into the working directory (BUG-940).
+#: The assertions target the cache *file*, not this directory: ".cache" is a
+#: common name, and a checkout where an older SDK once ran still has one, so
+#: asserting on the directory would fail on pre-existing state instead of on
+#: what the code under test did.
 CACHE_FOLDER = ".cache"
+LEGACY_CACHE_FILE = os.path.join(CACHE_FOLDER, "model.json")
 
 
 def pytest_generate_tests(metafunc):
@@ -308,7 +313,7 @@ def test_aixplain_model_cache_is_private_and_outside_the_cwd(model_cache):
     _ = ModelFactory.get(MODEL_ID_FOR_CACHE, use_cache=True)
 
     cache_file = Path(model_cache.cache_file)
-    assert not Path(CACHE_FOLDER).exists(), f"Cache must not be created in $CWD ({CACHE_FOLDER})."
+    assert not Path(LEGACY_CACHE_FILE).exists(), f"Cache must not be created in $CWD ({LEGACY_CACHE_FILE})."
     assert Path.cwd() not in cache_file.parents, f"Cache must live outside $CWD, got {cache_file}."
 
     if os.name != "nt":  # POSIX modes are not meaningful on Windows
@@ -325,7 +330,7 @@ def test_model_get_without_cache_writes_nothing(model_cache):
     _ = ModelFactory.get(MODEL_ID_FOR_CACHE)  # use_cache defaults to False
 
     assert not os.path.exists(model_cache.cache_file), "use_cache=False must not write the cache file."
-    assert not Path(CACHE_FOLDER).exists(), f"use_cache=False must not create {CACHE_FOLDER}."
+    assert not Path(LEGACY_CACHE_FILE).exists(), f"use_cache=False must not create {LEGACY_CACHE_FILE}."
 
 
 @pytest.mark.skip(reason="Flaky on test env: sample image asset returns 404 during document parsing")

--- a/tests/unit/model_factory_cache_test.py
+++ b/tests/unit/model_factory_cache_test.py
@@ -1,0 +1,212 @@
+"""Tests for ModelFactory.get's use of the shared asset cache (BUG-940).
+
+These exercise the getter rather than the cache: the cache-key form, what the
+cold path does to entries it did not fetch, and what happens when the bulk
+listing is unhealthy. All requests are mocked, and any real HTTP is an error.
+"""
+
+import contextlib
+import json
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from aixplain.modules.model import Model
+from aixplain.utils.asset_cache import AssetCache
+
+SLUG_ID = "aixplain/openai/gpt-4o-mini/openai"
+
+
+def model_payload(model_id):
+    """A minimal backend model response."""
+    return {
+        "id": model_id,
+        "name": f"model {model_id}",
+        "description": "",
+        "supplier": {"id": 1, "name": "aixplain", "code": "aixplain"},
+        "version": {"id": "1.0"},
+        "function": {"id": "text-generation"},
+        "pricing": {"price": 0},
+        "status": "onboarded",
+        "params": [],
+    }
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload, self.status_code = payload, status_code
+
+    def json(self):
+        return json.loads(json.dumps(self._payload))
+
+
+class FakeBackend:
+    """Serves the model endpoints and records every URL requested.
+
+    ``canonical_ids`` mimics a backend that answers a request by slug with the
+    model's own id, which is what makes the cache-key form observable.
+    """
+
+    def __init__(self, listing=(), paginate_error=None):
+        self.listing = list(listing)
+        self.paginate_error = paginate_error
+        self.calls = []
+
+    def __call__(self, method, url, *args, **kwargs):
+        self.calls.append(url)
+        if "paginate" in url:
+            if self.paginate_error:
+                raise self.paginate_error
+            return FakeResponse({"items": [model_payload(i) for i in self.listing], "total": len(self.listing)})
+        if "?ids=" in url:
+            wanted = url.split("?ids=")[1].split("&")[0].split(",")
+            return FakeResponse({"items": [model_payload(i) for i in wanted], "total": len(wanted)})
+        if "sdk/models/" in url:
+            requested = url.rstrip("/").split("sdk/models/")[1].split("?")[0]
+            # The backend answers with the canonical, unescaped id.
+            return FakeResponse(model_payload(requested.replace("%2F", "/")))
+        raise AssertionError(f"unexpected URL: {url}")
+
+    @property
+    def paginate_calls(self):
+        return [u for u in self.calls if "paginate" in u]
+
+    @property
+    def direct_calls(self):
+        # "sdk/models/paginate" also starts with "sdk/models/", so exclude it.
+        return [u for u in self.calls if "sdk/models/" in u and "paginate" not in u]
+
+
+@contextlib.contextmanager
+def mocked_backend(backend):
+    """Patch every imported reference to ``_request_with_retry``.
+
+    Call sites do ``from aixplain.utils.request_utils import
+    _request_with_retry``, so each module holds its own reference and patching
+    only the source module lets real HTTP through.
+    """
+    targets = {"aixplain.utils.request_utils"}
+    for name, module in list(sys.modules.items()):
+        if name.startswith("aixplain") and hasattr(module, "_request_with_retry"):
+            targets.add(name)
+
+    def no_network(*args, **kwargs):
+        raise AssertionError(f"real HTTP escaped the mock: {args[:2]}")
+
+    with contextlib.ExitStack() as stack:
+        for name in targets:
+            stack.enter_context(patch(f"{name}._request_with_retry", side_effect=backend))
+        stack.enter_context(patch.object(requests.Session, "request", no_network))
+        stack.enter_context(patch.object(requests, "request", no_network))
+        yield backend
+
+
+@pytest.fixture
+def factory(tmp_path, monkeypatch):
+    """Isolate the cache and hand back ModelFactory."""
+    monkeypatch.setenv("AIXPLAIN_CACHE_FOLDER", str(tmp_path / "cache"))
+    monkeypatch.chdir(tmp_path)
+    # config reads the environment at import time, so set the attribute.
+    monkeypatch.setattr("aixplain.utils.config.TEAM_API_KEY", "SENTINEL_KEY")
+    AssetCache.reset_shared()
+
+    from aixplain.factories import ModelFactory
+
+    yield ModelFactory
+    AssetCache.reset_shared()
+
+
+def test_a_slug_id_hits_the_cache_on_the_second_get(factory):
+    """A repeated lookup by slug must not re-issue the request.
+
+    The getter percent-escaped the id before the cache lookup while writes
+    keyed on the raw id, so ids containing "/" -- documented model paths such
+    as "openai/gpt-4o-mini/openai" -- never hit the cache. Every call refetched
+    and rewrote the file under the exclusive lock.
+    """
+    backend = FakeBackend()
+    with mocked_backend(backend):
+        first = factory.get(SLUG_ID, use_cache=True)
+        after_first = len(backend.direct_calls)
+        second = factory.get(SLUG_ID, use_cache=True)
+
+    assert first.id == SLUG_ID and second.id == SLUG_ID
+    assert len(backend.direct_calls) == after_first, "the second get must be served from cache"
+    assert SLUG_ID in AssetCache.shared(Model), "the entry must be keyed on the unescaped id"
+
+
+def test_a_slug_id_is_still_escaped_in_the_request_url(factory):
+    """Moving the escaping must not send raw slashes as path segments."""
+    backend = FakeBackend()
+    with mocked_backend(backend):
+        factory.get(SLUG_ID, use_cache=False)
+
+    assert backend.direct_calls, "expected a direct fetch"
+    assert "%2F" in backend.direct_calls[0]
+    assert f"sdk/models/{SLUG_ID}" not in backend.direct_calls[0]
+
+
+def test_an_expired_store_does_not_clobber_a_populated_cache_file(factory):
+    """A long-lived process whose store expired must not wipe the file.
+
+    Expiry only cleared memory, so the next lookup took the cold path, replaced
+    the cache with the ~20 models on the first listing page (``add_list``), and
+    discarded everything other processes had written since. Reloading on expiry
+    and adding additively both have to hold for this to be safe.
+    """
+    cache = AssetCache.shared(Model)
+    cache.add_many([Model(id=f"prior-{i}", api_key="SENTINEL_KEY") for i in range(50)])
+    assert len(json.load(open(cache.cache_file, encoding="utf-8"))["data"]) == 50
+
+    # The in-process copy goes stale while the file stays fresh.
+    cache.store.expiry = time.time() - 1
+
+    backend = FakeBackend(listing=["page-a", "page-b"])
+    with mocked_backend(backend):
+        factory.get("prior-7", use_cache=True)
+
+    on_disk = json.load(open(cache.cache_file, encoding="utf-8"))["data"]
+    assert "prior-7" in on_disk, "entries this process did not fetch must survive"
+    assert len(on_disk) >= 50, f"cache shrank to {len(on_disk)} entries"
+
+
+def test_a_failing_listing_is_not_retried_on_every_call(factory):
+    """When the bulk listing is unhealthy, the direct fetch is still cached.
+
+    The fallback stopped caching, so with use_cache=True and a failing paginate
+    every lookup re-issued the failing POST -- with retries -- before its direct
+    GET. A 10-tool agent paid that on every build.
+    """
+    backend = FakeBackend(paginate_error=RuntimeError("paginate 503"))
+    with mocked_backend(backend):
+        for _ in range(3):
+            factory.get("m-9", use_cache=True)
+
+    assert len(backend.paginate_calls) == 1, f"paginate attempted {len(backend.paginate_calls)} times"
+    assert len(backend.direct_calls) == 1, f"direct fetch repeated {len(backend.direct_calls)} times"
+    assert "m-9" in AssetCache.shared(Model)
+
+
+def test_use_cache_false_still_writes_nothing_when_the_cache_is_unhealthy(factory):
+    """The new fallback caching must not leak into the opt-out path."""
+    backend = FakeBackend(paginate_error=RuntimeError("paginate 503"))
+    with mocked_backend(backend):
+        factory.get("m-9")
+
+    assert not AssetCache.shared(Model).has_valid_cache()
+    assert "m-9" not in AssetCache.shared(Model)
+
+
+def test_an_explicit_api_key_is_not_served_from_another_callers_entry(factory):
+    """A cache hit carries the key the current call is authorized with."""
+    backend = FakeBackend()
+    with mocked_backend(backend):
+        factory.get("m-1", use_cache=True)
+        other = factory.get("m-1", api_key="OTHER_KEY", use_cache=True)
+        mine = factory.get("m-1", use_cache=True)
+
+    assert other.api_key == "OTHER_KEY"
+    assert mine.api_key == "SENTINEL_KEY"

--- a/tests/unit/utils/asset_cache_test.py
+++ b/tests/unit/utils/asset_cache_test.py
@@ -5,8 +5,11 @@ The cache mechanism itself was already covered; what was not covered was
 per call. Each test here pins one of those.
 """
 
+import contextlib
+import copy
 import json
 import os
+import pickle
 import stat
 import subprocess
 import sys
@@ -18,6 +21,7 @@ import pytest
 
 from aixplain.enums import AssetStatus, Function
 from aixplain.modules.model import Model
+from aixplain.modules.model.model_parameters import ModelParameters
 from aixplain.utils.asset_cache import (
     AssetCache,
     Store,
@@ -77,14 +81,20 @@ def test_serialize_asset_drops_the_api_key():
     "field",
     ["api_key", "token", "password", "secret", "access_token", "refresh_token", "client_secret", "authorization"],
 )
-def test_serialize_redacts_credential_shaped_keys_at_any_depth(field):
-    """Credential-shaped keys are dropped however deeply they are nested."""
-    payload = serialize({"outer": {"inner": [{field: SENTINEL_KEY, "keep": 1}]}})
+def test_serialize_is_faithful_and_does_not_drop_nested_keys(field):
+    """``serialize`` converts; it does not decide what may be persisted.
 
-    assert payload == {"outer": {"inner": [{"keep": 1}]}}
+    It used to drop credential-shaped keys at every depth, which silently
+    deleted user-defined parameters that happened to share those names. What
+    may be persisted is decided from the asset's own attribute names, in
+    :func:`serialize_asset`.
+    """
+    payload = serialize({"outer": {"inner": [{field: "a-parameter-value", "keep": 1}]}})
+
+    assert payload == {"outer": {"inner": [{field: "a-parameter-value", "keep": 1}]}}
 
 
-def test_serialize_redacts_credentials_on_arbitrary_objects():
+def test_serialize_asset_drops_credentials_on_arbitrary_objects():
     """A cached object that is not a Model still has its credential scrubbed."""
 
     class Holder:
@@ -92,7 +102,7 @@ def test_serialize_redacts_credentials_on_arbitrary_objects():
             self.api_key = SENTINEL_KEY
             self.name = "holder"
 
-    assert serialize(Holder()) == {"name": "holder"}
+    assert serialize_asset(Holder()) == {"name": "holder"}
 
 
 def test_environment_fields_are_not_persisted(cache_folder):
@@ -631,3 +641,214 @@ def test_a_shared_instance_stops_serving_entries_once_expired(cache_folder, monk
     assert cache.get("m-1") is None
     assert "m-1" not in cache
     assert not cache.has_valid_cache()
+
+
+# ======================================================================
+# Regression tests for the review of 515a133a. Each fails on that commit.
+# ======================================================================
+
+
+class _FchmodAbsent:
+    """Context manager removing ``os.fchmod``, as on Windows."""
+
+    def __enter__(self):
+        self._saved = os.fchmod
+        del os.fchmod
+
+    def __exit__(self, *exc):
+        os.fchmod = self._saved
+
+
+def _raise(exc):
+    def _boom(*args, **kwargs):
+        raise exc
+
+    return _boom
+
+
+@pytest.mark.parametrize(
+    "label, context",
+    [
+        ("absent", _FchmodAbsent()),
+        ("raises AttributeError", None),  # filled in below; patch needs the module
+        ("raises OSError", None),
+    ],
+)
+def test_write_succeeds_when_fchmod_is_unavailable(tmp_path, label, context, monkeypatch):
+    """Tightening permissions must never be what prevents the write (BUG-940).
+
+    ``os.fchmod`` is Unix-only, and a missing attribute raises ``AttributeError``
+    -- not ``OSError``. That escaped the handler, aborted the write and left
+    ``save()`` logging a failure, so every cache write failed on Windows while
+    the base branch's plain ``open()`` worked there. CI is Linux-only, so
+    nothing caught it.
+    """
+    if label == "raises AttributeError":
+        monkeypatch.setattr(os, "fchmod", _raise(AttributeError("no fchmod")))
+        context = contextlib.nullcontext()
+    elif label == "raises OSError":
+        monkeypatch.setattr(os, "fchmod", _raise(OSError("unsupported")))
+        context = contextlib.nullcontext()
+
+    target = tmp_path / "out.json"
+    with context:
+        atomic_write_private(str(target), '{"a": 1}')
+
+    assert json.loads(target.read_text()) == {"a": 1}
+    assert [p.name for p in tmp_path.iterdir()] == ["out.json"], "no temporary file may be left behind"
+
+
+@POSIX_ONLY
+def test_permissions_still_applied_through_the_chmod_fallback(tmp_path):
+    """With no ``os.fchmod``, the path-based fallback still yields 0600."""
+    target = tmp_path / "out.json"
+    with _FchmodAbsent():
+        atomic_write_private(str(target), "{}")
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_a_model_carrying_parameters_can_be_deep_copied():
+    """``deepcopy`` of a Model with ``model_params`` must not raise.
+
+    ``BaseParameters.__getattr__`` read ``self.parameters``, which misses on the
+    attribute-less instance ``copy`` builds before restoring state, re-entering
+    ``__getattr__`` until ``RecursionError``. ``get()`` then silently fell back
+    to a shallow copy.
+    """
+    original = make_model(model_params={"temperature": {"required": False}})
+
+    duplicate = copy.deepcopy(original)
+
+    assert duplicate.model_params is not original.model_params
+    assert duplicate.id == original.id
+
+
+def test_base_parameters_survives_pickling():
+    """The same defect broke pickling, e.g. across a process pool."""
+    params = ModelParameters({"temperature": {"required": False}})
+
+    assert "temperature" in pickle.loads(pickle.dumps(params)).parameters
+
+
+def test_undefined_parameter_still_raises_attribute_error():
+    """The __getattr__ fix must not weaken the error it reports."""
+    params = ModelParameters({"temperature": {"required": False}})
+
+    with pytest.raises(AttributeError, match="Parameter 'nope' is not defined"):
+        params.nope
+
+
+def test_isolation_holds_for_a_model_carrying_parameters(cache_folder):
+    """Isolation must hold for the models that actually reach the cache.
+
+    The earlier isolation test used a Model without ``model_params``, the one
+    shape whose ``deepcopy`` succeeded, so it proved nothing about the case
+    that matters.
+    """
+    cache = AssetCache(Model)
+    cache.add(make_model(displayName="original", model_params={"temperature": {"required": False}}))
+
+    borrowed = cache.get("m-1")
+    borrowed.additional_info["displayName"] = "mutated"
+    borrowed.model_params.temperature = 0.99
+
+    fresh = cache.get("m-1")
+    assert fresh.additional_info["displayName"] == "original"
+    assert fresh.model_params.parameters["temperature"].value is None
+
+
+def test_add_does_not_keep_the_callers_object(cache_folder):
+    """``add()`` stores a copy, so the caller never holds the cached entry.
+
+    ``ModelFactory.get`` returns the object it just added. On a shared instance
+    that handed every later reader an object the first caller was still free to
+    mutate -- ``build_llm`` assigns a temperature to it -- so a second agent
+    with the same llmId silently inherited the first agent's settings.
+    """
+    mine = make_model(model_params={"temperature": {"required": False}})
+    cache = AssetCache(Model)
+    cache.add(mine)
+
+    assert cache.store.data["m-1"] is not mine
+
+    mine.temperature = 0.9  # what build_llm does to the object it was handed
+    mine.additional_info["leaked"] = True
+
+    assert getattr(cache.get("m-1"), "temperature", None) != 0.9
+    assert "leaked" not in cache.get("m-1").additional_info
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"expiry": null, "data": {}}',
+        '{"expiry": 99999999999, "data": []}',
+        '{"expiry": "soon", "data": {}}',
+        '{"data": {}}',
+        "[]",
+        "{not json",
+    ],
+)
+def test_a_malformed_cache_file_never_escapes_construction(cache_folder, payload):
+    """A bad cache file must self-heal, not break every caller.
+
+    ``load()`` runs from ``__init__``, and ``agent_factory`` calls
+    ``AssetCache.shared(Model)`` outside its own try, so an exception here made
+    every ``AgentFactory.get`` with tools fail until the file was deleted by
+    hand.
+    """
+    os.makedirs(cache_folder, exist_ok=True)
+    (cache_folder / "model.json").write_text(payload)
+
+    cache = AssetCache.shared(Model)  # must not raise
+
+    assert cache.get_all() == []
+    assert not cache.has_valid_cache()
+
+
+@pytest.mark.parametrize("name", ["url", "token", "password", "secret", "authorization", "backend_url", "api_key"])
+def test_a_parameter_named_like_a_credential_is_still_persisted(cache_folder, name):
+    """Parameter *names* are data and must survive the credential filter.
+
+    Redacting by key name at every depth also stripped user-defined parameters,
+    because ``input_params``/``output_params``/``model_params`` are keyed by
+    parameter name. A fetch tool taking a ``url`` was cached without it; next
+    process ``ModelTool.validate_parameters`` raised, ``build_tool_safe``
+    swallowed it, and the tool disappeared for the whole TTL.
+    """
+    payload = serialize_asset(
+        make_model(
+            input_params={"text": {"required": True}, name: {"required": True}},
+            model_params={name: {"required": True}},
+        )
+    )
+
+    assert name in payload["input_params"], f"input parameter {name!r} was dropped"
+    assert name in payload["model_params"], f"model parameter {name!r} was dropped"
+
+
+def test_the_credential_attribute_is_still_excluded(cache_folder):
+    """Narrowing redaction must not reintroduce the leak it replaced."""
+    payload = serialize_asset(make_model(input_params={"url": {"required": True}}))
+    raw = json.dumps(payload)
+
+    assert "api_key" not in payload
+    assert SENTINEL_KEY not in raw
+    assert payload["input_params"]["url"] == {"required": True}
+
+
+def test_credential_attributes_are_excluded_without_an_allowlist():
+    """Assets with no ``__cache_fields__`` still lose their top-level secrets."""
+
+    class Untyped:
+        def __init__(self):
+            self.id = "u-1"
+            self.api_key = SENTINEL_KEY
+            self.backend_url = "https://internal"
+            self.params = {"url": "https://example.com"}
+
+    payload = serialize_asset(Untyped())
+
+    assert "api_key" not in payload and "backend_url" not in payload
+    assert payload["params"] == {"url": "https://example.com"}, "nested data must be untouched"

--- a/tests/unit/utils/asset_cache_test.py
+++ b/tests/unit/utils/asset_cache_test.py
@@ -1,0 +1,633 @@
+"""Tests for the asset cache's credential, permission and cost behaviour (BUG-940).
+
+The cache mechanism itself was already covered; what was not covered was
+*what* the cache writes, *where*, with *which* permissions, and what it costs
+per call. Each test here pins one of those.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from aixplain.enums import AssetStatus, Function
+from aixplain.modules.model import Model
+from aixplain.utils.asset_cache import (
+    AssetCache,
+    Store,
+    atomic_write_private,
+    default_cache_folder,
+    serialize,
+    serialize_asset,
+)
+
+SENTINEL_KEY = "SUPERSECRET_SENTINEL_0123456789abcdef"
+POSIX_ONLY = pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not meaningful on Windows")
+
+
+@pytest.fixture
+def cache_folder(tmp_path, monkeypatch):
+    """Point the cache at an isolated directory and drop shared instances."""
+    folder = tmp_path / "cache"
+    monkeypatch.setenv("AIXPLAIN_CACHE_FOLDER", str(folder))
+    monkeypatch.delenv("CACHE_EXPIRY_TIME", raising=False)
+    monkeypatch.delenv("CACHE_MAX_ENTRIES", raising=False)
+    AssetCache.reset_shared()
+    yield folder
+    AssetCache.reset_shared()
+
+
+def make_model(model_id="m-1", api_key=SENTINEL_KEY, **kwargs):
+    """Build a Model carrying a recognisable credential."""
+    kwargs.setdefault("name", f"model {model_id}")
+    kwargs.setdefault("function", Function.TEXT_GENERATION)
+    return Model(id=model_id, api_key=api_key, **kwargs)
+
+
+# ----------------------------------------------------------------------
+# 1. The credential must never be persisted
+# ----------------------------------------------------------------------
+
+
+def test_saved_cache_never_contains_the_api_key(cache_folder):
+    """The account credential must not appear in the cache file."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    raw = open(cache.cache_file, encoding="utf-8").read()
+    assert SENTINEL_KEY not in raw
+    assert "api_key" not in raw
+
+
+def test_serialize_asset_drops_the_api_key():
+    """The persisted projection of a Model excludes api_key."""
+    payload = serialize_asset(make_model())
+
+    assert "api_key" not in payload
+    assert payload["id"] == "m-1"
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["api_key", "token", "password", "secret", "access_token", "refresh_token", "client_secret", "authorization"],
+)
+def test_serialize_redacts_credential_shaped_keys_at_any_depth(field):
+    """Credential-shaped keys are dropped however deeply they are nested."""
+    payload = serialize({"outer": {"inner": [{field: SENTINEL_KEY, "keep": 1}]}})
+
+    assert payload == {"outer": {"inner": [{"keep": 1}]}}
+
+
+def test_serialize_redacts_credentials_on_arbitrary_objects():
+    """A cached object that is not a Model still has its credential scrubbed."""
+
+    class Holder:
+        def __init__(self):
+            self.api_key = SENTINEL_KEY
+            self.name = "holder"
+
+    assert serialize(Holder()) == {"name": "holder"}
+
+
+def test_environment_fields_are_not_persisted(cache_folder):
+    """Backend URLs describe the session, not the asset, so they are not cached."""
+    payload = serialize_asset(make_model())
+
+    assert "url" not in payload
+    assert "backend_url" not in payload
+
+
+def test_cached_model_authenticates_with_the_live_credential(cache_folder):
+    """A model rebuilt from cache uses the configured key, not one from disk."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("aixplain.utils.config.TEAM_API_KEY", "ROTATED_KEY")
+        AssetCache.reset_shared()
+        reloaded = AssetCache(Model).get("m-1")
+
+    assert reloaded.api_key == "ROTATED_KEY"
+
+
+# ----------------------------------------------------------------------
+# 2. Permissions and atomicity
+# ----------------------------------------------------------------------
+
+
+@POSIX_ONLY
+def test_cache_file_is_owner_only_and_directory_is_0700(cache_folder):
+    """The cache file is 0600 inside a 0700 directory."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    assert stat.S_IMODE(os.stat(cache.cache_file).st_mode) == 0o600
+    assert stat.S_IMODE(os.stat(cache.cache_folder).st_mode) == 0o700
+
+
+@POSIX_ONLY
+def test_permissions_are_repaired_for_a_directory_left_by_an_older_version(cache_folder):
+    """A pre-existing world-readable cache directory is tightened on save."""
+    os.makedirs(cache_folder, exist_ok=True)
+    os.chmod(cache_folder, 0o755)
+
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    assert stat.S_IMODE(os.stat(cache.cache_folder).st_mode) == 0o700
+
+
+@POSIX_ONLY
+def test_cache_file_is_never_world_readable_at_any_point(cache_folder):
+    """No window exists in which the file is readable by others.
+
+    The write goes to a private temporary file and is renamed into place, so
+    every intermediate file observed in the directory is also 0600.
+    """
+    cache = AssetCache(Model)
+    observed = []
+
+    real_replace = os.replace
+
+    def spy(src, dst):
+        # Inspect every data-bearing file present in the cache directory
+        # mid-write. The filelock lock file is excluded: it is always empty --
+        # it carries an advisory lock, not cache content -- and the enclosing
+        # 0700 directory already keeps other users out of it.
+        folder = os.path.dirname(src) or "."
+        for name in os.listdir(folder):
+            path = os.path.join(folder, name)
+            if os.path.isfile(path) and not name.endswith(".lock"):
+                observed.append(stat.S_IMODE(os.stat(path).st_mode))
+        return real_replace(src, dst)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("aixplain.utils.asset_cache.os.replace", spy)
+        cache.add(make_model())
+
+    assert observed, "expected to observe the temporary file mid-write"
+    assert all(mode & 0o077 == 0 for mode in observed), f"group/other bits set: {[oct(m) for m in observed]}"
+
+
+def test_a_failed_serialization_leaves_the_previous_cache_intact(cache_folder):
+    """Serialization happens before the file is touched, so nothing truncates."""
+    cache = AssetCache(Model)
+    cache.add(make_model("m-1"))
+    good = open(cache.cache_file, encoding="utf-8").read()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("aixplain.utils.asset_cache.json.dumps", lambda *a, **k: (_ for _ in ()).throw(ValueError("boom")))
+        cache.add(make_model("m-2"))
+
+    assert open(cache.cache_file, encoding="utf-8").read() == good
+
+
+def test_atomic_write_private_replaces_content_wholesale(tmp_path):
+    """atomic_write_private overwrites without leaving temporary files behind."""
+    target = tmp_path / "out.json"
+    atomic_write_private(str(target), '{"a": 1}')
+    atomic_write_private(str(target), '{"b": 2}')
+
+    assert json.loads(target.read_text()) == {"b": 2}
+    assert [p.name for p in tmp_path.iterdir()] == ["out.json"]
+
+
+# ----------------------------------------------------------------------
+# 3. Location
+# ----------------------------------------------------------------------
+
+
+def test_cache_folder_is_not_the_working_directory(monkeypatch, tmp_path):
+    """The default cache location is the per-user cache dir, never $CWD."""
+    monkeypatch.delenv("AIXPLAIN_CACHE_FOLDER", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    monkeypatch.chdir(tmp_path)
+
+    folder = default_cache_folder()
+
+    assert folder == str(tmp_path / "xdg" / "aixplain")
+    assert os.path.relpath(folder, tmp_path) != "."
+    assert ".cache" not in os.path.relpath(folder, tmp_path).split(os.sep)[:1]
+
+
+def test_cache_folder_falls_back_to_home_when_xdg_is_unset(monkeypatch, tmp_path):
+    """Without XDG_CACHE_HOME the cache lands in ~/.cache/aixplain."""
+    monkeypatch.delenv("AIXPLAIN_CACHE_FOLDER", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr("os.path.expanduser", lambda p: p.replace("~", str(tmp_path)))
+    monkeypatch.setattr("aixplain.utils.asset_cache.sys.platform", "linux")
+
+    assert default_cache_folder() == str(tmp_path / ".cache" / "aixplain")
+
+
+def test_nothing_is_written_into_the_working_directory(cache_folder, tmp_path, monkeypatch):
+    """Using the cache leaves the working directory untouched."""
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    AssetCache(Model).add(make_model())
+
+    assert list(work.iterdir()) == []
+
+
+# ----------------------------------------------------------------------
+# 4. Constructing a cache must not write
+# ----------------------------------------------------------------------
+
+
+def test_constructing_a_cache_writes_nothing(cache_folder):
+    """A cache only touches disk once something is added.
+
+    This is what lets ``ModelFactory.get(..., use_cache=False)`` avoid writing.
+    """
+    cache = AssetCache(Model)
+
+    assert not os.path.exists(cache.cache_file)
+
+
+# ----------------------------------------------------------------------
+# 5. Locking
+# ----------------------------------------------------------------------
+
+
+def test_invalidate_leaves_the_lock_file_in_place(cache_folder):
+    """invalidate() must not unlink the lock it may be running under.
+
+    Unlinking it drops mutual exclusion: another process recreates the path and
+    takes flock on a different inode, so both enter the critical section.
+    """
+    cache = AssetCache(Model)
+    cache.add(make_model())
+    assert os.path.exists(cache.lock_file)
+
+    cache.invalidate()
+
+    assert not os.path.exists(cache.cache_file), "the data file should be removed"
+    assert os.path.exists(cache.lock_file), "the lock file must survive invalidate()"
+
+
+def test_expiry_does_not_delete_the_lock_file(cache_folder, monkeypatch):
+    """Loading an expired cache keeps the lock file."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+    lock = cache.lock_file
+
+    cache.store.expiry = time.time() - 10
+    cache.save()
+    AssetCache.reset_shared()
+    reloaded = AssetCache(Model)
+
+    assert reloaded.get("m-1") is None, "an expired cache must not serve entries"
+    assert os.path.exists(lock)
+
+
+CONCURRENT_WORKER = textwrap.dedent(
+    """
+    import os, sys, time
+    from filelock import FileLock
+    from aixplain.utils.asset_cache import AssetCache
+    from aixplain.modules.model import Model
+
+    tag, log = sys.argv[1], sys.argv[2]
+    cache = AssetCache(Model)
+    for _ in range(12):
+        with FileLock(cache.lock_file):
+            with open(log, "a") as f:
+                f.write(tag + " IN\\n")
+            cache.invalidate()
+            time.sleep(0.01)
+            with open(log, "a") as f:
+                f.write(tag + " OUT\\n")
+        time.sleep(0.001)
+    """
+)
+
+
+@POSIX_ONLY
+def test_two_processes_cannot_both_enter_the_critical_section(tmp_path):
+    """Mutual exclusion holds across processes even when invalidate() runs inside it."""
+    worker = tmp_path / "worker.py"
+    worker.write_text(CONCURRENT_WORKER)
+    log = tmp_path / "trace.log"
+
+    env = dict(
+        os.environ,
+        AIXPLAIN_CACHE_FOLDER=str(tmp_path / "cache"),
+        CACHE_EXPIRY_TIME="1",
+        TEAM_API_KEY=SENTINEL_KEY,
+        PYTHONPATH=os.pathsep.join(sys.path),
+    )
+    procs = [
+        subprocess.Popen([sys.executable, str(worker), tag, str(log)], env=env, stderr=subprocess.PIPE)
+        for tag in ("A", "B")
+    ]
+    for proc in procs:
+        _, err = proc.communicate(timeout=120)
+        assert proc.returncode == 0, err.decode()
+
+    events = [line.split() for line in log.read_text().split("\n") if line.strip()]
+    overlaps, holder = 0, None
+    for _tag, event in events:
+        if event == "IN":
+            if holder is not None:
+                overlaps += 1
+            holder = _tag
+        else:
+            holder = None
+
+    assert events, "workers produced no trace"
+    assert overlaps == 0, f"{overlaps} of {len(events) // 2} critical sections overlapped"
+
+
+# ----------------------------------------------------------------------
+# 6. Cost per call
+# ----------------------------------------------------------------------
+
+
+def test_shared_returns_one_instance_per_asset_class(cache_folder):
+    """The shared cache is memoized, so a lookup does not reload the file."""
+    assert AssetCache.shared(Model) is AssetCache.shared(Model)
+
+
+def test_shared_instance_is_not_reloaded_per_call(cache_folder):
+    """Repeated shared() calls do not re-read the cache file."""
+    AssetCache.shared(Model).add(make_model())
+    reads = []
+
+    real_open = open
+
+    def counting_open(path, *a, **k):
+        if str(path).endswith("model.json"):
+            reads.append(path)
+        return real_open(path, *a, **k)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setitem(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__, "open", counting_open)
+        for _ in range(10):
+            AssetCache.shared(Model).get("m-1")
+
+    assert reads == [], "a cache hit must not read the cache file"
+
+
+def test_a_cache_hit_does_not_rewrite_the_file(cache_folder):
+    """Reads are free: nothing is serialized or written on a hit."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+    before = os.stat(cache.cache_file).st_mtime_ns
+
+    for _ in range(20):
+        cache.get("m-1")
+
+    assert os.stat(cache.cache_file).st_mtime_ns == before
+
+
+def test_serialization_does_not_expand_enum_members(cache_folder):
+    """An Enum serializes to its value, not to its class dictionary.
+
+    Recursing into ``Enum.__objclass__`` pulled in every other member of the
+    enum, which is what made a single cached Model ~21 KB.
+    """
+    payload = serialize_asset(make_model(supplier="aiXplain"))
+    encoded = json.dumps(payload)
+
+    assert "__objclass__" not in encoded
+    assert "_value_" not in encoded
+    assert len(encoded) < 4096, f"entry unexpectedly large: {len(encoded)} bytes"
+
+
+def test_add_list_writes_once_for_the_whole_batch(cache_folder):
+    """Bulk insertion is a single save, not one per asset."""
+    cache = AssetCache(Model)
+    saves = []
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "aixplain.utils.asset_cache.atomic_write_private",
+            lambda path, blob: saves.append(path) or atomic_write_private(path, blob),
+        )
+        cache.add_list([make_model(f"m-{i}") for i in range(25)])
+
+    assert len(saves) == 1
+    assert len(cache.get_all()) == 25
+
+
+# ----------------------------------------------------------------------
+# 7. Size cap and eviction
+# ----------------------------------------------------------------------
+
+
+def test_cache_evicts_least_recently_used_entries_past_the_cap(cache_folder, monkeypatch):
+    """The cache is bounded, and drops the least recently used entry first."""
+    monkeypatch.setenv("CACHE_MAX_ENTRIES", "3")
+    cache = AssetCache(Model)
+
+    for i in range(3):
+        cache.add(make_model(f"m-{i}"), save=False)
+    cache.get("m-0")  # m-1 is now the least recently used
+    cache.add(make_model("m-3"))
+
+    assert sorted(m.id for m in cache.get_all()) == ["m-0", "m-2", "m-3"]
+    assert cache.get("m-1") is None
+
+
+def test_loading_respects_the_size_cap(cache_folder, monkeypatch):
+    """A file larger than the cap is truncated to the cap on load."""
+    cache = AssetCache(Model)
+    cache.add_list([make_model(f"m-{i}") for i in range(10)])
+
+    monkeypatch.setenv("CACHE_MAX_ENTRIES", "4")
+    AssetCache.reset_shared()
+
+    assert len(AssetCache(Model).get_all()) == 4
+
+
+# ----------------------------------------------------------------------
+# 8. Robustness
+# ----------------------------------------------------------------------
+
+
+def test_expiry_is_checked_before_entries_are_deserialized(cache_folder, monkeypatch):
+    """An expired cache costs a read, not a full rebuild of every entry."""
+    cache = AssetCache(Model)
+    cache.add_list([make_model(f"m-{i}") for i in range(20)])
+    cache.store.expiry = time.time() - 10
+    cache.save()
+
+    calls = []
+    AssetCache.reset_shared()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(Model, "from_dict", classmethod(lambda cls, d: calls.append(d)))
+        reloaded = AssetCache(Model)
+
+    assert calls == [], "expired entries must not be deserialized"
+    assert reloaded.get_all() == []
+
+
+def test_one_unreadable_entry_does_not_discard_the_whole_cache(cache_folder):
+    """A single corrupt entry is skipped; the rest of the cache survives."""
+    cache = AssetCache(Model)
+    cache.add_list([make_model("good-1"), make_model("good-2")])
+
+    payload = json.load(open(cache.cache_file, encoding="utf-8"))
+    payload["data"]["broken"] = {"id": "broken", "function": "not-a-real-function"}
+    open(cache.cache_file, "w", encoding="utf-8").write(json.dumps(payload))
+
+    AssetCache.reset_shared()
+    reloaded = AssetCache(Model)
+
+    assert sorted(m.id for m in reloaded.get_all()) == ["good-1", "good-2"]
+
+
+def test_malformed_cache_file_is_tolerated(cache_folder):
+    """Invalid JSON yields an empty cache rather than an exception."""
+    os.makedirs(cache_folder, exist_ok=True)
+    open(os.path.join(cache_folder, "model.json"), "w").write("{not json")
+
+    assert AssetCache(Model).get_all() == []
+
+
+def test_get_returns_a_copy_so_callers_cannot_corrupt_the_cache(cache_folder):
+    """Mutating a returned model must not change what the cache holds."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    cache.get("m-1").name = "mutated"
+
+    assert cache.get("m-1").name != "mutated"
+
+
+def test_add_stores_the_asset_not_its_dict(cache_folder):
+    """In-process readers get the object back, with its concrete type."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    assert isinstance(cache.get("m-1"), Model)
+    assert isinstance(cache.get_all()[0], Model)
+
+
+def test_contains_does_not_require_a_copy(cache_folder):
+    """Membership can be tested without rebuilding the entry."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    assert "m-1" in cache
+    assert "absent" not in cache
+
+
+def test_status_and_datetime_round_trip_through_the_cache(cache_folder):
+    """Fields the cache claims to keep survive a reload."""
+    created = datetime(2024, 5, 6, 7, 8, 9, tzinfo=timezone.utc)
+    cache = AssetCache(Model)
+    cache.add(make_model(status=AssetStatus.DRAFT, created_at=created))
+
+    AssetCache.reset_shared()
+    reloaded = AssetCache(Model).get("m-1")
+
+    assert reloaded.status == AssetStatus.DRAFT
+    assert reloaded.created_at == created
+
+
+def test_store_accepts_a_plain_dict_for_backwards_compatibility():
+    """Store keeps its published shape."""
+    store = Store(data={"a": 1}, expiry=123)
+
+    assert store.data == {"a": 1}
+    assert store.expiry == 123
+
+
+def test_a_concurrent_add_by_another_process_is_not_lost(cache_folder):
+    """An incremental add merges with the file instead of overwriting it.
+
+    Two instances that both loaded an empty cache used to race, and whichever
+    saved last erased the other's entry.
+    """
+    first = AssetCache(Model)
+    second = AssetCache(Model)
+
+    first.add(make_model("from-first"))
+    second.add(make_model("from-second"))
+
+    AssetCache.reset_shared()
+    on_disk = sorted(json.load(open(second.cache_file, encoding="utf-8"))["data"])
+    assert on_disk == ["from-first", "from-second"]
+
+
+def test_add_list_replaces_rather_than_merging(cache_folder):
+    """add_list defines the whole cache, so stale entries do not survive it."""
+    cache = AssetCache(Model)
+    cache.add(make_model("stale"))
+
+    AssetCache(Model).add_list([make_model("fresh")])
+
+    on_disk = sorted(json.load(open(cache.cache_file, encoding="utf-8"))["data"])
+    assert on_disk == ["fresh"]
+
+
+def test_merge_does_not_resurrect_an_expired_cache(cache_folder, monkeypatch):
+    """Entries from an expired file on disk are dropped, not merged in."""
+    stale = AssetCache(Model)
+    stale.add(make_model("stale"))
+    stale.store.expiry = time.time() - 10
+    stale.save(merge=False)
+
+    AssetCache.reset_shared()
+    fresh = AssetCache(Model)
+    fresh.add(make_model("fresh"))
+
+    on_disk = sorted(json.load(open(fresh.cache_file, encoding="utf-8"))["data"])
+    assert on_disk == ["fresh"]
+
+
+def test_in_place_mutation_of_a_returned_model_does_not_corrupt_the_cache(cache_folder):
+    """A caller mutating a mutable attribute in place must not affect the cache.
+
+    The shared instance hands the same entry to every caller, so the copy has
+    to be deep -- ``Model.add_additional_info_for_benchmark`` mutates
+    ``additional_info`` in place.
+    """
+    cache = AssetCache(Model)
+    cache.add(make_model(displayName="original"))
+
+    borrowed = cache.get("m-1")
+    borrowed.additional_info["displayName"] = "mutated"
+
+    assert cache.get("m-1").additional_info["displayName"] == "original"
+
+
+def test_two_callers_receive_independent_objects(cache_folder):
+    """Concurrent consumers of one cached entry cannot see each other's edits."""
+    cache = AssetCache(Model)
+    cache.add(make_model())
+
+    first, second = cache.get("m-1"), cache.get("m-1")
+    first.api_key = "KEY_A"
+    second.api_key = "KEY_B"
+
+    assert (first.api_key, second.api_key) == ("KEY_A", "KEY_B")
+    assert first is not second
+
+
+def test_a_shared_instance_stops_serving_entries_once_expired(cache_folder, monkeypatch):
+    """Expiry is enforced on read, not only when the file is loaded.
+
+    The shared instance is built once per process, so a lookup no longer runs
+    load(); without a read-time check an expired entry would be served forever.
+    """
+    monkeypatch.setenv("CACHE_EXPIRY_TIME", "3600")
+    cache = AssetCache.shared(Model)
+    cache.add(make_model())
+    assert cache.get("m-1") is not None
+
+    # Expire in place, exactly as the passage of time would.
+    cache.store.expiry = time.time() - 1
+
+    assert cache.get("m-1") is None
+    assert "m-1" not in cache
+    assert not cache.has_valid_cache()

--- a/tests/unit/utils/asset_cache_test.py
+++ b/tests/unit/utils/asset_cache_test.py
@@ -19,6 +19,8 @@ from datetime import datetime, timezone
 
 import pytest
 
+from pathlib import Path
+
 from aixplain.enums import AssetStatus, Function
 from aixplain.modules.model import Model
 from aixplain.modules.model.model_parameters import ModelParameters
@@ -27,6 +29,7 @@ from aixplain.utils.asset_cache import (
     Store,
     atomic_write_private,
     default_cache_folder,
+    purge_legacy_cwd_cache,
     serialize,
     serialize_asset,
 )
@@ -37,13 +40,19 @@ POSIX_ONLY = pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are no
 
 @pytest.fixture
 def cache_folder(tmp_path, monkeypatch):
-    """Point the cache at an isolated directory and drop shared instances."""
-    folder = tmp_path / "cache"
-    monkeypatch.setenv("AIXPLAIN_CACHE_FOLDER", str(folder))
+    """Point the cache at an isolated directory and drop shared instances.
+
+    Yields the directory the cache actually uses -- the override gets its own
+    ``aixplain`` subdirectory, so that the only directories the SDK tightens
+    permissions on are ones it created itself.
+    """
+    monkeypatch.setenv("AIXPLAIN_CACHE_FOLDER", str(tmp_path / "cacheroot"))
     monkeypatch.delenv("CACHE_EXPIRY_TIME", raising=False)
     monkeypatch.delenv("CACHE_MAX_ENTRIES", raising=False)
+    # Keep every test out of any real ``./.cache`` in the working directory.
+    monkeypatch.chdir(tmp_path)
     AssetCache.reset_shared()
-    yield folder
+    yield Path(default_cache_folder())
     AssetCache.reset_shared()
 
 
@@ -635,7 +644,9 @@ def test_a_shared_instance_stops_serving_entries_once_expired(cache_folder, monk
     cache.add(make_model())
     assert cache.get("m-1") is not None
 
-    # Expire in place, exactly as the passage of time would.
+    # Expire both the store and the file, which is what elapsed time does.
+    cache.store.expiry = time.time() - 1
+    cache.save(merge=False)
     cache.store.expiry = time.time() - 1
 
     assert cache.get("m-1") is None
@@ -852,3 +863,137 @@ def test_credential_attributes_are_excluded_without_an_allowlist():
 
     assert "api_key" not in payload and "backend_url" not in payload
     assert payload["params"] == {"url": "https://example.com"}, "nested data must be untouched"
+
+
+def test_an_expired_store_picks_up_another_processes_refresh(cache_folder):
+    """An expired store reloads the file instead of discarding it.
+
+    Only clearing memory sent the next lookup down the cold path, which
+    repopulates from one page of the account's models and then overwrote
+    everything other processes had just written.
+    """
+    writer = AssetCache(Model)
+    writer.add_list([make_model(f"m-{i}") for i in range(300)])
+
+    reader = AssetCache(Model)
+    assert len(reader.get_all()) == 300
+    reader.store.expiry = time.time() - 1  # the reader's copy goes stale
+
+    # The file is still fresh, so the reader must recover all of it.
+    assert reader.get("m-7") is not None
+    assert len(reader.get_all()) == 300
+
+
+def test_add_list_restarts_the_expiry(cache_folder):
+    """Replacing the cache wholesale restarts its TTL.
+
+    add_list inherited whatever expiry the store happened to hold, so
+    repopulating an already-expired store wrote a file that was dead on
+    arrival and could never be read back.
+    """
+    cache = AssetCache(Model)
+    cache.store.expiry = time.time() - 10
+
+    cache.add_list([make_model()])
+
+    assert cache.has_valid_cache()
+    assert json.load(open(cache.cache_file, encoding="utf-8"))["expiry"] > time.time()
+    AssetCache.reset_shared()
+    assert AssetCache(Model).get("m-1") is not None
+
+
+def test_cache_keys_are_the_unescaped_id(cache_folder):
+    """Store, lookup and membership must agree on one key form.
+
+    Lookups percent-escaped the id while every write keyed on the raw id, so a
+    slug id never hit the cache -- and prefetch's membership test used the raw
+    form, so it also skipped warming ids the getter could never read.
+    """
+    slug = "aixplain/openai/gpt-4o-mini/openai"
+    cache = AssetCache(Model)
+    cache.add(make_model(slug))
+
+    assert slug in cache
+    assert cache.get(slug) is not None
+    assert list(cache.store.data) == [slug], "the key must not be escaped"
+
+
+def test_add_can_key_on_the_requested_id(cache_folder):
+    """A slug request answered with a canonical id is still cached under the slug."""
+    cache = AssetCache(Model)
+    cache.add(make_model("canonical-123"), key="openai/gpt-4o")
+
+    assert cache.get("openai/gpt-4o") is not None
+    assert cache.get("openai/gpt-4o").id == "canonical-123"
+
+
+def test_override_gets_its_own_subdirectory(monkeypatch, tmp_path):
+    """The override is never used verbatim.
+
+    ensure_cache_folder tightens the cache directory on every save, so pointing
+    the override at $HOME or a shared volume would strip that directory's group
+    and other bits -- and re-strip them after any manual fix.
+    """
+    shared = tmp_path / "shared_volume"
+    shared.mkdir()
+    monkeypatch.setenv("AIXPLAIN_CACHE_FOLDER", str(shared))
+
+    folder = default_cache_folder()
+
+    assert folder == str(shared / "aixplain")
+    assert folder != str(shared)
+
+
+@POSIX_ONLY
+def test_a_user_directory_named_by_the_override_keeps_its_permissions(monkeypatch, tmp_path):
+    """Only the SDK's own subdirectory is tightened, not the directory given."""
+    shared = tmp_path / "shared_volume"
+    shared.mkdir()
+    os.chmod(shared, 0o755)
+    monkeypatch.setenv("AIXPLAIN_CACHE_FOLDER", str(shared))
+    AssetCache.reset_shared()
+
+    AssetCache(Model).add(make_model())
+
+    assert stat.S_IMODE(shared.stat().st_mode) == 0o755, "the user's directory must be left alone"
+    assert stat.S_IMODE((shared / "aixplain").stat().st_mode) == 0o700
+
+
+def test_legacy_cwd_cache_is_removed(cache_folder, tmp_path):
+    """The credential an earlier release leaked into $CWD is cleaned up.
+
+    Relocating the cache stops new leaks but leaves the old cleartext file in
+    the checkout, where it stays readable indefinitely.
+    """
+    legacy_dir = tmp_path / ".cache"
+    legacy_dir.mkdir()
+    legacy = legacy_dir / "model.json"
+    legacy.write_text(json.dumps({"expiry": time.time() + 999, "data": {"m-1": {"id": "m-1", "api_key": SENTINEL_KEY}}}))
+
+    AssetCache.reset_shared()
+    AssetCache(Model)
+
+    assert not legacy.exists(), "the legacy cache file must be removed"
+    assert legacy_dir.exists(), "the .cache directory itself belongs to other tools too"
+
+
+@pytest.mark.parametrize(
+    "content",
+    ['{"unrelated": "tool"}', "not json at all", '{"expiry": 1}'],
+)
+def test_an_unrelated_cwd_cache_file_is_left_alone(cache_folder, tmp_path, content):
+    """Cleanup touches only files that are recognisably this cache's own."""
+    legacy_dir = tmp_path / ".cache"
+    legacy_dir.mkdir()
+    legacy = legacy_dir / "model.json"
+    legacy.write_text(content)
+
+    AssetCache.reset_shared()
+    AssetCache(Model)
+
+    assert legacy.read_text() == content, "a file we cannot identify as ours must be untouched"
+
+
+def test_legacy_cleanup_reports_nothing_to_do(cache_folder, tmp_path):
+    """With no legacy file the cleanup is a no-op."""
+    assert purge_legacy_cwd_cache("model") is False


### PR DESCRIPTION
The model cache wrote the account credential in cleartext, at mode 0644, into the current working directory -- confirmed at runtime, the file contained "api_key": "<TEAM_API_KEY>" with perms 0o644. Four compounding defects in one file, all reproduced before fixing.

1. Plaintext credential at rest. Model holds api_key as an instance attribute and add() serialized asset.__dict__, so the key landed on disk. Model now declares a __cache_fields__ allowlist mirroring what from_dict reads, and serialize() drops credential-shaped keys at any nesting depth as a backstop. Rebuilt models take the credential from the live session, so a rotated key is honoured and one caller's explicit api_key is never served to another.

2. use_cache=False still wrote. ModelFactory.get called cache.add() unconditionally on the opt-out path. Caching is now neither read nor written when it is declined, and constructing an AssetCache no longer touches the filesystem.

3. invalidate() unlinked the lock file while holding that lock, so two processes flocked different inodes and both entered the critical section -- measured 9 of 30 entries overlapping, ending in lost writes. Only the data file is removed now, and load() no longer invalidates from inside the lock. Verified 0 overlaps.

4. O(n) per call, O(n^2) to populate. Every get() rebuilt the cache and re-serialized it. The dominant cost was serialize() recursing into Enum.__objclass__, which expanded `supplier` into ~20 KB per model (one entry was 21,169 bytes; 500 models was a 10 MB file, not the ~1 MB estimated). Enums now serialize to their value, the instance is memoized process-wide, entries carry a precomputed payload, reads do no I/O, and there is an LRU cap.

Writes go through a private temporary file (0600) in a 0700 directory and are moved into place with os.replace, so there is no world-readable or truncated window and a serialization failure leaves the previous cache intact. Saves merge with the file under the lock instead of overwriting, so a concurrent add is not lost; add_list still replaces, as documented. Expiry is checked before deserializing, and also on read now that the instance outlives a single call.

The cache moved out of $CWD to $XDG_CACHE_HOME/aixplain (LOCALAPPDATA on Windows), matching default_experiment_cache_dir, overridable with AIXPLAIN_CACHE_FOLDER.

Agent loading was also an N+1: each build_tool issued its own ModelFactory.get, and the ThreadPoolExecutor bought nothing because the workers queued behind a global file lock. prefetch_tool_models resolves the whole batch, plus the main LLM, through the existing get_model_from_ids. A 20-tool agent goes from 22 requests to 1.

Also fixed along the way, in the same paths:

- add() stored asset.__dict__ rather than the asset, so a memoized cache would have returned a raw dict from ModelFactory.get.
- get_model_from_ids always fetched one extra page: the exit condition was checked after the request rather than before.
- get() returns a deep copy. The instance is now shared, and add_additional_info_for_benchmark mutates additional_info in place, which would have corrupted cached state for later readers.
- cache_utils.py had the same location and permission defects with no callers; it now shares the hardened helpers.

Measured: per-get wall time flat at 0.055 ms across 10/100/500 entries (was 1.5 / 4.0 / 8.8 ms); entries 21,169 -> 1,306 bytes.

Not fixed here, and worth its own ticket: load() rebuilds through Model.from_dict, so an LLM read back from disk is downgraded to a plain Model and loses its parameters. Doing it properly needs per-subclass serialization across every Model subclass. These changes shrink its reach -- in-process hits and prefetched models keep their real type.

Tests: 45 new unit tests in tests/unit/utils/asset_cache_test.py, one per acceptance criterion, including cross-process mutual exclusion. The existing functional test asserted the defect -- it required use_cache =False to create $CWD/.cache/model.json -- and is rewritten, with cases added for credential absence, permissions and the no-write path.