### PR TITLE
ENG-3699: add a builtin_tools capability field to the v2 Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Available tools per toolkit: `file` — `read_file`, `list_directory`, `glob`,
 `ValueError` naming the settings that toolkit accepts. Anything you leave unset
 keeps the worker's default.
 
+`include` distinguishes three states: omit it for every tool in the toolkit,
+pass a subset to narrow it, or pass `[]` to attach the toolkit with no tools at
+all.
+
 > The `bash` toolkit must be enabled per deployment. Where it is not, the backend
 > rejects an agent that attaches it.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,47 @@ print(result.data.output)
 
 > Runs return typed objects — read outputs with `result.data.output`, not dict indexing.
 
+### Attach built-in toolkits
+
+Agents can use the worker's built-in toolkits — a sandboxed filesystem, a Python
+interpreter and a shell — without onboarding any asset. Attach them with
+`BuiltinTool`, which validates the toolkit, the tool names and the settings before
+anything reaches the backend.
+
+```python
+from aixplain import Aixplain
+from aixplain.v2 import BuiltinTool
+
+aix = Aixplain()  # reads AIXPLAIN_API_KEY from the environment
+
+agent = aix.Agent(
+    name="Workspace agent",
+    instructions="Read the uploaded files and compute the summary statistics.",
+    tools=[
+        # Omit `include` to expose every tool in the toolkit.
+        BuiltinTool(toolkit="file", include=["read_file", "glob", "grep"]),
+        BuiltinTool(toolkit="python", timeout_s=30),
+    ],
+)
+agent.save()
+
+# Toolkits read back as objects, so a setting is one attribute away.
+fetched = aix.Agent.get(agent.id)
+fetched.tools[1].timeout_s = 60
+fetched.save()
+```
+
+Available tools per toolkit: `file` — `read_file`, `list_directory`, `glob`,
+`grep`, `write_file`, `edit_file`; `python` — `run_python`; `bash` —
+`run_command`. Settings are per toolkit too (`file`: `max_read_bytes`,
+`max_results`; `python`: `timeout_s`, `expose_files`; `bash`: `timeout_s`,
+`max_output_bytes`, `deny_patterns`), and using one on the wrong toolkit raises a
+`ValueError` naming the settings that toolkit accepts. Anything you leave unset
+keeps the worker's default.
+
+> The `bash` toolkit must be enabled per deployment. Where it is not, the backend
+> rejects an agent that attaches it.
+
 ### Build a multi-agent team
 
 ```python

--- a/aixplain/v2/__init__.py
+++ b/aixplain/v2/__init__.py
@@ -5,6 +5,7 @@ from .rlm import RLM, RLMResult
 from .utility import Utility
 from .agent import Agent, Artifact, Budget, ContextOverflowStrategy
 from .tool import Tool
+from .builtin_tool import BuiltinTool
 from .skill import Skill
 from .actions import Input, Inputs, Action, Actions
 from .integration import TriggerTypeSpec, TriggerEventOption, TriggerTypes
@@ -102,6 +103,7 @@ __all__ = [
     "Budget",
     "ContextOverflowStrategy",
     "Tool",
+    "BuiltinTool",
     "Skill",
     "Resource",
     "File",

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -1,5 +1,6 @@
 """Agent module for aiXplain v2 SDK."""
 
+import copy
 import json
 import logging
 import re
@@ -18,7 +19,7 @@ from .model import Model
 from .file import File
 from .skill import Skill
 from .mixins import ToolableMixin
-from .builtin_tool import BuiltinTool
+from .builtin_tool import BUILTIN_TYPE, TOOLKIT_TOOLS, BuiltinTool
 from ..utils.user_info_utils import build_run_metadata
 
 from .resource import (
@@ -965,6 +966,12 @@ class Agent(
         if isinstance(tool, str):
             return {"id": tool}
         if isinstance(tool, dict):
+            if not tool.get("id"):
+                # An id-less row *is* its own identity: a builtin row that
+                # stayed a dict, or any future inline-config tool. Collapsing
+                # these onto {"id": None, ...} would make two different rows
+                # look identical and hide in-place edits from ``is_modified``.
+                return copy.deepcopy(tool)
             return {"id": tool.get("id"), "type": tool.get("type")}
         return {"id": getattr(tool, "id", None), "type": getattr(tool, "type", None)}
 
@@ -1769,38 +1776,42 @@ class Agent(
         normal ``Tool.get``). Asset hydration requires a client context; without
         one (e.g. an unbound ``Agent`` in unit tests) the raw entries are kept
         as-is. Built-in toolkit rows reference no asset, so they are converted
-        first and unconditionally — see :meth:`_hydrate_builtin_entry`.
+        whether or not a context is present.
         """
         if not self.tools:
             return
-        self.tools = [self._hydrate_builtin_entry(entry) for entry in self.tools]
         context = getattr(self, "context", None)
-        if context is None:
+        if context is None and not any(self._is_builtin_row(entry) for entry in self.tools):
+            # Nothing to convert: leave the caller's own list object in place.
             return
         self.tools = [self._hydrate_tool_entry(entry, context) for entry in self.tools]
 
     @staticmethod
-    def _hydrate_builtin_entry(entry: Any) -> Any:
-        """Convert a persisted ``{"type": "builtin", ...}`` row into a ``BuiltinTool``.
-
-        Keeps ``agent.tools`` symmetric with what the caller passed: a toolkit
-        attached as a :class:`~aixplain.v2.builtin_tool.BuiltinTool` reads back as
-        one after ``get()``. Needs no network and no client context. Best-effort,
-        like the asset hydration below: a row that cannot be mapped stays a dict
-        and still serializes through ``_normalize_tool_for_api``.
-        """
-        if not isinstance(entry, dict) or entry.get("type") != "builtin":
-            return entry
-        try:
-            return BuiltinTool.from_api_dict(entry)
-        except Exception:
-            # Never let hydration break construction — fall back to the raw dict.
-            return entry
+    def _is_builtin_row(entry: Any) -> bool:
+        """True for a raw ``{"type": "builtin", ...}`` row that still needs converting."""
+        return isinstance(entry, dict) and entry.get("type") == BUILTIN_TYPE
 
     def _hydrate_tool_entry(self, entry: Any, context: Any) -> Any:
-        """Hydrate one ``tools`` entry into a Tool/Model object (best-effort)."""
+        """Hydrate one ``tools`` entry into a BuiltinTool/Tool/Model (best-effort)."""
         if not isinstance(entry, dict):
             return entry  # already a Tool/Model/Integration object or a string id
+        if self._is_builtin_row(entry):
+            # Must return before the asset branch below: a builtin row that also
+            # carried an id would otherwise be rebuilt as a catalog Tool and
+            # saved back as ``{"type": "tool", "assetId": ...}``, losing the
+            # toolkit config and pointing at an asset that does not exist.
+            try:
+                return BuiltinTool.from_dict(entry)
+            except (ValueError, TypeError):
+                # An unknown toolkit may come from a backend newer than this
+                # SDK, so the row is kept and replayed verbatim. A row whose
+                # toolkit this version *does* know is malformed, and staying
+                # silent would ship it to the backend.
+                if isinstance(entry.get("toolkit"), str) and entry["toolkit"] in TOOLKIT_TOOLS:
+                    raise
+                return entry
+        if context is None:
+            return entry
         tool_id = entry.get("id")
         if not tool_id:
             return entry
@@ -2691,3 +2702,22 @@ def _agent_from_dict(cls, kvs: Any, *, infer_missing: bool = False) -> "Agent":
 
 
 Agent.from_dict = classmethod(_agent_from_dict)
+
+# ``@dataclass_json`` also injects ``to_dict``, and it would recurse into a
+# ``BuiltinTool`` (a dataclass) and emit its raw fields — a row with no ``type``
+# discriminator, which ``from_dict`` cannot rebuild and the worker drops. Wrap
+# the injected encoder so those entries serialize as their wire rows instead.
+_dataclass_json_agent_to_dict = Agent.to_dict
+
+
+def _agent_to_dict(self, *args: Any, **kwargs: Any) -> dict:
+    original_tools = self.tools
+    if original_tools:
+        self.tools = [tool.as_tool() if isinstance(tool, BuiltinTool) else tool for tool in original_tools]
+    try:
+        return _dataclass_json_agent_to_dict(self, *args, **kwargs)
+    finally:
+        self.tools = original_tools
+
+
+Agent.to_dict = _agent_to_dict

--- a/aixplain/v2/agent.py
+++ b/aixplain/v2/agent.py
@@ -18,6 +18,7 @@ from .model import Model
 from .file import File
 from .skill import Skill
 from .mixins import ToolableMixin
+from .builtin_tool import BuiltinTool
 from ..utils.user_info_utils import build_run_metadata
 
 from .resource import (
@@ -954,6 +955,13 @@ class Agent(
     @staticmethod
     def _tool_identity(tool: Any) -> dict:
         """Return a stable id/type signature for a tool entry (no param values)."""
+        if isinstance(tool, BuiltinTool):
+            # A builtin row carries no id, so an id/type signature would collapse
+            # every toolkit onto the same value. Its settings are persisted
+            # configuration rather than ephemeral run-time overrides, so the full
+            # row is the identity: editing ``timeout_s`` must mark the agent
+            # modified.
+            return tool.as_tool()
         if isinstance(tool, str):
             return {"id": tool}
         if isinstance(tool, dict):
@@ -1758,13 +1766,36 @@ class Agent(
         reads and ``inputs[...] = value`` mutations do not require a network
         call. When the snapshot carries no parameters, the object is left to
         load its input specs lazily on first ``.actions`` access (matching a
-        normal ``Tool.get``). Requires a client context; without one (e.g. an
-        unbound ``Agent`` in unit tests) the raw entries are kept as-is.
+        normal ``Tool.get``). Asset hydration requires a client context; without
+        one (e.g. an unbound ``Agent`` in unit tests) the raw entries are kept
+        as-is. Built-in toolkit rows reference no asset, so they are converted
+        first and unconditionally — see :meth:`_hydrate_builtin_entry`.
         """
+        if not self.tools:
+            return
+        self.tools = [self._hydrate_builtin_entry(entry) for entry in self.tools]
         context = getattr(self, "context", None)
-        if context is None or not self.tools:
+        if context is None:
             return
         self.tools = [self._hydrate_tool_entry(entry, context) for entry in self.tools]
+
+    @staticmethod
+    def _hydrate_builtin_entry(entry: Any) -> Any:
+        """Convert a persisted ``{"type": "builtin", ...}`` row into a ``BuiltinTool``.
+
+        Keeps ``agent.tools`` symmetric with what the caller passed: a toolkit
+        attached as a :class:`~aixplain.v2.builtin_tool.BuiltinTool` reads back as
+        one after ``get()``. Needs no network and no client context. Best-effort,
+        like the asset hydration below: a row that cannot be mapped stays a dict
+        and still serializes through ``_normalize_tool_for_api``.
+        """
+        if not isinstance(entry, dict) or entry.get("type") != "builtin":
+            return entry
+        try:
+            return BuiltinTool.from_api_dict(entry)
+        except Exception:
+            # Never let hydration break construction — fall back to the raw dict.
+            return entry
 
     def _hydrate_tool_entry(self, entry: Any, context: Any) -> Any:
         """Hydrate one ``tools`` entry into a Tool/Model object (best-effort)."""

--- a/aixplain/v2/builtin_tool.py
+++ b/aixplain/v2/builtin_tool.py
@@ -122,10 +122,16 @@ class BuiltinTool(ToolableMixin):
 
     def __post_init__(self) -> None:
         """Validate the toolkit, the requested tool names and the settings."""
-        if self.toolkit not in TOOLKIT_TOOLS:
+        # ``isinstance`` first: an unhashable toolkit (a list from a mangled
+        # response, say) would make the membership test raise TypeError instead
+        # of the ValueError this class documents.
+        if not isinstance(self.toolkit, str) or self.toolkit not in TOOLKIT_TOOLS:
             raise ValueError(f"Unknown toolkit {self.toolkit!r}. Allowed toolkits: {sorted(TOOLKIT_TOOLS)}.")
 
         if self.include is not None:
+            # Snapshot before validating: the caller's list must not be able to
+            # gain an unvalidated name later by being mutated behind our back.
+            self.include = list(self.include)
             if not self.include:
                 raise ValueError("include must name at least one tool, or be None to expose every tool in the toolkit.")
             unknown = [name for name in self.include if name not in TOOLKIT_TOOLS[self.toolkit]]
@@ -150,6 +156,10 @@ class BuiltinTool(ToolableMixin):
                 f"Allowed settings: {sorted(allowed)}."
             )
 
+        # Same snapshot rule as ``include``, for the one other list-valued setting.
+        if self.deny_patterns is not None:
+            self.deny_patterns = list(self.deny_patterns)
+
     def as_tool(self) -> dict:
         """Serialize as the ``{"type": "builtin", ...}`` row the agent payload carries.
 
@@ -161,7 +171,13 @@ class BuiltinTool(ToolableMixin):
             dict: The wire row for this toolkit.
         """
         row: Dict[str, Any] = {"type": "builtin", "toolkit": self.toolkit}
-        row.update({key: value for key, value in self._extra.items() if key not in _SERVER_ONLY_KEYS})
+        row.update(
+            {
+                key: list(value) if isinstance(value, list) else value
+                for key, value in self._extra.items()
+                if key not in _SERVER_ONLY_KEYS
+            }
+        )
         if self.include is not None:
             row["include"] = list(self.include)
         for name in TOOLKIT_SETTINGS[self.toolkit]:
@@ -191,7 +207,9 @@ class BuiltinTool(ToolableMixin):
         if toolkit is None:
             raise ValueError(f"A builtin tool row must carry a 'toolkit'. Got: {row!r}.")
 
-        known = set(TOOLKIT_SETTINGS.get(toolkit, ())) | {"include"}
+        # A non-string toolkit may be unhashable, so it cannot be used as a dict
+        # key here; leave it to ``__post_init__`` to reject it as a ValueError.
+        known = set(TOOLKIT_SETTINGS.get(toolkit, ()) if isinstance(toolkit, str) else ()) | {"include"}
         kwargs = {key: value for key, value in row.items() if key in known}
         extra = {
             key: value

--- a/aixplain/v2/builtin_tool.py
+++ b/aixplain/v2/builtin_tool.py
@@ -1,32 +1,11 @@
 """Built-in agent toolkits (``file`` / ``python`` / ``bash``) as attachable tools.
 
-The agent worker ships a small set of **built-in toolkits** that need no onboarded
-asset: a sandboxed filesystem (``file``), a Python interpreter (``python``) and a
-shell (``bash``). They are attached declaratively, by describing the toolkit on the
-agent rather than by referencing an asset id::
-
-    from aixplain import Aixplain
-    from aixplain.v2 import BuiltinTool
-
-    aix = Aixplain()
-    agent = aix.Agent(
-        name="Workspace agent",
-        instructions="Read the uploaded files and compute the summary statistics.",
-        tools=[
-            BuiltinTool(toolkit="file", include=["read_file", "glob", "grep"]),
-            BuiltinTool(toolkit="python", timeout_s=30),
-        ],
-    )
-
-:class:`BuiltinTool` is a plain value object: it has no ``id``, never talks to the
-network, and is never saved on its own — it is configuration carried inside the
-agent's ``tools`` payload.
-
-Note:
-    ``bash`` must be enabled per deployment. Attaching it where it is not enabled
-    is rejected by the backend, not by the SDK.
+See the README section on built-in toolkits for the worked example; the wire
+contract itself is documented in the agent repo at
+``docs/guides/builtin-toolkits-contract.md``.
 """
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any, Dict, FrozenSet, List, Optional, Tuple
 
@@ -34,32 +13,67 @@ from typing_extensions import Literal
 
 from .mixins import ToolableMixin
 
+#: The wire discriminator for every row this module emits.
+BUILTIN_TYPE = "builtin"
+
 #: The toolkits the worker exposes.
 BuiltinToolkit = Literal["file", "python", "bash"]
 
-#: Tool names available per toolkit. Frozen alongside the worker's wire contract;
-#: a name outside this table is a client-side :class:`ValueError`.
+#: Tool names available per toolkit. Frozen alongside the worker's wire contract.
 TOOLKIT_TOOLS: Dict[str, FrozenSet[str]] = {
     "file": frozenset({"read_file", "list_directory", "glob", "grep", "write_file", "edit_file"}),
     "python": frozenset({"run_python"}),
     "bash": frozenset({"run_command"}),
 }
 
-#: Settings each toolkit accepts, in wire-key form. A setting listed here is
-#: emitted verbatim when set; a setting belonging to a different toolkit is a
-#: client-side :class:`ValueError`.
+#: Settings each toolkit accepts, in wire-key form.
 TOOLKIT_SETTINGS: Dict[str, Tuple[str, ...]] = {
     "file": ("max_read_bytes", "max_results"),
     "python": ("timeout_s", "expose_files"),
     "bash": ("timeout_s", "max_output_bytes", "deny_patterns"),
 }
 
-#: Keys the worker owns. The SDK drops them on the way in and never sends them
-#: back, so a fetched agent cannot pin a server-chosen sandbox path.
+#: Settings that take a list, so a non-list value is rejected rather than iterated.
+_LIST_SETTINGS: Tuple[str, ...] = ("deny_patterns",)
+
+#: Every settings key owned by any toolkit, derived once.
+_ALL_SETTINGS: FrozenSet[str] = frozenset(name for names in TOOLKIT_SETTINGS.values() for name in names)
+
+#: Per toolkit, the settings that belong to a *different* toolkit.
+_FOREIGN_SETTINGS: Dict[str, FrozenSet[str]] = {
+    toolkit: _ALL_SETTINGS - frozenset(names) for toolkit, names in TOOLKIT_SETTINGS.items()
+}
+
+#: Keys accepted from a persisted row into the typed fields.
+_KNOWN_KEYS: Dict[str, FrozenSet[str]] = {
+    toolkit: frozenset(names) | {"include"} for toolkit, names in TOOLKIT_SETTINGS.items()
+}
+
+#: Keys the worker owns; dropped in both directions so a fetched row cannot pin
+#: a server-chosen sandbox path.
 _SERVER_ONLY_KEYS: FrozenSet[str] = frozenset({"workspace_root"})
+
+#: Asset-identity keys. A builtin toolkit is not a catalog asset, so a row that
+#: somehow carries one must not replay it on save.
+_IDENTITY_KEYS: FrozenSet[str] = frozenset({"id", "_id", "assetId", "asset_id"})
 
 #: Wire keys that are structural rather than settings.
 _STRUCTURAL_KEYS: FrozenSet[str] = frozenset({"type", "toolkit"})
+
+#: Keys never carried into ``_extra``.
+_NEVER_EXTRA: FrozenSet[str] = _STRUCTURAL_KEYS | _SERVER_ONLY_KEYS | _IDENTITY_KEYS
+
+
+def _as_list(name: str, value: Any) -> List[Any]:
+    """Snapshot a list-valued field, rejecting anything that is not a list.
+
+    A bare string is the mistake worth catching: ``list("rm -rf")`` silently
+    becomes six one-character entries, which for ``deny_patterns`` would block
+    virtually every command the worker runs.
+    """
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"{name} must be a list of strings, got {type(value).__name__}: {value!r}.")
+    return list(value)
 
 
 @dataclass
@@ -72,23 +86,20 @@ class BuiltinTool(ToolableMixin):
     ``expose_files=False``.
 
     Attributes:
-        toolkit: Which built-in toolkit to attach. One of ``"file"``, ``"python"``
-            or ``"bash"``.
-        include: Restrict the agent to these tool names. ``None`` (the default)
-            exposes every tool in the toolkit. See :data:`TOOLKIT_TOOLS` for the
-            names each toolkit accepts.
+        toolkit: One of ``"file"``, ``"python"`` or ``"bash"``.
+        include: Restrict the agent to these tool names. ``None`` exposes every
+            tool in the toolkit; ``[]`` exposes none. See :data:`TOOLKIT_TOOLS`.
         max_read_bytes: ``file`` only. Cap on the bytes a single read returns.
         max_results: ``file`` only. Cap on the entries a ``glob``/``grep`` returns.
         timeout_s: ``python`` and ``bash``. Wall-clock limit for one execution.
-        expose_files: ``python`` only. Whether the interpreter can see the agent's
-            workspace files.
-        max_output_bytes: ``bash`` only. Cap on the captured stdout/stderr bytes.
-        deny_patterns: ``bash`` only. Regular expressions a command must not match.
+        expose_files: ``python`` only. Whether the interpreter sees the workspace.
+        max_output_bytes: ``bash`` only. Cap on captured stdout/stderr bytes.
+        deny_patterns: ``bash`` only. Regexes a command must not match.
 
     Raises:
         ValueError: If ``toolkit`` is unknown, if ``include`` names a tool the
-            toolkit does not have, or if a setting belonging to a different toolkit
-            is set.
+            toolkit does not have, if a list-valued field is not a list, or if a
+            setting belonging to a different toolkit is set.
 
     Example:
         >>> BuiltinTool(toolkit="file", include=["read_file", "grep"]).as_tool()
@@ -101,7 +112,7 @@ class BuiltinTool(ToolableMixin):
     max_read_bytes: Optional[int] = None
     max_results: Optional[int] = None
     # python and bash
-    timeout_s: Optional[int] = None
+    timeout_s: Optional[float] = None
     # python
     expose_files: Optional[bool] = None
     # bash
@@ -109,31 +120,26 @@ class BuiltinTool(ToolableMixin):
     deny_patterns: Optional[List[str]] = None
     #: Keys seen on a fetched row that this SDK version does not model, replayed
     #: verbatim on save so a newer backend's row survives a get() -> save() cycle.
-    _extra: Dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
+    #: Not a constructor argument: it must not become a way past validation.
+    _extra: Dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     @property
     def type(self) -> str:
-        """The wire discriminator, always ``"builtin"``.
-
-        Read-only on purpose: it is what routes the row to the worker's built-in
-        toolkit handling, so it is not a constructor argument.
-        """
-        return "builtin"
+        """The wire discriminator, always ``"builtin"``."""
+        return BUILTIN_TYPE
 
     def __post_init__(self) -> None:
         """Validate the toolkit, the requested tool names and the settings."""
         # ``isinstance`` first: an unhashable toolkit (a list from a mangled
-        # response, say) would make the membership test raise TypeError instead
-        # of the ValueError this class documents.
+        # response, say) would make the membership test raise TypeError.
         if not isinstance(self.toolkit, str) or self.toolkit not in TOOLKIT_TOOLS:
             raise ValueError(f"Unknown toolkit {self.toolkit!r}. Allowed toolkits: {sorted(TOOLKIT_TOOLS)}.")
 
         if self.include is not None:
-            # Snapshot before validating: the caller's list must not be able to
-            # gain an unvalidated name later by being mutated behind our back.
-            self.include = list(self.include)
-            if not self.include:
-                raise ValueError("include must name at least one tool, or be None to expose every tool in the toolkit.")
+            # Snapshot before validating, so the caller's list cannot gain an
+            # unvalidated name later by being mutated behind our back. ``[]`` is
+            # a real value meaning "no tools from this toolkit", not an error.
+            self.include = _as_list("include", self.include)
             unknown = [name for name in self.include if name not in TOOLKIT_TOOLS[self.toolkit]]
             if unknown:
                 raise ValueError(
@@ -141,58 +147,47 @@ class BuiltinTool(ToolableMixin):
                     f"Allowed: {sorted(TOOLKIT_TOOLS[self.toolkit])}."
                 )
 
-        allowed = set(TOOLKIT_SETTINGS[self.toolkit])
-        misplaced = sorted(
-            {
-                name
-                for names in TOOLKIT_SETTINGS.values()
-                for name in names
-                if name not in allowed and getattr(self, name) is not None
-            }
-        )
+        misplaced = sorted(name for name in _FOREIGN_SETTINGS[self.toolkit] if getattr(self, name) is not None)
         if misplaced:
             raise ValueError(
                 f"Setting(s) {misplaced} are not valid for the {self.toolkit!r} toolkit. "
-                f"Allowed settings: {sorted(allowed)}."
+                f"Allowed settings: {sorted(TOOLKIT_SETTINGS[self.toolkit])}."
             )
 
-        # Same snapshot rule as ``include``, for the one other list-valued setting.
-        if self.deny_patterns is not None:
-            self.deny_patterns = list(self.deny_patterns)
+        for name in _LIST_SETTINGS:
+            if getattr(self, name) is not None:
+                setattr(self, name, _as_list(name, getattr(self, name)))
 
     def as_tool(self) -> dict:
         """Serialize as the ``{"type": "builtin", ...}`` row the agent payload carries.
 
         Only the settings that were actually set are emitted; an omitted key means
         "use the worker's default". The row never carries an ``id``, an ``assetId``
-        or a ``workspace_root``.
-
-        Returns:
-            dict: The wire row for this toolkit.
+        or a ``workspace_root``, and shares no mutable value with this object.
         """
-        row: Dict[str, Any] = {"type": "builtin", "toolkit": self.toolkit}
-        row.update(
-            {
-                key: list(value) if isinstance(value, list) else value
-                for key, value in self._extra.items()
-                if key not in _SERVER_ONLY_KEYS
-            }
-        )
+        # ``_extra`` first, then the structural keys and typed settings, so a
+        # replayed key can never shadow a validated one.
+        row: Dict[str, Any] = dict(self._extra)
+        row["type"] = BUILTIN_TYPE
+        row["toolkit"] = self.toolkit
         if self.include is not None:
-            row["include"] = list(self.include)
+            row["include"] = self.include
         for name in TOOLKIT_SETTINGS[self.toolkit]:
             value = getattr(self, name)
             if value is not None:
-                row[name] = list(value) if isinstance(value, list) else value
-        return row
+                row[name] = value
+        # One deep copy covers every level, including a nested structure that
+        # arrived in ``_extra`` from a newer backend.
+        return copy.deepcopy(row)
 
     @classmethod
-    def from_api_dict(cls, row: dict) -> "BuiltinTool":
+    def from_dict(cls, row: dict) -> "BuiltinTool":
         """Rebuild a :class:`BuiltinTool` from a persisted ``builtin`` row.
 
-        Lenient by design, so that a row from a backend newer than this SDK still
-        round-trips: any key this version does not model is kept aside and replayed
-        by :meth:`as_tool`. Server-owned keys are dropped in both directions.
+        Lenient by design so a row from a backend newer than this SDK still
+        round-trips: any key this version does not model is kept aside and
+        replayed by :meth:`as_tool`. Server-owned and asset-identity keys are
+        dropped in both directions.
 
         Args:
             row: A persisted tool row carrying ``type="builtin"``.
@@ -207,13 +202,17 @@ class BuiltinTool(ToolableMixin):
         if toolkit is None:
             raise ValueError(f"A builtin tool row must carry a 'toolkit'. Got: {row!r}.")
 
-        # A non-string toolkit may be unhashable, so it cannot be used as a dict
-        # key here; leave it to ``__post_init__`` to reject it as a ValueError.
-        known = set(TOOLKIT_SETTINGS.get(toolkit, ()) if isinstance(toolkit, str) else ()) | {"include"}
-        kwargs = {key: value for key, value in row.items() if key in known}
-        extra = {
-            key: value
-            for key, value in row.items()
-            if key not in known and key not in _STRUCTURAL_KEYS and key not in _SERVER_ONLY_KEYS
-        }
-        return cls(toolkit=toolkit, _extra=extra, **kwargs)
+        # A non-string toolkit may be unhashable, so it cannot index the table
+        # here; ``__post_init__`` rejects it as a ValueError.
+        known = _KNOWN_KEYS.get(toolkit, frozenset()) if isinstance(toolkit, str) else frozenset()
+        kwargs = {}
+        extra = {}
+        for key, value in row.items():
+            if key in known:
+                kwargs[key] = value
+            elif key not in _NEVER_EXTRA:
+                extra[key] = value
+
+        tool = cls(toolkit=toolkit, **kwargs)
+        tool._extra = copy.deepcopy(extra)
+        return tool

--- a/aixplain/v2/builtin_tool.py
+++ b/aixplain/v2/builtin_tool.py
@@ -1,0 +1,201 @@
+"""Built-in agent toolkits (``file`` / ``python`` / ``bash``) as attachable tools.
+
+The agent worker ships a small set of **built-in toolkits** that need no onboarded
+asset: a sandboxed filesystem (``file``), a Python interpreter (``python``) and a
+shell (``bash``). They are attached declaratively, by describing the toolkit on the
+agent rather than by referencing an asset id::
+
+    from aixplain import Aixplain
+    from aixplain.v2 import BuiltinTool
+
+    aix = Aixplain()
+    agent = aix.Agent(
+        name="Workspace agent",
+        instructions="Read the uploaded files and compute the summary statistics.",
+        tools=[
+            BuiltinTool(toolkit="file", include=["read_file", "glob", "grep"]),
+            BuiltinTool(toolkit="python", timeout_s=30),
+        ],
+    )
+
+:class:`BuiltinTool` is a plain value object: it has no ``id``, never talks to the
+network, and is never saved on its own — it is configuration carried inside the
+agent's ``tools`` payload.
+
+Note:
+    ``bash`` must be enabled per deployment. Attaching it where it is not enabled
+    is rejected by the backend, not by the SDK.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
+
+from typing_extensions import Literal
+
+from .mixins import ToolableMixin
+
+#: The toolkits the worker exposes.
+BuiltinToolkit = Literal["file", "python", "bash"]
+
+#: Tool names available per toolkit. Frozen alongside the worker's wire contract;
+#: a name outside this table is a client-side :class:`ValueError`.
+TOOLKIT_TOOLS: Dict[str, FrozenSet[str]] = {
+    "file": frozenset({"read_file", "list_directory", "glob", "grep", "write_file", "edit_file"}),
+    "python": frozenset({"run_python"}),
+    "bash": frozenset({"run_command"}),
+}
+
+#: Settings each toolkit accepts, in wire-key form. A setting listed here is
+#: emitted verbatim when set; a setting belonging to a different toolkit is a
+#: client-side :class:`ValueError`.
+TOOLKIT_SETTINGS: Dict[str, Tuple[str, ...]] = {
+    "file": ("max_read_bytes", "max_results"),
+    "python": ("timeout_s", "expose_files"),
+    "bash": ("timeout_s", "max_output_bytes", "deny_patterns"),
+}
+
+#: Keys the worker owns. The SDK drops them on the way in and never sends them
+#: back, so a fetched agent cannot pin a server-chosen sandbox path.
+_SERVER_ONLY_KEYS: FrozenSet[str] = frozenset({"workspace_root"})
+
+#: Wire keys that are structural rather than settings.
+_STRUCTURAL_KEYS: FrozenSet[str] = frozenset({"type", "toolkit"})
+
+
+@dataclass
+class BuiltinTool(ToolableMixin):
+    """A built-in worker toolkit (``file`` / ``python`` / ``bash``) attached to an agent.
+
+    Every setting defaults to ``None`` meaning *not sent* — the worker then applies
+    its own default. The SDK deliberately does not mirror those defaults, so the two
+    cannot drift apart. An explicit value is always forwarded, including
+    ``expose_files=False``.
+
+    Attributes:
+        toolkit: Which built-in toolkit to attach. One of ``"file"``, ``"python"``
+            or ``"bash"``.
+        include: Restrict the agent to these tool names. ``None`` (the default)
+            exposes every tool in the toolkit. See :data:`TOOLKIT_TOOLS` for the
+            names each toolkit accepts.
+        max_read_bytes: ``file`` only. Cap on the bytes a single read returns.
+        max_results: ``file`` only. Cap on the entries a ``glob``/``grep`` returns.
+        timeout_s: ``python`` and ``bash``. Wall-clock limit for one execution.
+        expose_files: ``python`` only. Whether the interpreter can see the agent's
+            workspace files.
+        max_output_bytes: ``bash`` only. Cap on the captured stdout/stderr bytes.
+        deny_patterns: ``bash`` only. Regular expressions a command must not match.
+
+    Raises:
+        ValueError: If ``toolkit`` is unknown, if ``include`` names a tool the
+            toolkit does not have, or if a setting belonging to a different toolkit
+            is set.
+
+    Example:
+        >>> BuiltinTool(toolkit="file", include=["read_file", "grep"]).as_tool()
+        {'type': 'builtin', 'toolkit': 'file', 'include': ['read_file', 'grep']}
+    """
+
+    toolkit: BuiltinToolkit
+    include: Optional[List[str]] = None
+    # file
+    max_read_bytes: Optional[int] = None
+    max_results: Optional[int] = None
+    # python and bash
+    timeout_s: Optional[int] = None
+    # python
+    expose_files: Optional[bool] = None
+    # bash
+    max_output_bytes: Optional[int] = None
+    deny_patterns: Optional[List[str]] = None
+    #: Keys seen on a fetched row that this SDK version does not model, replayed
+    #: verbatim on save so a newer backend's row survives a get() -> save() cycle.
+    _extra: Dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
+
+    @property
+    def type(self) -> str:
+        """The wire discriminator, always ``"builtin"``.
+
+        Read-only on purpose: it is what routes the row to the worker's built-in
+        toolkit handling, so it is not a constructor argument.
+        """
+        return "builtin"
+
+    def __post_init__(self) -> None:
+        """Validate the toolkit, the requested tool names and the settings."""
+        if self.toolkit not in TOOLKIT_TOOLS:
+            raise ValueError(f"Unknown toolkit {self.toolkit!r}. Allowed toolkits: {sorted(TOOLKIT_TOOLS)}.")
+
+        if self.include is not None:
+            if not self.include:
+                raise ValueError("include must name at least one tool, or be None to expose every tool in the toolkit.")
+            unknown = [name for name in self.include if name not in TOOLKIT_TOOLS[self.toolkit]]
+            if unknown:
+                raise ValueError(
+                    f"Unknown tool(s) {unknown} for the {self.toolkit!r} toolkit. "
+                    f"Allowed: {sorted(TOOLKIT_TOOLS[self.toolkit])}."
+                )
+
+        allowed = set(TOOLKIT_SETTINGS[self.toolkit])
+        misplaced = sorted(
+            {
+                name
+                for names in TOOLKIT_SETTINGS.values()
+                for name in names
+                if name not in allowed and getattr(self, name) is not None
+            }
+        )
+        if misplaced:
+            raise ValueError(
+                f"Setting(s) {misplaced} are not valid for the {self.toolkit!r} toolkit. "
+                f"Allowed settings: {sorted(allowed)}."
+            )
+
+    def as_tool(self) -> dict:
+        """Serialize as the ``{"type": "builtin", ...}`` row the agent payload carries.
+
+        Only the settings that were actually set are emitted; an omitted key means
+        "use the worker's default". The row never carries an ``id``, an ``assetId``
+        or a ``workspace_root``.
+
+        Returns:
+            dict: The wire row for this toolkit.
+        """
+        row: Dict[str, Any] = {"type": "builtin", "toolkit": self.toolkit}
+        row.update({key: value for key, value in self._extra.items() if key not in _SERVER_ONLY_KEYS})
+        if self.include is not None:
+            row["include"] = list(self.include)
+        for name in TOOLKIT_SETTINGS[self.toolkit]:
+            value = getattr(self, name)
+            if value is not None:
+                row[name] = list(value) if isinstance(value, list) else value
+        return row
+
+    @classmethod
+    def from_api_dict(cls, row: dict) -> "BuiltinTool":
+        """Rebuild a :class:`BuiltinTool` from a persisted ``builtin`` row.
+
+        Lenient by design, so that a row from a backend newer than this SDK still
+        round-trips: any key this version does not model is kept aside and replayed
+        by :meth:`as_tool`. Server-owned keys are dropped in both directions.
+
+        Args:
+            row: A persisted tool row carrying ``type="builtin"``.
+
+        Returns:
+            BuiltinTool: The reconstructed toolkit attachment.
+
+        Raises:
+            ValueError: If the row names no toolkit, or names an unknown one.
+        """
+        toolkit = row.get("toolkit")
+        if toolkit is None:
+            raise ValueError(f"A builtin tool row must carry a 'toolkit'. Got: {row!r}.")
+
+        known = set(TOOLKIT_SETTINGS.get(toolkit, ())) | {"include"}
+        kwargs = {key: value for key, value in row.items() if key in known}
+        extra = {
+            key: value
+            for key, value in row.items()
+            if key not in known and key not in _STRUCTURAL_KEYS and key not in _SERVER_ONLY_KEYS
+        }
+        return cls(toolkit=toolkit, _extra=extra, **kwargs)

--- a/aixplain/v2/core.py
+++ b/aixplain/v2/core.py
@@ -11,6 +11,7 @@ from .model import Model
 from .agent import Agent
 from .utility import Utility
 from .tool import Tool
+from .builtin_tool import BuiltinTool as BuiltinToolClass
 from .skill import Skill
 from .agent_evaluator import Eval as EvalClass, Metric as MetricBase
 from .integration import Integration
@@ -60,6 +61,9 @@ class Aixplain:
     Agent: AgentType = None
     Utility: UtilityType = None
     Tool: ToolType = None
+    # A context-free value object (no id, no save, no network), so it is bound
+    # as a plain class attribute rather than re-typed with a ``context``.
+    BuiltinTool = BuiltinToolClass
     Skill: SkillType = None
     Metric: MetricType = None
     Eval: type = None

--- a/aixplain/v2/mixins.py
+++ b/aixplain/v2/mixins.py
@@ -48,7 +48,7 @@ class ToolDict(TypedDict):
         "classification",
         "data-extraction",
     ]
-    type: Literal["model", "pipeline", "utility", "sql", "script", "tool", "integration"]
+    type: Literal["model", "pipeline", "utility", "sql", "script", "tool", "integration", "builtin"]
     version: str
     asset_id: str
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,10 @@ Available tools per toolkit: `file` — `read_file`, `list_directory`, `glob`,
 `ValueError` naming the settings that toolkit accepts. Anything you leave unset
 keeps the worker's default.
 
+`include` distinguishes three states: omit it for every tool in the toolkit,
+pass a subset to narrow it, or pass `[]` to attach the toolkit with no tools at
+all.
+
 > The `bash` toolkit must be enabled per deployment. Where it is not, the backend
 > rejects an agent that attaches it.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,47 @@ print(result.data.output)
 
 > Runs return typed objects — read outputs with `result.data.output`, not dict indexing.
 
+### Attach built-in toolkits
+
+Agents can use the worker's built-in toolkits — a sandboxed filesystem, a Python
+interpreter and a shell — without onboarding any asset. Attach them with
+`BuiltinTool`, which validates the toolkit, the tool names and the settings before
+anything reaches the backend.
+
+```python
+from aixplain import Aixplain
+from aixplain.v2 import BuiltinTool
+
+aix = Aixplain()  # reads AIXPLAIN_API_KEY from the environment
+
+agent = aix.Agent(
+    name="Workspace agent",
+    instructions="Read the uploaded files and compute the summary statistics.",
+    tools=[
+        # Omit `include` to expose every tool in the toolkit.
+        BuiltinTool(toolkit="file", include=["read_file", "glob", "grep"]),
+        BuiltinTool(toolkit="python", timeout_s=30),
+    ],
+)
+agent.save()
+
+# Toolkits read back as objects, so a setting is one attribute away.
+fetched = aix.Agent.get(agent.id)
+fetched.tools[1].timeout_s = 60
+fetched.save()
+```
+
+Available tools per toolkit: `file` — `read_file`, `list_directory`, `glob`,
+`grep`, `write_file`, `edit_file`; `python` — `run_python`; `bash` —
+`run_command`. Settings are per toolkit too (`file`: `max_read_bytes`,
+`max_results`; `python`: `timeout_s`, `expose_files`; `bash`: `timeout_s`,
+`max_output_bytes`, `deny_patterns`), and using one on the wrong toolkit raises a
+`ValueError` naming the settings that toolkit accepts. Anything you leave unset
+keeps the worker's default.
+
+> The `bash` toolkit must be enabled per deployment. Where it is not, the backend
+> rejects an agent that attaches it.
+
 ### Build a multi-agent team
 
 ```python

