### PR TITLE
chore: bump version to 0.2.48

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ namespaces = true
 
 [project]
 name = "aiXplain"
-version = "0.2.47"
+version = "0.2.48"
 description = "aiXplain SDK adds AI functions to software."
 readme = "README.md"
 requires-python = ">=3.9, <4"


### PR DESCRIPTION
Bumps `[project].version` from `0.2.47` to `0.2.48`. One-line change; no code touched.

## What ships in 0.2.48

`main` and `development` currently have **identical file trees** (`git diff --name-only origin/main origin/development` → 0 files); the 261-commit gap between them is history shape only. So this release ships everything merged since the `0.2.47` tag, including:

- v2 unified `File` assets and persistent agent files (#1055)
- `Skill.update()` / file-content updates (#1075)
- ENG-3543 package-discovery fix — the glob that made a `.git`-less build ship 3 of 169 modules (#1047)
- ENG-3428 release pipeline and least-privilege workflow permissions (#1048)
- ENG-3544 test-integrity guards, ENG-3435 generator path/escaping fix (#1090)
- SEV1/SEV2 fixes: poll-URL host validation and `x-api-key` drop on cross-host redirect (#1040), duplicate run submissions (#1045), RLM sandbox key leak (#1042), search filters / `save()` / run kwargs (#1074), and the HTTP/load/security set (#1076, #1078)

## Pre-flight run locally on this branch

| Check | Result |
| --- | --- |
| `pytest tests/unit` with `AIXPLAIN_REQUIRE_EXECUTED_TESTS=1` | 2812 passed |
| `python -m build` (sdist → wheel from sdist) | `aixplain-0.2.48.tar.gz`, `aixplain-0.2.48-py3-none-any.whl` |
| Wheel installed into a clean venv, imported from outside the repo | OK — 171 modules, `aixplain --help` OK, reports `0.2.48` |
| `Version(tag[1:]) == Version(declared)` for `v0.2.48` | OK |

## After merge — release steps

1. Tag the merge commit **`v0.2.48`** and push the tag.
   The `v` prefix is **required**: `release.yaml` triggers on `v*` only, and every earlier tag (`0.2.47` and back) is bare, so this is the first tag under the new convention. A bare `0.2.48` tag publishes nothing.
2. The tag push runs `release.yaml`: it re-asserts tag == `[project].version`, re-runs the unit suite, builds, installs the wheel into a clean venv, then publishes to PyPI with attestations.

## Blocker to confirm before tagging

This is the **first automated publish** — 0.2.47 was `twine upload`-ed by hand, so the path has never executed. Two settings must already exist or the `publish` job fails after a successful build:

- A repo environment named **`pypi`** (`gh api repos/aixplain/aiXplain/environments` currently lists none).
- A **PyPI Trusted Publisher** on the `aiXplain` project registered against the exact triple: repository `aixplain/aiXplain`, workflow filename `release.yaml`, environment `pypi`. The job passes no `password:`/`user:`, so OIDC is the only path.

A failed `publish` job is recoverable (fix settings, re-run the job — the build artifact is unchanged), but a *successful* upload is not: PyPI filenames are immutable and a mislabelled `0.2.48` can only be yanked.

## Notes

- `uv.lock` still records the project as `0.2.45rc1` and is missing a few `test` extras. Pre-existing drift, deliberately left out of this PR to keep the release diff to one line.
- The `0.2.47` references in `plugins/aixplain/skills/**` and `aixplain/v2/agent.py:143` are prose about SDK behavior, not packaging metadata; they are not updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)