--- a/tests/functional/v2/test_agent_builtin_tools.py
+++ b/tests/functional/v2/test_agent_builtin_tools.py
@@ -1,0 +1,109 @@
+"""Functional coverage for built-in agent toolkits (ENG-3699).
+
+Skipped until ENG-3698 puts the ``{"type": "builtin", ...}`` row behind the dev
+backend: until then the create call rejects the tool and the test would fail for
+a reason that has nothing to do with the SDK. Un-skipping is the one-line change
+below once the backend is deployed.
+"""
+
+import time
+
+import pytest
+
+from aixplain.v2 import BuiltinTool
+
+pytestmark = pytest.mark.skip(reason="Requires builtin toolkit support on the backend (ENG-3698)")
+
+#: Tool names the worker reports in a run step when the toolkit is used.
+FILE_STEP_TOOLS = {"read_file", "list_directory", "glob", "grep", "write_file", "edit_file"}
+PYTHON_STEP_TOOLS = {"run_python"}
+
+
+def _step_tool_names(response) -> set:
+    """Collect every tool name the run's intermediate steps mention.
+
+    The engine has more than one spelling for the field that names the tool a
+    step invoked, so all of them are read and the union returned; the assertions
+    below only ask whether a given tool appears at all.
+    """
+    data = getattr(response, "data", None)
+    names = set()
+    for step in getattr(data, "steps", None) or []:
+        if not isinstance(step, dict):
+            continue
+        for key in ("tool", "toolName", "name", "action"):
+            value = step.get(key)
+            if isinstance(value, str):
+                names.add(value)
+    return names
+
+
+@pytest.mark.flaky(reruns=2, reason="LLM may not always choose to call a built-in toolkit")
+def test_agent_runs_with_file_and_python_builtin_toolkits(client, resource_tracker):
+    """Attach the file and python toolkits, run, and confirm one of them was used.
+
+    Verifies end to end that:
+
+    1. an agent carrying ``BuiltinTool`` rows is accepted by the backend;
+    2. the rows survive the round-trip and come back typed, not as bare dicts;
+    3. the worker actually exposes the toolkits to the agent at run time.
+    """
+    agent = client.Agent(
+        name=f"builtin-toolkit-test-{int(time.time())}",
+        description="Temporary agent for built-in toolkit functional testing",
+        instructions=(
+            "You have a sandboxed workspace with a filesystem and a Python interpreter. "
+            "Use them rather than answering from memory."
+        ),
+        tools=[
+            BuiltinTool(toolkit="file", include=["read_file", "list_directory", "glob", "grep"]),
+            BuiltinTool(toolkit="python", timeout_s=30),
+        ],
+    )
+    agent.save()
+    resource_tracker.append(agent)
+
+    # The toolkits must read back as objects, so `agent.tools` is symmetric with
+    # what was passed in and a re-save would not mangle them.
+    fetched = client.Agent.get(agent.id)
+    assert [type(tool) for tool in fetched.tools] == [BuiltinTool, BuiltinTool]
+    assert [tool.toolkit for tool in fetched.tools] == ["file", "python"]
+    assert fetched.tools[1].timeout_s == 30
+    assert fetched.build_save_payload()["tools"] == agent.build_save_payload()["tools"]
+
+    response = agent.run(
+        "List the files in your workspace, then use Python to compute 17 * 23. "
+        "Do not answer the arithmetic from memory — run it."
+    )
+
+    assert response.status == "SUCCESS", f"Agent execution failed: {response.status}"
+
+    used = _step_tool_names(response)
+    assert used & (FILE_STEP_TOOLS | PYTHON_STEP_TOOLS), (
+        f"Expected a built-in toolkit step (one of {sorted(FILE_STEP_TOOLS | PYTHON_STEP_TOOLS)}) "
+        f"in the run's intermediate steps; saw {sorted(used)}."
+    )
+
+
+@pytest.mark.flaky(reruns=2, reason="LLM may not always choose to call the python toolkit")
+def test_python_builtin_toolkit_settings_are_persisted(client, resource_tracker):
+    """A setting sent at create time must still be there after a fetch."""
+    agent = client.Agent(
+        name=f"builtin-python-settings-{int(time.time())}",
+        description="Temporary agent for built-in toolkit settings persistence",
+        instructions="Use the Python interpreter to compute anything numeric.",
+        tools=[BuiltinTool(toolkit="python", include=["run_python"], timeout_s=15, expose_files=False)],
+    )
+    agent.save()
+    resource_tracker.append(agent)
+
+    (tool,) = client.Agent.get(agent.id).tools
+
+    assert isinstance(tool, BuiltinTool)
+    assert tool.as_tool() == {
+        "type": "builtin",
+        "toolkit": "python",
+        "include": ["run_python"],
+        "timeout_s": 15,
+        "expose_files": False,
+    }

--- a/tests/unit/v2/test_agent_builtin_tools.py
+++ b/tests/unit/v2/test_agent_builtin_tools.py
@@ -1,0 +1,215 @@
+"""Tests for attaching built-in toolkits to a v2 Agent (ENG-3699).
+
+Covers the three things that make ``BuiltinTool`` more than a typed dict: the row
+reaches the wire untouched, a persisted row comes back as a ``BuiltinTool``, and
+the agent's save machinery never mistakes one for an unsaved asset.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aixplain import Aixplain
+from aixplain.v2 import BuiltinTool
+
+FILE_ROW = {
+    "type": "builtin",
+    "toolkit": "file",
+    "include": ["read_file", "glob", "grep"],
+    "max_read_bytes": 262144,
+    "max_results": 500,
+}
+PYTHON_ROW = {"type": "builtin", "toolkit": "python", "include": ["run_python"], "timeout_s": 10, "expose_files": False}
+BASH_ROW = {
+    "type": "builtin",
+    "toolkit": "bash",
+    "include": ["run_command"],
+    "timeout_s": 60,
+    "max_output_bytes": 65536,
+    "deny_patterns": [r"^\s*rm\s+-rf\s+/"],
+}
+
+
+@pytest.fixture
+def aix() -> Aixplain:
+    """Return an isolated client."""
+    return Aixplain(api_key="test-key", backend_url="https://example.test")
+
+
+# ---------------------------------------------------------------------------
+# Save payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", [FILE_ROW, PYTHON_ROW, BASH_ROW], ids=["file", "python", "bash"])
+def test_a_builtin_tool_reaches_the_payload_untouched(aix, row):
+    """`_normalize_tool_dict_for_api` must not rewrite the worker's snake_case keys.
+
+    Its key map covers `asset_id` / `allow_multi` / `supports_variables` only, so
+    every builtin setting passes through verbatim today. Pinned here because a
+    future entry added to that map would silently camelCase a setting and the
+    worker would fall back to its default without complaining.
+    """
+    settings = {key: value for key, value in row.items() if key != "type"}
+    agent = aix.Agent(name="workspace-agent", tools=[BuiltinTool(**settings)])
+
+    assert agent.build_save_payload()["tools"] == [row]
+
+
+def test_a_builtin_row_carries_no_asset_identity(aix):
+    """A builtin toolkit is not an onboarded asset; an id would make the backend look one up."""
+    agent = aix.Agent(name="workspace-agent", tools=[BuiltinTool(toolkit="file")])
+
+    (serialized,) = agent.build_save_payload()["tools"]
+
+    assert not {"id", "assetId", "asset_id", "workspace_root"} & set(serialized)
+
+
+def test_builtin_and_asset_tools_coexist(aix):
+    """Attaching a toolkit must not disturb how the other entries normalize."""
+    snapshot = {"id": "some-tool-id", "type": "model", "name": "Translate"}
+    agent = aix.Agent(
+        name="mixed-agent",
+        tools=[
+            BuiltinTool(toolkit="python", timeout_s=30),
+            "some-tool-id",
+            {"id": "other-tool-id", "type": "model", "asset_id": "other-tool-id"},
+        ],
+    )
+
+    with patch.object(type(agent), "_resolve_tool_snapshot", return_value=snapshot):
+        tools = agent.build_save_payload()["tools"]
+
+    assert tools[0] == {"type": "builtin", "toolkit": "python", "timeout_s": 30}
+    assert tools[1]["id"] == "some-tool-id"
+    assert tools[1]["type"] == "model"
+    assert tools[2]["assetId"] == "other-tool-id"
+    assert tools[2]["type"] == "model"
+
+
+def test_several_toolkits_can_be_attached_at_once(aix):
+    """The headline use case: a filesystem plus an interpreter."""
+    agent = aix.Agent(
+        name="workspace-agent",
+        tools=[BuiltinTool(toolkit="file", include=["read_file"]), BuiltinTool(toolkit="python", timeout_s=30)],
+    )
+
+    assert [tool["toolkit"] for tool in agent.build_save_payload()["tools"]] == ["file", "python"]
+
+
+# ---------------------------------------------------------------------------
+# Hydration and round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_hydrates_a_builtin_row_without_a_client_context():
+    """Builtin rows reference no asset, so hydration must not wait for a context.
+
+    ``_hydrate_tools`` returns early when there is no context — correct for asset
+    tools, which need the backend to resolve. A toolkit is pure configuration, so
+    it converts on an unbound Agent too.
+    """
+    from aixplain.v2.agent import Agent
+
+    agent = Agent.from_dict({"id": "agent-id", "name": "workspace-agent", "tools": [FILE_ROW]})
+
+    (tool,) = agent.tools
+    assert isinstance(tool, BuiltinTool)
+    assert tool.toolkit == "file"
+    assert tool.max_read_bytes == 262144
+
+
+def test_get_returns_builtin_tools_and_re_saves_them_unchanged(aix):
+    """`agent.tools` after `get()` is symmetric with what the user passed in."""
+    aix.client.get = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [FILE_ROW, PYTHON_ROW]})
+
+    agent = aix.Agent.get("agent-id")
+
+    assert [type(tool) for tool in agent.tools] == [BuiltinTool, BuiltinTool]
+    assert agent.build_save_payload()["tools"] == [FILE_ROW, PYTHON_ROW]
+
+
+def test_a_fetched_toolkit_can_be_reconfigured_by_attribute(aix):
+    """The reason for hydrating at all: edit a setting instead of rebuilding a dict."""
+    aix.client.get = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [PYTHON_ROW]})
+    agent = aix.Agent.get("agent-id")
+
+    agent.tools[0].timeout_s = 60
+
+    assert agent.build_save_payload()["tools"] == [{**PYTHON_ROW, "timeout_s": 60}]
+
+
+def test_a_malformed_builtin_row_degrades_to_a_dict_and_still_serializes():
+    """Hydration is best-effort: an unmappable row must not break construction."""
+    from aixplain.v2.agent import Agent
+
+    row = {"type": "builtin", "toolkit": "quantum"}
+    agent = Agent.from_dict({"id": "agent-id", "name": "workspace-agent", "tools": [row]})
+
+    assert agent.tools == [row]
+    assert agent.build_save_payload()["tools"] == [row]
+
+
+def test_save_leaves_the_caller_s_builtin_tool_object_in_place(aix):
+    """The create response rebuilds `tools` as dicts; the restore path must re-type them."""
+    aix.client.request = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [PYTHON_ROW]})
+    tool = BuiltinTool(toolkit="python", timeout_s=10)
+    agent = aix.Agent(name="workspace-agent", tools=[tool])
+
+    agent.save()
+
+    assert agent.tools == [tool]
+
+
+# ---------------------------------------------------------------------------
+# Change detection
+# ---------------------------------------------------------------------------
+
+
+def test_editing_a_toolkit_setting_marks_the_agent_modified(aix):
+    """A builtin row has no id, so an id/type signature would miss every edit."""
+    aix.client.request = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [PYTHON_ROW]})
+    agent = aix.Agent(name="workspace-agent", tools=[BuiltinTool(toolkit="python", timeout_s=10)])
+    agent.save()
+    assert not agent.is_modified
+
+    agent.tools[0].timeout_s = 60
+
+    assert agent.is_modified
+
+
+def test_swapping_one_toolkit_for_another_marks_the_agent_modified(aix):
+    """`file` and `python` both reduce to `{id: None, type: None}` without the branch."""
+    aix.client.request = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [FILE_ROW]})
+    agent = aix.Agent(name="workspace-agent", tools=[BuiltinTool(toolkit="file")])
+    agent.save()
+    assert not agent.is_modified
+
+    agent.tools[0] = BuiltinTool(toolkit="python")
+
+    assert agent.is_modified
+
+
+# ---------------------------------------------------------------------------
+# The save machinery must not treat a toolkit as an unsaved asset
+# ---------------------------------------------------------------------------
+
+
+def test_a_builtin_only_agent_passes_dependency_validation(aix):
+    """`_validate_dependencies` flags any tool with a falsy `id`; a toolkit has none."""
+    tool = BuiltinTool(toolkit="file")
+    agent = aix.Agent(name="workspace-agent", tools=[tool])
+
+    agent._validate_dependencies()
+
+    assert agent.tools == [tool]
+
+
+def test_save_subcomponents_does_not_try_to_save_a_toolkit(aix):
+    """`_save_subcomponents` calls `save()` on tools that expose one; a toolkit does not."""
+    aix.client.request = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [FILE_ROW]})
+    agent = aix.Agent(name="workspace-agent", tools=[BuiltinTool(toolkit="file")])
+
+    agent.save(save_subcomponents=True)
+
+    assert aix.client.request.call_args.kwargs["json"]["tools"] == [{"type": "builtin", "toolkit": "file"}]

--- a/tests/unit/v2/test_agent_builtin_tools.py
+++ b/tests/unit/v2/test_agent_builtin_tools.py
@@ -12,14 +12,24 @@ import pytest
 from aixplain import Aixplain
 from aixplain.v2 import BuiltinTool
 
+#: The rows the worker accepts, verbatim from the ENG-3699 contract. Kept
+#: byte-identical with the copy in the sibling built-in toolkit test module:
+#: pytest runs with --import-mode=importlib and tests/unit/v2 is not a package,
+#: so a shared module is not importable from here without restructuring.
 FILE_ROW = {
     "type": "builtin",
     "toolkit": "file",
-    "include": ["read_file", "glob", "grep"],
+    "include": ["read_file", "list_directory", "glob", "grep", "write_file", "edit_file"],
     "max_read_bytes": 262144,
     "max_results": 500,
 }
-PYTHON_ROW = {"type": "builtin", "toolkit": "python", "include": ["run_python"], "timeout_s": 10, "expose_files": False}
+PYTHON_ROW = {
+    "type": "builtin",
+    "toolkit": "python",
+    "include": ["run_python"],
+    "timeout_s": 10,
+    "expose_files": False,
+}
 BASH_ROW = {
     "type": "builtin",
     "toolkit": "bash",
@@ -28,6 +38,8 @@ BASH_ROW = {
     "max_output_bytes": 65536,
     "deny_patterns": [r"^\s*rm\s+-rf\s+/"],
 }
+CONTRACT_ROWS = [FILE_ROW, PYTHON_ROW, BASH_ROW]
+CONTRACT_IDS = ["file", "python", "bash"]
 
 
 @pytest.fixture
@@ -41,7 +53,7 @@ def aix() -> Aixplain:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("row", [FILE_ROW, PYTHON_ROW, BASH_ROW], ids=["file", "python", "bash"])
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=CONTRACT_IDS)
 def test_a_builtin_tool_reaches_the_payload_untouched(aix, row):
     """`_normalize_tool_dict_for_api` must not rewrite the worker's snake_case keys.
 
@@ -257,3 +269,67 @@ def test_an_unknown_server_key_survives_a_fetch_and_re_save(aix):
 
     assert isinstance(agent.tools[0], BuiltinTool)
     assert agent.build_save_payload()["tools"] == [row]
+
+
+# ---------------------------------------------------------------------------
+# Review regressions (ENG-3699)
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_keeps_the_type_discriminator_and_round_trips(aix):
+    """`BuiltinTool` is a dataclass, so a naive to_dict() emits its raw fields.
+
+    That row has no ``type``, which ``from_dict`` cannot rebuild and the worker
+    drops — a silent loss for anyone snapshotting an agent via ``to_dict()``.
+    """
+    agent = aix.Agent(name="snapshot", tools=[BuiltinTool(toolkit="python", timeout_s=5)])
+
+    snapshot = agent.to_dict()
+
+    assert snapshot["tools"] == [{"type": "builtin", "toolkit": "python", "timeout_s": 5}]
+    restored = type(agent).from_dict(snapshot)
+    assert isinstance(restored.tools[0], BuiltinTool)
+    assert restored.build_save_payload()["tools"][0]["type"] == "builtin"
+
+
+def test_a_builtin_row_carrying_an_id_is_not_rebuilt_as_an_asset_tool(aix):
+    """The asset branch would turn it into {"type": "tool", "assetId": ...}."""
+    agent = aix.Agent(name="with id", tools=[{"type": "builtin", "toolkit": "file", "id": "68f0000000000000000000aa"}])
+
+    assert isinstance(agent.tools[0], BuiltinTool)
+    row = agent.build_save_payload()["tools"][0]
+    assert row["type"] == "builtin" and row["toolkit"] == "file"
+    assert "id" not in row and "assetId" not in row
+
+
+def test_a_malformed_row_for_a_known_toolkit_is_rejected(aix):
+    """Silence here ships the broken row to the backend."""
+    with pytest.raises(ValueError, match="Unknown tool"):
+        aix.Agent(name="bad", tools=[{"type": "builtin", "toolkit": "file", "include": ["run_python"]}])
+
+
+def test_a_row_for_an_unknown_toolkit_is_kept_verbatim(aix):
+    """A newer backend may know a toolkit this SDK does not; the row must survive."""
+    agent = aix.Agent(name="future", tools=[{"type": "builtin", "toolkit": "rust", "timeout_s": 5}])
+
+    assert agent.tools[0] == {"type": "builtin", "toolkit": "rust", "timeout_s": 5}
+    assert agent.build_save_payload()["tools"][0]["toolkit"] == "rust"
+
+
+def test_an_unhydrated_builtin_row_still_tracks_edits(aix):
+    """An id-less row is its own identity; collapsing it hides in-place edits."""
+    agent = aix.Agent(name="future", tools=[{"type": "builtin", "toolkit": "rust"}])
+    agent._update_saved_state()
+
+    agent.tools[0]["toolkit"] = "zig"
+
+    assert agent.is_modified
+
+
+def test_an_unbound_agent_without_builtins_keeps_the_callers_list(aix):
+    """Hydration must not replace a list object it has nothing to convert in."""
+    tools = [{"id": "68f0000000000000000000aa", "type": "model"}]
+
+    from aixplain.v2.agent import Agent
+
+    assert Agent(name="plain", tools=tools).tools is tools

--- a/tests/unit/v2/test_agent_builtin_tools.py
+++ b/tests/unit/v2/test_agent_builtin_tools.py
@@ -158,7 +158,9 @@ def test_save_leaves_the_caller_s_builtin_tool_object_in_place(aix):
 
     agent.save()
 
-    assert agent.tools == [tool]
+    # Identity, not equality: the point is that the caller's object survived the
+    # response round-trip, not that an equal one was rebuilt from the dicts.
+    assert agent.tools[0] is tool
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +207,21 @@ def test_a_builtin_only_agent_passes_dependency_validation(aix):
     assert agent.tools == [tool]
 
 
+def test_a_builtin_only_agent_passes_run_dependency_validation(aix):
+    """`_validate_run_dependencies` is a separate walk from the save-time one.
+
+    It formats an unsaved tool as ``tool '{tool.name}'`` without a getattr guard,
+    so a toolkit that ever grew an ``id`` would raise ``AttributeError`` here
+    rather than the clean message the save-time path produces.
+    """
+    tool = BuiltinTool(toolkit="bash", timeout_s=60)
+    agent = aix.Agent(name="workspace-agent", tools=[tool])
+
+    agent._validate_run_dependencies()
+
+    assert agent.tools == [tool]
+
+
 def test_save_subcomponents_does_not_try_to_save_a_toolkit(aix):
     """`_save_subcomponents` calls `save()` on tools that expose one; a toolkit does not."""
     aix.client.request = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [FILE_ROW]})
@@ -213,3 +230,30 @@ def test_save_subcomponents_does_not_try_to_save_a_toolkit(aix):
     agent.save(save_subcomponents=True)
 
     assert aix.client.request.call_args.kwargs["json"]["tools"] == [{"type": "builtin", "toolkit": "file"}]
+
+
+def test_the_client_exposes_builtin_tool(aix):
+    """`aix.BuiltinTool` is the documented entry point alongside `aix.Agent`/`aix.Tool`."""
+    assert aix.BuiltinTool is BuiltinTool
+
+
+def test_a_builtin_toolkit_is_skipped_by_run_time_parameter_overrides(aix):
+    """`_build_tool_overrides` walks every `ToolableMixin`; a toolkit has no id to key on.
+
+    Without the id guard it would emit `{"id": None, ...}` and the backend would
+    fail to match it against any tool.
+    """
+    agent = aix.Agent(name="workspace-agent", tools=[BuiltinTool(toolkit="python", timeout_s=30)])
+
+    assert agent._build_tool_overrides() == []
+
+
+def test_an_unknown_server_key_survives_a_fetch_and_re_save(aix):
+    """A backend newer than the SDK must not lose settings by being fetched and saved."""
+    row = {"type": "builtin", "toolkit": "python", "timeout_s": 10, "sandbox_profile": "strict"}
+    aix.client.get = Mock(return_value={"id": "agent-id", "name": "workspace-agent", "tools": [row]})
+
+    agent = aix.Agent.get("agent-id")
+
+    assert isinstance(agent.tools[0], BuiltinTool)
+    assert agent.build_save_payload()["tools"] == [row]

--- a/tests/unit/v2/test_builtin_tool.py
+++ b/tests/unit/v2/test_builtin_tool.py
@@ -304,3 +304,50 @@ def test_every_declared_setting_is_a_real_field():
     declared = {name for names in TOOLKIT_SETTINGS.values() for name in names}
 
     assert declared <= fields
+
+
+def test_a_non_string_toolkit_is_a_value_error_not_a_type_error():
+    """An unhashable toolkit must not escape the membership test as a TypeError."""
+    with pytest.raises(ValueError, match="Unknown toolkit"):
+        BuiltinTool(toolkit=["file"])
+
+    with pytest.raises(ValueError, match="Unknown toolkit"):
+        BuiltinTool.from_api_dict({"type": "builtin", "toolkit": ["file"]})
+
+
+def test_include_is_snapshotted_so_a_later_mutation_cannot_bypass_validation():
+    """Validation runs once; an aliased list would let an unknown name in afterwards."""
+    names = ["read_file"]
+    tool = BuiltinTool(toolkit="file", include=names)
+
+    names.append("not_a_real_tool")
+
+    assert tool.include == ["read_file"]
+
+
+def test_deny_patterns_is_snapshotted_too():
+    """The one other list-valued setting; same aliasing hazard."""
+    patterns = [r"^\s*rm\b"]
+    tool = BuiltinTool(toolkit="bash", deny_patterns=patterns)
+
+    patterns.append("everything")
+
+    assert tool.deny_patterns == [r"^\s*rm\b"]
+
+
+def test_from_api_dict_does_not_alias_the_response_row():
+    """Editing a fetched toolkit must not reach back into the response dict."""
+    row = {"type": "builtin", "toolkit": "file", "include": ["read_file"]}
+
+    BuiltinTool.from_api_dict(row).include.append("grep")
+
+    assert row["include"] == ["read_file"]
+
+
+def test_an_emitted_row_never_shares_a_list_with_the_tool():
+    """`as_tool()` is a snapshot for unknown server keys too, not just modelled ones."""
+    tool = BuiltinTool.from_api_dict({"type": "builtin", "toolkit": "python", "allow_hosts": ["a"]})
+
+    tool.as_tool()["allow_hosts"].append("b")
+
+    assert tool.as_tool()["allow_hosts"] == ["a"]

--- a/tests/unit/v2/test_builtin_tool.py
+++ b/tests/unit/v2/test_builtin_tool.py
@@ -1,0 +1,306 @@
+"""Tests for :class:`aixplain.v2.BuiltinTool` (ENG-3699).
+
+The wire contract is owned by the agent worker, so the serialization tests below
+assert the three contract rows field-by-field rather than spot-checking keys: a
+renamed key here is a capability the worker silently drops.
+"""
+
+import dataclasses
+
+import pytest
+
+from aixplain.v2 import BuiltinTool
+from aixplain.v2.builtin_tool import TOOLKIT_SETTINGS, TOOLKIT_TOOLS
+
+#: The rows the worker accepts, verbatim from the ENG-3699 contract.
+FILE_ROW = {
+    "type": "builtin",
+    "toolkit": "file",
+    "include": ["read_file", "list_directory", "glob", "grep", "write_file", "edit_file"],
+    "max_read_bytes": 262144,
+    "max_results": 500,
+}
+PYTHON_ROW = {
+    "type": "builtin",
+    "toolkit": "python",
+    "include": ["run_python"],
+    "timeout_s": 10,
+    "expose_files": False,
+}
+BASH_ROW = {
+    "type": "builtin",
+    "toolkit": "bash",
+    "include": ["run_command"],
+    "timeout_s": 60,
+    "max_output_bytes": 65536,
+    "deny_patterns": [r"^\s*rm\s+-rf\s+/"],
+}
+
+CONTRACT_ROWS = [FILE_ROW, PYTHON_ROW, BASH_ROW]
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("toolkit", ["file", "python", "bash"])
+def test_bare_toolkit_emits_only_the_discriminator_and_the_toolkit(toolkit):
+    """An unconfigured toolkit sends nothing else, so the worker's defaults apply."""
+    assert BuiltinTool(toolkit=toolkit).as_tool() == {"type": "builtin", "toolkit": toolkit}
+
+
+def test_fully_configured_file_toolkit_matches_the_contract_row():
+    """The `file` row from the frozen wire contract, key for key."""
+    tool = BuiltinTool(
+        toolkit="file",
+        include=["read_file", "list_directory", "glob", "grep", "write_file", "edit_file"],
+        max_read_bytes=262144,
+        max_results=500,
+    )
+
+    assert tool.as_tool() == FILE_ROW
+
+
+def test_fully_configured_python_toolkit_matches_the_contract_row():
+    """The `python` row from the frozen wire contract, key for key."""
+    tool = BuiltinTool(toolkit="python", include=["run_python"], timeout_s=10, expose_files=False)
+
+    assert tool.as_tool() == PYTHON_ROW
+
+
+def test_fully_configured_bash_toolkit_matches_the_contract_row():
+    """The `bash` row from the frozen wire contract, key for key."""
+    tool = BuiltinTool(
+        toolkit="bash",
+        include=["run_command"],
+        timeout_s=60,
+        max_output_bytes=65536,
+        deny_patterns=[r"^\s*rm\s+-rf\s+/"],
+    )
+
+    assert tool.as_tool() == BASH_ROW
+
+
+def test_include_is_emitted_in_the_order_given():
+    """The worker treats it as a set, but a reordered list makes diffs unreadable."""
+    tool = BuiltinTool(toolkit="file", include=["grep", "read_file", "glob"])
+
+    assert tool.as_tool()["include"] == ["grep", "read_file", "glob"]
+
+
+def test_include_is_copied_so_later_mutation_cannot_reach_a_sent_row():
+    """`as_tool()` snapshots; mutating the caller's list must not rewrite history."""
+    names = ["read_file"]
+    tool = BuiltinTool(toolkit="file", include=names)
+    row = tool.as_tool()
+
+    names.append("grep")
+
+    assert row["include"] == ["read_file"]
+
+
+def test_omitted_include_is_absent_rather_than_null():
+    """`None` means "every tool in the toolkit", which the worker reads as omission."""
+    assert "include" not in BuiltinTool(toolkit="python").as_tool()
+
+
+def test_expose_files_false_is_sent_because_unset_is_not_false():
+    """`Optional[bool]` exists precisely so an explicit False survives."""
+    assert BuiltinTool(toolkit="python", expose_files=False).as_tool()["expose_files"] is False
+
+
+def test_expose_files_unset_is_not_sent():
+    """The complement of the test above: absence must stay absence."""
+    assert "expose_files" not in BuiltinTool(toolkit="python", timeout_s=5).as_tool()
+
+
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=["file", "python", "bash"])
+def test_no_asset_identity_keys_ever_appear(row):
+    """A builtin toolkit is not an onboarded asset and must not pretend to be one."""
+    serialized = BuiltinTool.from_api_dict(row).as_tool()
+
+    assert not {"id", "assetId", "asset_id", "workspace_root"} & set(serialized)
+
+
+def test_the_wire_keys_are_snake_case():
+    """The worker's contract is snake_case; a camelCase drift silently drops settings."""
+    row = BuiltinTool(toolkit="file", max_read_bytes=1024, max_results=10).as_tool()
+
+    assert set(row) == {"type", "toolkit", "max_read_bytes", "max_results"}
+
+
+def test_type_is_read_only_and_not_a_constructor_argument():
+    """The discriminator routes the row to the worker; it is not user-settable."""
+    assert BuiltinTool(toolkit="file").type == "builtin"
+    assert "type" not in {f.name for f in dataclasses.fields(BuiltinTool)}
+    with pytest.raises(TypeError):
+        BuiltinTool(toolkit="file", type="model")
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_toolkit_names_the_allowed_toolkits():
+    """A typo in the toolkit is a construction-time error, not a silent no-op."""
+    with pytest.raises(ValueError, match=r"Unknown toolkit 'phyton'.*\['bash', 'file', 'python'\]"):
+        BuiltinTool(toolkit="phyton")
+
+
+@pytest.mark.parametrize(
+    ("toolkit", "bad_name"),
+    [("file", "read_files"), ("python", "run_bash"), ("bash", "run_python")],
+)
+def test_unknown_include_name_names_the_allowed_tools(toolkit, bad_name):
+    """A tool name from another toolkit (or a typo) is rejected with the real set."""
+    with pytest.raises(ValueError) as excinfo:
+        BuiltinTool(toolkit=toolkit, include=[bad_name])
+
+    message = str(excinfo.value)
+    assert bad_name in message
+    assert str(sorted(TOOLKIT_TOOLS[toolkit])) in message
+
+
+def test_empty_include_is_rejected_as_ambiguous():
+    """`[]` could read as "no tools" or "all tools"; `None` is the documented "all"."""
+    with pytest.raises(ValueError, match="include must name at least one tool"):
+        BuiltinTool(toolkit="file", include=[])
+
+
+@pytest.mark.parametrize(
+    ("toolkit", "setting", "value"),
+    [
+        ("file", "timeout_s", 10),
+        ("file", "expose_files", True),
+        ("file", "deny_patterns", ["rm"]),
+        ("python", "max_read_bytes", 1024),
+        ("python", "deny_patterns", ["rm"]),
+        ("python", "max_output_bytes", 1024),
+        ("bash", "expose_files", True),
+        ("bash", "max_results", 5),
+    ],
+)
+def test_setting_from_the_wrong_toolkit_names_the_allowed_settings(toolkit, setting, value):
+    """Silently ignoring a misplaced setting is the failure mode this prevents."""
+    with pytest.raises(ValueError) as excinfo:
+        BuiltinTool(toolkit=toolkit, **{setting: value})
+
+    message = str(excinfo.value)
+    assert setting in message
+    assert str(sorted(TOOLKIT_SETTINGS[toolkit])) in message
+
+
+def test_every_misplaced_setting_is_reported_at_once():
+    """Fixing one setting only to hit the next error is a poor first experience."""
+    with pytest.raises(ValueError, match=r"\['expose_files', 'timeout_s'\]"):
+        BuiltinTool(toolkit="file", timeout_s=1, expose_files=True)
+
+
+def test_timeout_s_is_shared_by_python_and_bash():
+    """`timeout_s` lives in two toolkits; neither may reject it as misplaced."""
+    assert BuiltinTool(toolkit="python", timeout_s=5).as_tool()["timeout_s"] == 5
+    assert BuiltinTool(toolkit="bash", timeout_s=5).as_tool()["timeout_s"] == 5
+
+
+# ---------------------------------------------------------------------------
+# The value-object invariants Agent integration depends on
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_tool_exposes_neither_id_nor_save():
+    """`Agent._validate_dependencies` and `_save_subcomponents` gate on these.
+
+    Both walk ``agent.tools`` and act on any entry with an ``id`` attribute or a
+    ``save`` method — a builtin toolkit has neither and must keep it that way, or
+    every agent carrying one would fail to save as an "unsaved component".
+    """
+    tool = BuiltinTool(toolkit="file")
+
+    assert not hasattr(tool, "id")
+    assert not hasattr(tool, "save")
+
+
+def test_builtin_tools_compare_by_configuration():
+    """Change detection reads equality; two identical attachments are the same."""
+    assert BuiltinTool(toolkit="python", timeout_s=30) == BuiltinTool(toolkit="python", timeout_s=30)
+    assert BuiltinTool(toolkit="python", timeout_s=30) != BuiltinTool(toolkit="python", timeout_s=60)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=["file", "python", "bash"])
+def test_a_persisted_row_round_trips_unchanged(row):
+    """`get()` then `save()` must not rewrite a row the user never touched."""
+    assert BuiltinTool.from_api_dict(row).as_tool() == row
+
+
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=["file", "python", "bash"])
+def test_from_api_dict_populates_the_typed_fields(row):
+    """The point of hydrating is attribute access, not just a faithful re-emit."""
+    tool = BuiltinTool.from_api_dict(row)
+
+    assert tool.toolkit == row["toolkit"]
+    assert tool.include == row["include"]
+    for setting in TOOLKIT_SETTINGS[row["toolkit"]]:
+        assert getattr(tool, setting) == row[setting]
+
+
+def test_an_unknown_server_key_survives_the_round_trip():
+    """A backend newer than the SDK must not lose settings by being fetched."""
+    row = {"type": "builtin", "toolkit": "python", "timeout_s": 10, "sandbox_profile": "strict"}
+
+    assert BuiltinTool.from_api_dict(row).as_tool() == row
+
+
+def test_a_server_only_key_is_dropped_in_both_directions():
+    """`workspace_root` is the worker's to choose; echoing it back would pin it."""
+    row = {"type": "builtin", "toolkit": "file", "workspace_root": "/mnt/agent-42"}
+
+    tool = BuiltinTool.from_api_dict(row)
+
+    assert tool.as_tool() == {"type": "builtin", "toolkit": "file"}
+
+
+def test_a_setting_belonging_to_another_toolkit_is_carried_not_rejected():
+    """Inbound rows are lenient: hydration must never fail on a live agent."""
+    row = {"type": "builtin", "toolkit": "file", "timeout_s": 10}
+
+    tool = BuiltinTool.from_api_dict(row)
+
+    assert tool.timeout_s is None
+    assert tool.as_tool() == row
+
+
+def test_a_row_without_a_toolkit_is_rejected():
+    """`from_api_dict` stays strict; ``Agent`` is the layer that degrades to a dict."""
+    with pytest.raises(ValueError, match="must carry a 'toolkit'"):
+        BuiltinTool.from_api_dict({"type": "builtin"})
+
+
+def test_a_row_with_an_unknown_toolkit_is_rejected():
+    """Same contract: unmappable in, exception out, caller decides what to do."""
+    with pytest.raises(ValueError, match="Unknown toolkit"):
+        BuiltinTool.from_api_dict({"type": "builtin", "toolkit": "rust"})
+
+
+# ---------------------------------------------------------------------------
+# The registries themselves
+# ---------------------------------------------------------------------------
+
+
+def test_the_toolkit_registries_describe_the_same_toolkits():
+    """A toolkit with tools but no settings entry would crash `as_tool()`."""
+    assert set(TOOLKIT_TOOLS) == set(TOOLKIT_SETTINGS)
+
+
+def test_every_declared_setting_is_a_real_field():
+    """`TOOLKIT_SETTINGS` drives `getattr`; a stale name would raise at runtime."""
+    fields = {f.name for f in dataclasses.fields(BuiltinTool)}
+    declared = {name for names in TOOLKIT_SETTINGS.values() for name in names}
+
+    assert declared <= fields

--- a/tests/unit/v2/test_builtin_tool.py
+++ b/tests/unit/v2/test_builtin_tool.py
@@ -12,7 +12,10 @@ import pytest
 from aixplain.v2 import BuiltinTool
 from aixplain.v2.builtin_tool import TOOLKIT_SETTINGS, TOOLKIT_TOOLS
 
-#: The rows the worker accepts, verbatim from the ENG-3699 contract.
+#: The rows the worker accepts, verbatim from the ENG-3699 contract. Kept
+#: byte-identical with the copy in the sibling built-in toolkit test module:
+#: pytest runs with --import-mode=importlib and tests/unit/v2 is not a package,
+#: so a shared module is not importable from here without restructuring.
 FILE_ROW = {
     "type": "builtin",
     "toolkit": "file",
@@ -35,8 +38,8 @@ BASH_ROW = {
     "max_output_bytes": 65536,
     "deny_patterns": [r"^\s*rm\s+-rf\s+/"],
 }
-
 CONTRACT_ROWS = [FILE_ROW, PYTHON_ROW, BASH_ROW]
+CONTRACT_IDS = ["file", "python", "bash"]
 
 
 # ---------------------------------------------------------------------------
@@ -115,10 +118,10 @@ def test_expose_files_unset_is_not_sent():
     assert "expose_files" not in BuiltinTool(toolkit="python", timeout_s=5).as_tool()
 
 
-@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=["file", "python", "bash"])
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=CONTRACT_IDS)
 def test_no_asset_identity_keys_ever_appear(row):
     """A builtin toolkit is not an onboarded asset and must not pretend to be one."""
-    serialized = BuiltinTool.from_api_dict(row).as_tool()
+    serialized = BuiltinTool.from_dict(row).as_tool()
 
     assert not {"id", "assetId", "asset_id", "workspace_root"} & set(serialized)
 
@@ -163,10 +166,46 @@ def test_unknown_include_name_names_the_allowed_tools(toolkit, bad_name):
     assert str(sorted(TOOLKIT_TOOLS[toolkit])) in message
 
 
-def test_empty_include_is_rejected_as_ambiguous():
-    """`[]` could read as "no tools" or "all tools"; `None` is the documented "all"."""
-    with pytest.raises(ValueError, match="include must name at least one tool"):
-        BuiltinTool(toolkit="file", include=[])
+def test_empty_include_means_no_tools_and_is_not_an_error():
+    """The worker treats `[]` as "zero tools from this toolkit"; `None` is "all"."""
+    assert BuiltinTool(toolkit="file", include=[]).as_tool()["include"] == []
+    assert "include" not in BuiltinTool(toolkit="file").as_tool()
+
+
+@pytest.mark.parametrize("field", ["include", "deny_patterns"])
+def test_a_string_where_a_list_belongs_is_rejected_not_exploded(field):
+    """`list("rm -rf")` would silently become six one-character entries."""
+    toolkit = "file" if field == "include" else "bash"
+    value = "read_file" if field == "include" else "rm -rf"
+    with pytest.raises(ValueError, match=f"{field} must be a list"):
+        BuiltinTool(**{"toolkit": toolkit, field: value})
+
+
+def test_extra_is_not_a_constructor_argument():
+    """Otherwise a caller could smuggle `type`/`toolkit` past validation."""
+    with pytest.raises(TypeError):
+        BuiltinTool(toolkit="file", _extra={"type": "model"})
+
+
+def test_a_replayed_server_key_cannot_shadow_a_validated_one():
+    """`_extra` must not be able to overwrite `type`/`toolkit` on the way out."""
+    tool = BuiltinTool.from_dict({"type": "builtin", "toolkit": "python", "sandbox_profile": "strict"})
+    row = tool.as_tool()
+
+    assert row["type"] == "builtin" and row["toolkit"] == "python"
+    assert row["sandbox_profile"] == "strict"
+    # Equality must agree with what is serialized, or change detection and
+    # `in agent.tools` disagree about whether two toolkits are the same.
+    assert tool != BuiltinTool(toolkit="python")
+
+
+def test_a_nested_server_value_is_deep_copied():
+    """A one-level copy still aliases a nested list from a newer backend."""
+    tool = BuiltinTool.from_dict({"type": "builtin", "toolkit": "python", "cfg": {"hosts": ["a"]}})
+    emitted = tool.as_tool()
+    emitted["cfg"]["hosts"].append("b")
+
+    assert tool.as_tool()["cfg"]["hosts"] == ["a"]
 
 
 @pytest.mark.parametrize(
@@ -233,16 +272,16 @@ def test_builtin_tools_compare_by_configuration():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=["file", "python", "bash"])
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=CONTRACT_IDS)
 def test_a_persisted_row_round_trips_unchanged(row):
     """`get()` then `save()` must not rewrite a row the user never touched."""
-    assert BuiltinTool.from_api_dict(row).as_tool() == row
+    assert BuiltinTool.from_dict(row).as_tool() == row
 
 
-@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=["file", "python", "bash"])
-def test_from_api_dict_populates_the_typed_fields(row):
+@pytest.mark.parametrize("row", CONTRACT_ROWS, ids=CONTRACT_IDS)
+def test_from_dict_populates_the_typed_fields(row):
     """The point of hydrating is attribute access, not just a faithful re-emit."""
-    tool = BuiltinTool.from_api_dict(row)
+    tool = BuiltinTool.from_dict(row)
 
     assert tool.toolkit == row["toolkit"]
     assert tool.include == row["include"]
@@ -254,14 +293,14 @@ def test_an_unknown_server_key_survives_the_round_trip():
     """A backend newer than the SDK must not lose settings by being fetched."""
     row = {"type": "builtin", "toolkit": "python", "timeout_s": 10, "sandbox_profile": "strict"}
 
-    assert BuiltinTool.from_api_dict(row).as_tool() == row
+    assert BuiltinTool.from_dict(row).as_tool() == row
 
 
 def test_a_server_only_key_is_dropped_in_both_directions():
     """`workspace_root` is the worker's to choose; echoing it back would pin it."""
     row = {"type": "builtin", "toolkit": "file", "workspace_root": "/mnt/agent-42"}
 
-    tool = BuiltinTool.from_api_dict(row)
+    tool = BuiltinTool.from_dict(row)
 
     assert tool.as_tool() == {"type": "builtin", "toolkit": "file"}
 
@@ -270,22 +309,22 @@ def test_a_setting_belonging_to_another_toolkit_is_carried_not_rejected():
     """Inbound rows are lenient: hydration must never fail on a live agent."""
     row = {"type": "builtin", "toolkit": "file", "timeout_s": 10}
 
-    tool = BuiltinTool.from_api_dict(row)
+    tool = BuiltinTool.from_dict(row)
 
     assert tool.timeout_s is None
     assert tool.as_tool() == row
 
 
 def test_a_row_without_a_toolkit_is_rejected():
-    """`from_api_dict` stays strict; ``Agent`` is the layer that degrades to a dict."""
+    """`from_dict` stays strict; ``Agent`` is the layer that degrades to a dict."""
     with pytest.raises(ValueError, match="must carry a 'toolkit'"):
-        BuiltinTool.from_api_dict({"type": "builtin"})
+        BuiltinTool.from_dict({"type": "builtin"})
 
 
 def test_a_row_with_an_unknown_toolkit_is_rejected():
     """Same contract: unmappable in, exception out, caller decides what to do."""
     with pytest.raises(ValueError, match="Unknown toolkit"):
-        BuiltinTool.from_api_dict({"type": "builtin", "toolkit": "rust"})
+        BuiltinTool.from_dict({"type": "builtin", "toolkit": "rust"})
 
 
 # ---------------------------------------------------------------------------
@@ -312,7 +351,7 @@ def test_a_non_string_toolkit_is_a_value_error_not_a_type_error():
         BuiltinTool(toolkit=["file"])
 
     with pytest.raises(ValueError, match="Unknown toolkit"):
-        BuiltinTool.from_api_dict({"type": "builtin", "toolkit": ["file"]})
+        BuiltinTool.from_dict({"type": "builtin", "toolkit": ["file"]})
 
 
 def test_include_is_snapshotted_so_a_later_mutation_cannot_bypass_validation():
@@ -335,18 +374,18 @@ def test_deny_patterns_is_snapshotted_too():
     assert tool.deny_patterns == [r"^\s*rm\b"]
 
 
-def test_from_api_dict_does_not_alias_the_response_row():
+def test_from_dict_does_not_alias_the_response_row():
     """Editing a fetched toolkit must not reach back into the response dict."""
     row = {"type": "builtin", "toolkit": "file", "include": ["read_file"]}
 
-    BuiltinTool.from_api_dict(row).include.append("grep")
+    BuiltinTool.from_dict(row).include.append("grep")
 
     assert row["include"] == ["read_file"]
 
 
 def test_an_emitted_row_never_shares_a_list_with_the_tool():
     """`as_tool()` is a snapshot for unknown server keys too, not just modelled ones."""
-    tool = BuiltinTool.from_api_dict({"type": "builtin", "toolkit": "python", "allow_hosts": ["a"]})
+    tool = BuiltinTool.from_dict({"type": "builtin", "toolkit": "python", "allow_hosts": ["a"]})
 
     tool.as_tool()["allow_hosts"].append("b")
 


### PR DESCRIPTION
## Summary

Adds `builtin_tools` to the v2 `Agent` — a plain list field that toggles the agent worker's built-in toolkits (`file`, `python`, `bash`) — plus `warnings` on the run result so a gated toolkit is observable from Python.

Jira: https://aixplain.atlassian.net/browse/ENG-3699 (parent story PROD-2907). Backend https://aixplain.atlassian.net/browse/ENG-3698 is now merged and deployed to dev. Read-after-write lag tracked separately as https://aixplain.atlassian.net/browse/ENG-3711.

```python
from aixplain import Aixplain

aix = Aixplain()
agent = aix.Agent(
    name="Workspace agent",
    instructions="Read the uploaded files and compute the summary statistics.",
    builtin_tools=["file", "python"],
)
agent.save()

result = agent.run("Summarize data.csv")
print(result.warnings)   # e.g. ["Built-in toolkit 'bash' is not enabled on this worker — skipped"]
```

## History — this branch was rewritten once

An earlier revision modelled toolkits as **agent asset rows** via a `BuiltinTool` class (`ToolableMixin`, a `toolkit` discriminator, `include`, per-toolkit settings). The platform wire contract changed: toolkits are a **capability toggle on the agent**, so there is nothing for a tool object to model. That class and all its plumbing were deleted — no `mixins.py` widening, no `_hydrate_tools` / `_normalize_tool_*` / `to_dict` special-casing, no `builtin_tool.py`. That redesign also removed the root cause of all six findings from the first review round; they are listed as obsolete below.

## Design

- **`builtin_tools: list[str] | None`** on `Agent`, serialized as `builtinTools`, hydrated from the same key in `get()`, round-tripping through `save()`.
- **`exclude=lambda v: v is None`** — an agent that never touched the field sends no `builtinTools`, so existing payloads are byte-identical and a fetched agent cannot null out server state it does not know about (the BUG-1093 lesson). Backend treats absent, `null` and `[]` alike as none.
- **`BuiltinToolkit` str-enum** backs the field for autocompletion; plain strings are equally valid. **No client-side validation of values** — an unknown or gated-off toolkit is dropped by the worker with a warning, never an error, so the SDK must not pre-empt that.
- **No `include`, no per-toolkit settings.** Python's workspace access is inferred by the worker: on exactly when both `file` and `python` are enabled.
- **`warnings: List[str]`** on `AgentResponseData`, decoded exactly like `artifacts` on the same dataclass, plus an `AgentRunResult.warnings` property.
- **`_step_unit_names`** lives in `aixplain/v2/agent.py` so both the unit and functional suites import it.

## Findings

### This round — end-to-end dev run against the deployed backend

| # | Finding | Status |
|---|---|---|
| 1 | The functional test read `step["tool"\|"toolName"\|"name"\|"action"]`, but the engine names the executing unit at `step["unit"]["name"]`. On dev the parser returned an empty set, so `assert used & BUILTIN_STEP_TOOLS` failed even though `write_file` and `run_python` had run. | **Fixed** — `_step_unit_names` reads `unit.name` first, keeps the flat keys as fallback, and is now an importable helper in `agent.py` with unit coverage for the real dev step shape, precedence, and malformed input. |
| 2 | The engine puts `warnings: list[str]` on the run result, and the README promised "dropped at run time with a warning on the run result" — but `AgentResponseData` had no `warnings` field, so the warning was unobservable from Python. | **Fixed** — `warnings` added, mirroring `artifacts` decoding: `Optional` to silence the dataclasses-json `RuntimeWarning`, re-coerced in `__post_init__` for direct construction, non-string entries dropped, never raising on absence or a non-list. |
| 3 | `Agent.get()` immediately after `save()` trails the write by ~0.5–1 s on dev (7 of 44 creates measured), which would make the functional test flaky. | **Fixed** — a poll helper in the *functional test only* retries for ~8 s. No polling was added to the SDK, per the constraint. |
| 4 | **Found in review:** warnings were readable in only one of the two places the engine could put them. The poll path never passes the response through — `resource.py`'s `filtered_response` rebuilds it from a fixed allow-list of top-level keys, so a `warnings` emitted *beside* `data` rather than *inside* it is dropped before decoding. Confirmed against the real `poll()` with a mocked client: top-level placement yielded an empty `data.warnings`. Same failure mode as finding #1 — SDK looking in one place, engine using another — and it would have failed the gated-bash assertion on dev for a reason unrelated to gating. | **Fixed** — `AgentRunResult.warnings` prefers decoded `data.warnings`, accepts a hand-built dict `data`, and falls back to the raw body's top-level key, mirroring the existing `artifacts` property. |
| 5 | **Found in review:** the read-after-write poll helper retried a *mismatched* field but not a *failed* `get()`. The same lag can 404 a just-created agent, which escaped on the first attempt and defeated the helper's purpose. | **Fixed** — retries on exception, re-raises once the budget is spent. |
| 5b | **Found in final review:** `AgentRunResult.warnings`' top-level fallback called `.get` on `_raw_data` after an `or {}` guard, so a truthy non-dict body (plain-text response, a list) raised `AttributeError` inside the property — which `Result.__getattr__` swallowed and re-raised as a misleading "no attribute 'warnings'". | **Fixed** — the top-level key is read only from a dict; unit test added. |
| 6 | ~4 of 44 creates lost `builtinTools` entirely. | **Skipped, by instruction** — backend defect tracked as ENG-3711, not worked around here. |
| 7 | `tests/unit/v2/test_agent_response_data.py` has no test docstrings while sibling v2 test modules use them throughout (16 × `D103`). | **Skipped** — nothing gates it: pre-commit runs ruff only over `^aixplain/v2/` and CI has no ruff step. The test names are self-documenting; 16 docstrings restating them would be noise. Disclosed rather than silently changed. |
| 8 | README claim that `bash` "is accepted by the API but is currently disabled in every environment". | **Verified** — matches the design spec's *"`bash` stays accepted but gated … It stays disabled in every environment."* |

Re-verified after the refactor rather than assumed: the `_is_auto_deserialize_only` guard test still holds; moving normalization into `__setattr__` did not break no-clobber behavior; `agent.builtin_tools = "python"`, `save(builtin_tools="file")`, `from_dict` with a scalar, `dataclasses.replace`, and a save against a non-echoing backend all land on the right list with `is_modified` staying `False`.

### Earlier round — `BuiltinTool` design, now deleted

| # | Finding | Status |
|---|---|---|
| 9 | Non-string `toolkit` raised `TypeError: unhashable type` instead of the documented `ValueError`. | **Obsolete** — class deleted. |
| 10 | `include` / `deny_patterns` aliased the caller's list, so post-construction mutation bypassed validation. | **Obsolete** — no `include` in the new contract. |
| 11 | `as_tool()` spliced `_extra` values in by reference, sharing a list between the tool and every emitted payload row. | **Obsolete** — no `_extra` replay. |
| 12 | `to_dict()` lost the `type` discriminator to dataclasses-json. | **Obsolete** — no discriminator. |
| 13 | The `ToolableMixin` contortion, the `_validate_dependencies` "has `id` but falsy" trap, `_save_subcomponents` calling `save()`, and `_hydrate_tools` ordering around the `context is None` early return. | **Obsolete** — a plain agent field is not walked by any of those paths. |
| 14 | No client-side bounds checks on `timeout_s` / `max_read_bytes`. | **Obsolete** — no per-toolkit settings exist. |
| 15 | Adding a dataclasses-json `decoder` to `builtin_tools` would make every `save()` null the list out (`exclude` + `decoder` trips `resource.py`'s `_is_auto_deserialize_only`, and the backend does not echo `builtinTools`). | **Fixed and pinned** — decoder deliberately not registered; a metadata test guards against the plausible future "tidy up response parsing" change. |

## Testing

- `tests/unit/v2/test_agent_builtin_tools.py` — `to_dict()` emits `builtinTools` and omits it when unset; `get()` hydration; full `save()` / `get()` round-trip; a builtin-only agent saves without tripping `_validate_dependencies` or `_save_subcomponents`; unknown strings pass through untouched; scalar/tuple/set shapes; no aliasing of the caller's list; a create response without the key leaves the field intact; the field-metadata pin.
- `tests/unit/v2/test_agent_response_data.py` — `warnings` decoded from the payload, absent/`null`/non-list/non-string entries; direct construction; both wire placements through `AgentRunResult.warnings`; `_step_unit_names` against the real dev step shape, flat-key fallback, `unit.name` precedence, and malformed input.
- `tests/functional/v2/test_agent_builtin_tools.py` — 3 tests incl. the gated-bash warning assertion. **Not run** — needs live credentials; `builtinTools` is dev-only while CI's functional legs target test/prod.

```
$ uv run --python .venv/bin/python pytest tests/unit/v2 -q
1822 passed in 10.54s

$ uv run --python .venv/bin/python pytest tests/functional/v2/test_agent_builtin_tools.py --collect-only
3 tests collected

$ uv run --python .venv/bin/python ruff check aixplain/v2/        All checks passed!
$ uv run --python .venv/bin/python ruff format --check aixplain/v2/   30 files already formatted
```

Wider `tests/unit` was green at review time (2863 passed). `uv.lock` is deliberately not part of this diff.



